### PR TITLE
loop streamlining

### DIFF
--- a/disassembler.asm
+++ b/disassembler.asm
@@ -238,6 +238,7 @@ _special_handlers:
     .word sliteral_runtime,     disasm_sliteral
     .word zero_branch_runtime,  disasm_0branch
     .word branch_runtime,       disasm_branch
+    .word do_runtime,           disasm_do
 _end_handlers:
 
 
@@ -442,6 +443,14 @@ disasm_branch:
                 jsr print_string_no_lf ; "BRANCH "
                 ; The address after the 0BRANCH is handled the same as a literal.
                 bra disasm_print_literal
+
+; DO handler
+disasm_do:
+                lda #'D'
+                jsr emit_a
+                lda #'O'
+                jsr emit_a
+                rts
 
 ; Literal handler
 disasm_literal:

--- a/docs/WORDLIST.md
+++ b/docs/WORDLIST.md
@@ -80,8 +80,8 @@ RTS instruction at the end of each word.
 | DIGIT_QUESTION | `digit?` | Tali Forth | 52 | **auto** |
 | DISASM | `disasm` | Tali Forth | 6 | tested |
 | DNEGATE | `dnegate` | ANS double | 26 | **auto** |
-| QUESTION_DO | `?do` | ANS core ext | 96 | **auto** |
-| DO | `do` | ANS core | 90 | **auto** |
+| QUESTION_DO | `?do` | ANS core ext | 57 | **auto** |
+| DO | `do` | ANS core | 51 | **auto** |
 | DOES | `does>` | ANS core | 14 | **auto** |
 | DOT | `.` | ANS core | 33 | **auto** |
 | DOT_PAREN | `.(` | ANS core | 14 | **auto** |
@@ -124,7 +124,7 @@ RTS instruction at the end of each word.
 | HEX | `hex` | ANS core ext | 6 | **auto** |
 | HEXSTORE | `hexstore` | Tali | 82 | **auto** |
 | HOLD | `hold` | ANS core | 17 | **auto** |
-| I | `i` | ANS core | 25 | **auto** |
+| I | `i` | ANS core | 23 | **auto** |
 | IF | `if` | ANS core | 16 | **auto** |
 | IMMEDIATE | `immediate` | ANS core | 11 | **auto** |
 | INPUT | `input` | Tali Forth | 10 | tested |
@@ -143,8 +143,8 @@ RTS instruction at the end of each word.
 | LIST | `list` | ANS block ext | 12 | tested |
 | LITERAL | `literal` | ANS core | 13 | **auto** |
 | LOAD | `load` | ANS block | 67 | **auto** |
-| LOOP | `loop` | ANS core | 109 | **auto** |
-| PLUS_LOOP | `+loop` | ANS core | 102 | **auto** |
+| LOOP | `loop` | ANS core | 89 | **auto** |
+| PLUS_LOOP | `+loop` | ANS core | 74 | **auto** |
 | LSHIFT | `lshift` | ANS core | 19 | **auto** |
 | M_STAR | `m*` | ANS core | 26 | **auto** |
 | MARKER | `marker` | ANS core ext | 61 | **auto** |

--- a/docs/WORDLIST.md
+++ b/docs/WORDLIST.md
@@ -61,7 +61,7 @@ RTS instruction at the end of each word.
 | COLON_NONAME | `:NONAME` | ANS core | 27 | **auto** |
 | COMMA | `,` | ANS core | 25 | **auto** |
 | COMPARE | `compare` | ANS string | 100 | **auto** |
-| COMPILE_COMMA | `compile,` | ANS core ext | 279 | **auto** |
+| COMPILE_COMMA | `compile,` | ANS core ext | 296 | **auto** |
 | COMPILE_ONLY | `compile-only` | Tali Forth | 11 | tested |
 | CONSTANT | `constant` | ANS core | 61 | **auto** |
 | COUNT | `count` | ANS core | 19 | **auto** |
@@ -80,8 +80,8 @@ RTS instruction at the end of each word.
 | DIGIT_QUESTION | `digit?` | Tali Forth | 52 | **auto** |
 | DISASM | `disasm` | Tali Forth | 6 | tested |
 | DNEGATE | `dnegate` | ANS double | 26 | **auto** |
-| QUESTION_DO | `?do` | ANS core ext | 57 | **auto** |
-| DO | `do` | ANS core | 51 | **auto** |
+| QUESTION_DO | `?do` | ANS core ext | 63 | **auto** |
+| DO | `do` | ANS core | 57 | **auto** |
 | DOES | `does>` | ANS core | 14 | **auto** |
 | DOT | `.` | ANS core | 33 | **auto** |
 | DOT_PAREN | `.(` | ANS core | 14 | **auto** |
@@ -143,8 +143,8 @@ RTS instruction at the end of each word.
 | LIST | `list` | ANS block ext | 12 | tested |
 | LITERAL | `literal` | ANS core | 13 | **auto** |
 | LOAD | `load` | ANS block | 67 | **auto** |
-| LOOP | `loop` | ANS core | 89 | **auto** |
-| PLUS_LOOP | `+loop` | ANS core | 74 | **auto** |
+| LOOP | `loop` | ANS core | 93 | **auto** |
+| PLUS_LOOP | `+loop` | ANS core | 76 | **auto** |
 | LSHIFT | `lshift` | ANS core | 19 | **auto** |
 | M_STAR | `m*` | ANS core | 26 | **auto** |
 | MARKER | `marker` | ANS core ext | 61 | **auto** |

--- a/native_words.asm
+++ b/native_words.asm
@@ -5912,7 +5912,7 @@ loop_runtime:
 
                 clv             ; note inc doesn't affect V
                 ply             ; LSB of index
-                iny             ; stash updated LSB
+                iny             ; add one
                 bne _skip_msb   ; definitely not done
 
                 pla             ; MSB of index

--- a/native_words.asm
+++ b/native_words.asm
@@ -2246,12 +2246,12 @@ _underflow_strip:
                 ; See if the user wants underflow stripping turned on
                 lda uf_strip
                 ora uf_strip+1
-                beq cmpl_Inline
+                beq cmpl_inline
 
                 ; See if this word even contains underflow checking
                 lda tmp3
                 and #UF
-                beq cmpl_Inline
+                beq cmpl_inline
 
                 ; If we arrived here, underflow has to go. It's always 3 bytes
                 ; long. Note hat PICK is a special case.

--- a/taliforth.asm
+++ b/taliforth.asm
@@ -102,6 +102,25 @@ cmpl_a:
 _done:
                 rts
 
+cmpl_inline:
+        ; helper to copy Y bytes from (tmp1) to (cp) and increase CP by Y
+                phy             ; save counter to adjust CP
+                dey             ; we were actually copying Y+1 before
+-
+                lda (tmp1),y
+                sta (cp),y
+                dey
+                bpl -
+
+                ; Adjust CP
+                pla
+                clc
+                adc cp
+                sta cp
+                lda cp+1
+                adc #0          ; only need carry
+                sta cp+1
+                rts
 
 ; =====================================================================
 ; CODE FIELD ROUTINES

--- a/taliforth.asm
+++ b/taliforth.asm
@@ -102,26 +102,6 @@ cmpl_a:
 _done:
                 rts
 
-cmpl_inline:
-        ; helper to copy Y bytes from (tmp1) to (cp) and increase CP by Y
-                phy             ; save counter to adjust CP
-                dey             ; we were actually copying Y+1 before
--
-                lda (tmp1),y
-                sta (cp),y
-                dey
-                bpl -
-
-                ; Adjust CP
-                pla
-                clc
-                adc cp
-                sta cp
-                lda cp+1
-                adc #0          ; only need carry
-                sta cp+1
-                rts
-
 ; =====================================================================
 ; CODE FIELD ROUTINES
 

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -866,11 +866,11 @@ create result  ok
 92 c, ( \\ )  ok
   ok
 T{ result here result - 2dup dump ( Make a string out of result ) 
-0F76  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-0F86   ok
+0F71  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+0F81   ok
    s\" \a\b\e\f\l\m\n\q\r\t\v\z\"\x41\\" 2dup dump compare -> 0 }T 
-0F89  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-0F99   ok
+0F84  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+0F94   ok
 hex  ok
   ok
 \ ------------------------------------------------------------------------  ok
@@ -2219,8 +2219,8 @@ T{ saved-string s\"  ok\ned \nq  ok\nrestore-output  " compare -> 0 }T  ok
 \ Test --- q --- Don't quit if we have unsaved changes  ok
 test-ed  ok
 saved-string dump 
-0F58  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
-0F68  0A 51 20  .Q  ok
+0F53  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
+0F63  0A 51 20  .Q  ok
 T{ s\" \na \nzzz \n. \nq \n?\nQ " compare -> 0 }T  ok
   ok
   ok
@@ -3303,7 +3303,7 @@ drop \ accept test complete  ok
 \ skipping     begin  ok
              ' bell          cycle_test            CYCLES:     36 ok
              ' bl            cycle_test drop       CYCLES:     26 ok
-here 5       ' blank         cycle_test            CYCLES:    325 ok
+here 5       ' blank         cycle_test            CYCLES:    326 ok
 5 5          ' bounds        cycle_test 2drop      CYCLES:     70 ok
 \ skipping     [char]  ok
 \ skipping     [']  ok
@@ -3314,17 +3314,17 @@ here 5       ' blank         cycle_test            CYCLES:    325 ok
 5 here       ' c!            cycle_test            CYCLES:     46 ok
 5            ' cell+         cycle_test drop       CYCLES:     46 ok
 5            ' cells         cycle_test drop       CYCLES:     40 ok
-             ' char          cycle_test w drop     CYCLES:    451 ok
+             ' char          cycle_test w drop     CYCLES:    450 ok
 5            ' char+         cycle_test drop       CYCLES:     37 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  15153 ok
+             ' :             cycle_test wrd ;      CYCLES:  15154 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:     66 ok
-' aword      ' compile,      cycle_test            CYCLES:    787 ok
+' aword      ' compile,      cycle_test            CYCLES:    785 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
-5            ' constant      cycle_test mycnst     CYCLES:  15650 ok
+5            ' constant      cycle_test mycnst     CYCLES:  15648 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3351,7 +3351,7 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 5 5          ' =             cycle_test drop       CYCLES:     64 ok
 here 5       ' erase         cycle_test            CYCLES:    321 ok
 here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  16623 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  16685 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3359,8 +3359,8 @@ here         ' @             cycle_test drop       CYCLES:     59 ok
 \ making counted string for find  ok
 here 5 c, char a c, char w c, char o c,  ok
 char r c, char d c,  ok
-             ' find          cycle_test 2drop      CYCLES:    782 ok
-s" aword"    ' find-name     cycle_test drop       CYCLES:    450 ok
+             ' find          cycle_test 2drop      CYCLES:    781 ok
+s" aword"    ' find-name     cycle_test drop       CYCLES:    449 ok
 5. 5         ' fm/mod        cycle_test 2drop      CYCLES:   1311 ok
 5 5          ' >             cycle_test drop       CYCLES:     81 ok
              ' here          cycle_test drop       CYCLES:     30 ok
@@ -3369,7 +3369,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    450 ok
 \ skipping     i  ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   1679 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   1676 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
@@ -3383,9 +3383,9 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    450 ok
 \ skipping     loop  ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
-5 5          ' m*            cycle_test 2drop      CYCLES:    651 ok
-             ' marker        cycle_test marka      CYCLES:  17307 ok
-             ' marka         cycle_test            CYCLES:    883 ok
+5 5          ' m*            cycle_test 2drop      CYCLES:    679 ok
+             ' marker        cycle_test marka      CYCLES:  17306 ok
+             ' marka         cycle_test            CYCLES:    848 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
 5 5          ' -             cycle_test drop       CYCLES:     58 ok
@@ -3399,7 +3399,7 @@ here s" a"   ' move          cycle_test            CYCLES:    148 ok
 5 5          ' nip           cycle_test drop       CYCLES:     48 ok
 5 5          ' <>            cycle_test drop       CYCLES:     68 ok
 5 5 5        ' -rot          cycle_test 2drop drop CYCLES:     76 ok
-s" 5"        ' number        cycle_test drop       CYCLES:   1650 ok
+s" 5"        ' number        cycle_test drop       CYCLES:   1710 ok
 \ skipping     #  ok
 \ skipping     #>  ok
 \ skipping     #s  ok
@@ -3411,13 +3411,13 @@ s" 5"        ' number        cycle_test drop       CYCLES:   1650 ok
 5 5          ' over          cycle_test 2drop drop CYCLES:     48 ok
              ' pad           cycle_test drop       CYCLES:     36 ok
 \ skipping     page  ok
-             ' parse-name    cycle_test a 2drop    CYCLES:    410 ok
+             ' parse-name    cycle_test a 2drop    CYCLES:    409 ok
 char "       ' parse         cycle_test " 2drop    CYCLES:    215 ok
 5 0          ' pick          cycle_test 2drop      CYCLES:     42 ok
 5 5          ' +             cycle_test drop       CYCLES:     58 ok
 5 here       ' +!            cycle_test            CYCLES:     86 ok
 \ skipping     postpone  ok
-myvar        ' ?             cycle_test          5 CYCLES:   3894 ok
+myvar        ' ?             cycle_test          5 CYCLES:   3897 ok
 5            ' ?dup          cycle_test 2drop      CYCLES:     58 ok
 \ skipping     r>  ok
 \ skipping     recurse  ok
@@ -3437,15 +3437,15 @@ s" abc" 1    ' /string       cycle_test 2drop      CYCLES:     84 ok
              ' source-id     cycle_test drop       CYCLES:     30 ok
              ' space         cycle_test            CYCLES:     36 ok
 1            ' spaces        cycle_test            CYCLES:    159 ok
-5 5          ' *             cycle_test drop       CYCLES:    507 ok
+5 5          ' *             cycle_test drop       CYCLES:    535 ok
              ' state         cycle_test drop       CYCLES:     28 ok
 5 here       ' !             cycle_test            CYCLES:     65 ok
 5 5          ' swap          cycle_test 2drop      CYCLES:     60 ok
-             ' '             cycle_test aword drop CYCLES:   1333 ok
+             ' '             cycle_test aword drop CYCLES:   1331 ok
 \ postponing   to ( see value )  ok
-' aword      ' >body         cycle_test drop       CYCLES:    594 ok
+' aword      ' >body         cycle_test drop       CYCLES:    591 ok
              ' >in           cycle_test drop       CYCLES:     28 ok
-0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2428 ok
+0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2546 ok
 \ skipping     >r  ok
              ' true          cycle_test drop       CYCLES:     26 ok
 5 5          ' tuck          cycle_test 2drop drop CYCLES:     72 ok
@@ -3461,21 +3461,21 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  15928 ok
+             ' 2variable     cycle_test eword      CYCLES:  15927 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
-s" *"        ' type          cycle_test           *CYCLES:    121 ok
-5            ' u.            cycle_test          5 CYCLES:   3615 ok
+s" *"        ' type          cycle_test           *CYCLES:    124 ok
+5            ' u.            cycle_test          5 CYCLES:   3618 ok
 5 5          ' u>            cycle_test drop       CYCLES:     60 ok
 5 5          ' u<            cycle_test drop       CYCLES:     60 ok
              ' strip-underflow   cycle_test drop       CYCLES:     28 ok
 5. 5         ' um/mod        cycle_test 2drop      CYCLES:   1260 ok
-5 5          ' um*           cycle_test 2drop      CYCLES:    475 ok
+5 5          ' um*           cycle_test 2drop      CYCLES:    503 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  16147 ok
+5            ' value         cycle_test fword      CYCLES:  16146 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
-5            ' to            cycle_test fword      CYCLES:   1136 ok
-             ' variable      cycle_test gword      CYCLES:  15927 ok
+5            ' to            cycle_test fword      CYCLES:   1135 ok
+             ' variable      cycle_test gword      CYCLES:  15926 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    676 ok
 \ skipping     words  ok

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -866,11 +866,11 @@ create result  ok
 92 c, ( \\ )  ok
   ok
 T{ result here result - 2dup dump ( Make a string out of result ) 
-103A  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-104A   ok
+0F76  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+0F86   ok
    s\" \a\b\e\f\l\m\n\q\r\t\v\z\"\x41\\" 2dup dump compare -> 0 }T 
-104D  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-105D   ok
+0F89  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+0F99   ok
 hex  ok
   ok
 \ ------------------------------------------------------------------------  ok
@@ -2219,8 +2219,8 @@ T{ saved-string s\"  ok\ned \nq  ok\nrestore-output  " compare -> 0 }T  ok
 \ Test --- q --- Don't quit if we have unsaved changes  ok
 test-ed  ok
 saved-string dump 
-101C  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
-102C  0A 51 20  .Q  ok
+0F58  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
+0F68  0A 51 20  .Q  ok
 T{ s\" \na \nzzz \n. \nq \n?\nQ " compare -> 0 }T  ok
   ok
   ok
@@ -3314,17 +3314,17 @@ here 5       ' blank         cycle_test            CYCLES:    325 ok
 5 here       ' c!            cycle_test            CYCLES:     46 ok
 5            ' cell+         cycle_test drop       CYCLES:     46 ok
 5            ' cells         cycle_test drop       CYCLES:     40 ok
-             ' char          cycle_test w drop     CYCLES:    450 ok
+             ' char          cycle_test w drop     CYCLES:    451 ok
 5            ' char+         cycle_test drop       CYCLES:     37 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  15147 ok
+             ' :             cycle_test wrd ;      CYCLES:  15153 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:     66 ok
 ' aword      ' compile,      cycle_test            CYCLES:    787 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
-5            ' constant      cycle_test mycnst     CYCLES:  15641 ok
+5            ' constant      cycle_test mycnst     CYCLES:  15650 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3351,7 +3351,7 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 5 5          ' =             cycle_test drop       CYCLES:     64 ok
 here 5       ' erase         cycle_test            CYCLES:    321 ok
 here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  16677 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  16623 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3369,7 +3369,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    450 ok
 \ skipping     i  ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   1676 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   1679 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
@@ -3383,13 +3383,13 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    450 ok
 \ skipping     loop  ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
-5 5          ' m*            cycle_test 2drop      CYCLES:    679 ok
-             ' marker        cycle_test marka      CYCLES:  17299 ok
-             ' marka         cycle_test            CYCLES:    848 ok
+5 5          ' m*            cycle_test 2drop      CYCLES:    651 ok
+             ' marker        cycle_test marka      CYCLES:  17307 ok
+             ' marka         cycle_test            CYCLES:    883 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
 5 5          ' -             cycle_test drop       CYCLES:     58 ok
-s" txt   "   ' -trailing     cycle_test 2drop      CYCLES:    222 ok
+s" txt   "   ' -trailing     cycle_test 2drop      CYCLES:    218 ok
 here s" a"   ' move          cycle_test            CYCLES:    148 ok
 ' + int>name ' name>int      cycle_test drop       CYCLES:     71 ok
 ' + int>name ' name>string   cycle_test 2drop      CYCLES:     70 ok
@@ -3399,7 +3399,7 @@ here s" a"   ' move          cycle_test            CYCLES:    148 ok
 5 5          ' nip           cycle_test drop       CYCLES:     48 ok
 5 5          ' <>            cycle_test drop       CYCLES:     68 ok
 5 5 5        ' -rot          cycle_test 2drop drop CYCLES:     76 ok
-s" 5"        ' number        cycle_test drop       CYCLES:   1710 ok
+s" 5"        ' number        cycle_test drop       CYCLES:   1650 ok
 \ skipping     #  ok
 \ skipping     #>  ok
 \ skipping     #s  ok
@@ -3411,13 +3411,13 @@ s" 5"        ' number        cycle_test drop       CYCLES:   1710 ok
 5 5          ' over          cycle_test 2drop drop CYCLES:     48 ok
              ' pad           cycle_test drop       CYCLES:     36 ok
 \ skipping     page  ok
-             ' parse-name    cycle_test a 2drop    CYCLES:    409 ok
+             ' parse-name    cycle_test a 2drop    CYCLES:    410 ok
 char "       ' parse         cycle_test " 2drop    CYCLES:    215 ok
 5 0          ' pick          cycle_test 2drop      CYCLES:     42 ok
 5 5          ' +             cycle_test drop       CYCLES:     58 ok
 5 here       ' +!            cycle_test            CYCLES:     86 ok
 \ skipping     postpone  ok
-myvar        ' ?             cycle_test          5 CYCLES:   3896 ok
+myvar        ' ?             cycle_test          5 CYCLES:   3894 ok
 5            ' ?dup          cycle_test 2drop      CYCLES:     58 ok
 \ skipping     r>  ok
 \ skipping     recurse  ok
@@ -3437,15 +3437,15 @@ s" abc" 1    ' /string       cycle_test 2drop      CYCLES:     84 ok
              ' source-id     cycle_test drop       CYCLES:     30 ok
              ' space         cycle_test            CYCLES:     36 ok
 1            ' spaces        cycle_test            CYCLES:    159 ok
-5 5          ' *             cycle_test drop       CYCLES:    535 ok
+5 5          ' *             cycle_test drop       CYCLES:    507 ok
              ' state         cycle_test drop       CYCLES:     28 ok
 5 here       ' !             cycle_test            CYCLES:     65 ok
 5 5          ' swap          cycle_test 2drop      CYCLES:     60 ok
-             ' '             cycle_test aword drop CYCLES:   1332 ok
+             ' '             cycle_test aword drop CYCLES:   1333 ok
 \ postponing   to ( see value )  ok
-' aword      ' >body         cycle_test drop       CYCLES:    591 ok
+' aword      ' >body         cycle_test drop       CYCLES:    594 ok
              ' >in           cycle_test drop       CYCLES:     28 ok
-0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2546 ok
+0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2428 ok
 \ skipping     >r  ok
              ' true          cycle_test drop       CYCLES:     26 ok
 5 5          ' tuck          cycle_test 2drop drop CYCLES:     72 ok
@@ -3461,21 +3461,21 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  15920 ok
+             ' 2variable     cycle_test eword      CYCLES:  15928 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
-s" *"        ' type          cycle_test           *CYCLES:    123 ok
-5            ' u.            cycle_test          5 CYCLES:   3617 ok
+s" *"        ' type          cycle_test           *CYCLES:    121 ok
+5            ' u.            cycle_test          5 CYCLES:   3615 ok
 5 5          ' u>            cycle_test drop       CYCLES:     60 ok
 5 5          ' u<            cycle_test drop       CYCLES:     60 ok
              ' strip-underflow   cycle_test drop       CYCLES:     28 ok
 5. 5         ' um/mod        cycle_test 2drop      CYCLES:   1260 ok
-5 5          ' um*           cycle_test 2drop      CYCLES:    503 ok
+5 5          ' um*           cycle_test 2drop      CYCLES:    475 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  16139 ok
+5            ' value         cycle_test fword      CYCLES:  16147 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
 5            ' to            cycle_test fword      CYCLES:   1136 ok
-             ' variable      cycle_test gword      CYCLES:  15919 ok
+             ' variable      cycle_test gword      CYCLES:  15927 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    676 ok
 \ skipping     words  ok


### PR DESCRIPTION
Here are a few ideas for do loop optimization while I was figuring out how it worked.

The ROM size is +6 bytes where some space optimizations were compensated by adding a specialized loop_runtime (+1 instead of +step).

The runtime is about 40 bytes less for each instance by making do_runtime a subroutine, so slightly more expensive on loop startup, but the loop step (for step=1) is shorter and quicker (avoiding the jsr xt_one stack juggling stuff).  

Saved a couple of bytes in xt_i but wondering if there's something better there.   If you assume i is accessed in most loops it might be better to speculatively increment the index at the same time as incremental the fudged limit in the loop footer?