### PR TITLE
merge definiitions with relocatable tables to ease understanding and maintenance

### DIFF
--- a/definitions.asm
+++ b/definitions.asm
@@ -30,7 +30,8 @@
 dsp0      = zpage_end-7    ; initial Data Stack Pointer
 
 cold_zp_table:
-        .logical user0
+        .logical user0              ; make labels refer to relocated address
+
 cp:         .word cp0+256+1024      ; Compiler Pointer
                                     ; moved to make room for user vars and block buffer
 dp:         .word dictionary_start  ; Dictionary Pointer
@@ -102,7 +103,7 @@ cold_zp_table_end:
 ; which are relocated to 'up' (defaulting to cp0) by COLD.
 
 cold_user_table:
-    .logical 0          ; this makes labels here offsets that we can add to 'up'
+    .logical 0          ; make labels here offsets that we can add to 'up'
 
 ; Block variables
 blk_offset:             .word 0         ; BLK
@@ -136,8 +137,6 @@ buffstatus_offset:      .word 0         ; Buffer status (bit 0 = used, bit 1 = d
 
 blockread_offset:       .word xt_block_word_error   ; Vector to block reading routine
 blockwrite_offset:      .word xt_block_word_error   ; Vector to block writing routine
-
-                        .word 0          ; 'COLD
     .endlogical
 cold_user_table_end:
 

--- a/definitions.asm
+++ b/definitions.asm
@@ -7,6 +7,13 @@
 ; definitions; platform-specific definitions such as the
 ; memory map are kept in the platform folder.
 
+; TaliForth reserves the first part of zero page ($0 - zpage_end) which is
+; configured by zpage_end in platform/platform-*.asm and normally 128 bytes.
+; The rest of zero page is free for kernel/external use (zpage_end+1 - $ff)
+; TaliForth usage is as follows:
+;   zero page variables: 28 words = 56 bytes ($0000-$0038)
+;   Forth Data Stack: 128 - 56 - 8 = 64 bytes or 32 words
+;   Data Stack underflow floodplain: 8 bytes (to avoid catastropic underflow)
 
 ; ZERO PAGE ADDRESSES/VARIABLES
 
@@ -14,96 +21,126 @@
 ; the top because the Data Stack grows towards this area from dsp0: If there is
 ; an overflow, the lower, less important variables will be clobbered first,
 ; giving the system a chance to recover. In other words, they are part of the
-; floodplain.
+; overflow floodplain.
 
-; The four variables insrc, cib, ciblen, and toin must stay together in this
-; sequence for the words INPUT>R and R>INPUT to work correctly.
-; The offsets here must match the cold_zp_table defined in native_words.asm
-
-cp        = user0+0   ; Compiler Pointer
-dp        = user0+2   ; Dictionary Pointer
-workword  = user0+4   ; nt (not xt!) of word being compiled, except in
-                           ; a :NONAME declared word (see status)
-insrc     = user0+6   ; input Source for SOURCE-ID
-cib       = user0+8   ; address of current input buffer
-ciblen    = user0+10  ; length of current input buffer
-toin      = user0+12  ; pointer to CIB (>IN in Forth)
-ip        = user0+14  ; Instruction Pointer (current xt)
-output    = user0+16  ; vector for EMIT
-input     = user0+18  ; vector for KEY
-havekey   = user0+20  ; vector for KEY?
-state     = user0+22  ; STATE: -1 compile, 0 interpret
-base      = user0+24  ; number radix, default decimal
-nc_limit  = user0+26  ; limit for Native Compile size
-uf_strip  = user0+28  ; flag to strip underflow detection code
-up        = user0+30  ; User Pointer (Address of user variables)
-status    = user0+32  ; internal status information
-                           ; (used by : :NONAME ; ACCEPT)
-                           ; Bit 7 = Redefined word message postpone
-                           ;         When set before calling CREATE, it will
-                           ;         not print the "redefined xxxx" message if
-                           ;         the word exists. Instead, this bit will
-                           ;         be reused and after CREATE has run, it will
-                           ;         be set if the word was redefined and 0 if
-                           ;         not. This bit should be 0 when not in use.
-                           ; Bit 6 = 1 for normal ":" definitions
-                           ;         WORKWORD contains nt of word being compiled
-                           ;       = 0 for :NONAME definitions
-                           ;         WORKWORD contains xt of word being compiled
-                           ; Bit 5 = 1 for NUMBER returning a double word
-                           ;       = 0 for NUMBER returning a single word
-                           ; Bit 3 = 1 makes CTRL-n recall current history
-                           ;       = 0 CTRL-n recalls previous history
-                           ; Bit 2 = Current history buffer msb
-                           ; Bit 1 = Current history buffer (0-7, wraps)
-                           ; Bit 0 = Current history buffer lsb
-                           ; status+1 is used by ACCEPT to hold history lengths.
-tmpbranch = user0+34  ; temporary storage for 0BRANCH, BRANCH only
-tmp1      = user0+36  ; temporary storage
-tmp2      = user0+38  ; temporary storage
-tmp3      = user0+40  ; temporary storage (especially for print)
-tmpdsp    = user0+42  ; temporary DSP (X) storage (two bytes)
-tmptos    = user0+44  ; temporary TOS storage
-editor1   = user0+46  ; temporary for editors
-editor2   = user0+48  ; temporary for editors
-editor3   = user0+50  ; temporary for editors
-tohold    = user0+52  ; pointer for formatted output
-scratch   = user0+54  ; 8 byte scratchpad (see UM/MOD)
-
-; Zero Page:
-; Bytes used for variables: 62 ($0000-$003D)
-; First usable Data Stack location: $003E (decimal 62)
-; Bytes available for Data Stack: 128-62 = 66 --> 33 16-bit cells
+; This table defines all of the zero page variables along with their initial
+; values except the uninitialized temporaries at the end.  This table
+; is relocated to zero page by COLD.
 
 dsp0      = zpage_end-7    ; initial Data Stack Pointer
 
-; RAM System Variables: this must match cold_user_table in native_words.asm
+cold_zp_table:
+        .logical user0
+cp:         .word cp0+256+1024      ; Compiler Pointer
+                                    ; moved to make room for user vars and block buffer
+dp:         .word dictionary_start  ; Dictionary Pointer
+workword:   .word 0                 ; nt (not xt!) of word being compiled, except in
+                                    ; a :NONAME declared word (see status)
+
+; The four variables insrc, cib, ciblen, and toin must stay together in this
+; sequence for the words INPUT>R and R>INPUT to work correctly.
+
+insrc:      .word 0                 ; input source for SOURCE-ID (0 for keyboard)
+cib:        .word buffer0           ; address of current input buffer
+ciblen:     .word 0                 ; length of current input buffer
+toin:       .word 0                 ; pointer to CIB (>IN in Forth)
+
+ip:         .word 0                 ; Instruction Pointer (current xt)
+output:     .word kernel_putc       ; vector for EMIT
+input:      .word kernel_getc       ; vector for KEY
+havekey:    .word 0                 ; vector for KEY?
+state:      .word 0                 ; STATE: -1 compile, 0 interpret
+base:       .word 10                ; number radix, default decimal
+nc_limit:   .word 20                ; byte limit for Native Compile size
+uf_strip:   .word 0                 ; flag to strip underflow detection code (0 off)
+up:         .word cp0               ; Forth user vars at start of available RAM
+status:     .word 0                 ; internal status used by : :NONAME ; ACCEPT
+        ; Bit 7 = Redefined word message postpone
+        ;         When set before calling CREATE, it will
+        ;         not print the "redefined xxxx" message if
+        ;         the word exists. Instead, this bit will
+        ;         be reused and after CREATE has run, it will
+        ;         be set if the word was redefined and 0 if
+        ;         not. This bit should be 0 when not in use.
+        ; Bit 6 = 1 for normal ":" definitions
+        ;         WORKWORD contains nt of word being compiled
+        ;       = 0 for :NONAME definitions
+        ;         WORKWORD contains xt of word being compiled
+        ; Bit 5 = 1 for NUMBER returning a double word
+        ;       = 0 for NUMBER returning a single word
+        ; Bit 3 = 1 makes CTRL-n recall current history
+        ;       = 0 CTRL-n recalls previous history
+        ; Bit 2 = Current history buffer msb
+        ; Bit 1 = Current history buffer (0-7, wraps)
+        ; Bit 0 = Current history buffer lsb
+        ;
+        ; status+1 is used by ACCEPT to hold history lengths.
+
+; The remaining ZP variables are uninitialized temporaries.
+
+    .virtual
+tmpbranch:  .word ?         ; temporary storage for 0BRANCH, BRANCH only
+tmp1:       .word ?         ; temporary storage
+tmp2:       .word ?         ; temporary storage
+tmp3:       .word ?         ; temporary storage (especially for print)
+tmpdsp:     .word ?         ; temporary DSP (X) storage (two bytes)
+tmptos:     .word ?         ; temporary TOS storage
+editor1:    .word ?         ; temporary for editors
+editor2:    .word ?         ; temporary for editors
+editor3:    .word ?         ; temporary for editors
+tohold:     .word ?         ; pointer for formatted output
+scratch:    .word ?         ; 8 byte scratchpad (see UM/MOD)
+    .endvirtual
+
+    .endlogical
+cold_zp_table_end:
+
+
+; RAM System Variables
+
+; This table defines the initial values for forth user variables above zero page,
+; which are relocated to 'up' (defaulting to cp0) by COLD.
+
+cold_user_table:
+    .logical 0          ; this makes labels here offsets that we can add to 'up'
+
 ; Block variables
-blk_offset = 0        ; BLK : UP + 0
-scr_offset = 2        ; SCR : UP + 2
+blk_offset:             .word 0         ; BLK
+scr_offset:             .word 0         ; SCR
 
 ; Wordlists
-current_offset = 4    ; CURRENT (byte) : UP + 4 (Compilation wordlist)
-num_wordlists_offset = 5
-                           ; #WORDLISTS (byte) : UP + 5
-wordlists_offset = 6  ; WORDLISTS (cells) : UP + 6 to UP + 29
-                           ;          (FORTH, EDITOR, ASSEMBLER, ROOT, +8 more)
-num_order_offset = 30 ; #ORDER (byte) : UP + 30
-                           ;          (Number of wordlists in search order)
-search_order_offset = 31
-                           ; SEARCH-ORDER (bytes) : UP + 31 to UP + 39
-                           ; Allowing for 9 to keep offsets even.
-max_wordlists = 12    ; Maximum number of wordlists supported
-                           ; 4 Tali built-ins + 8 user wordlists
+
+max_wordlists = 12    ; Maximum number of wordlists supported (4 built-in, 8 user wordlists)
+
+current_offset:         .byte 0         ; CURRENT = FORTH-WORDLIST (compilation wordlist)
+num_wordlists_offset:   .byte 4         ; #WORDLISTS (FORTH EDITOR ASSEMBLER ROOT)
+
+wordlists_offset:
+    .word dictionary_start              ; FORTH-WORDLIST
+    .word editor_dictionary_start       ; EDITOR-WORDLIST
+    .word assembler_dictionary_start    ; ASSEMBLER-WORDLIST
+    .word root_dictionary_start         ; ROOT-WORDLIST
+    .word 0,0,0,0,0,0,0,0               ; Space for 8 User wordlists
+
+num_order_offset:       .byte 1         ; #ORDER (Number of wordlists in search order)
+search_order_offset:
+    .byte 0,0,0,0,0,0,0,0,0             ; SEARCH-ORDER (9 bytes to keep offsets even)
 
 ; Buffer variables
-blkbuffer_offset    = 40   ; Address of buffer
-buffblocknum_offset = 42   ; Block number current in buffer
-buffstatus_offset   = 44   ; Status of buffer (bit 0 = used, bit 1 = dirty)
+
+blkbuffer_offset:       .word cp0+256   ; Address of buffer (right after USER vars)
+buffblocknum_offset:    .word 0         ; Block number current in buffer
+buffstatus_offset:      .word 0         ; Buffer status (bit 0 = used, bit 1 = dirty) (not in use)
 
 ; Block I/O vectors
-blockread_offset    = 46   ; Vector to block reading routine
-blockwrite_offset   = 48   ; Vector to block writing routine
+
+blockread_offset:       .word xt_block_word_error   ; Vector to block reading routine
+blockwrite_offset:      .word xt_block_word_error   ; Vector to block writing routine
+
+                        .word 0          ; 'COLD
+    .endlogical
+cold_user_table_end:
+
 
 ; ASCII CHARACTERS
 AscCC   = $03  ; break (CTRL-c)

--- a/native_words.asm
+++ b/native_words.asm
@@ -219,57 +219,6 @@ z_abort:
 z_quit:         ; no RTS required
 
 
-
-; This table holds all of the initial values for the variables in zero page.
-; This table is used by COLD.  This must match the zp offsets in definitions.asm
-cold_zp_table:
-        .word cp0+256+1024      ; cp moved to make room for user vars and
-                                ; block buffer
-        .word dictionary_start  ; dp
-        .word 0                 ; workword
-        .word 0                 ; insrc (SOURCE-ID is 0 for keyboard)
-        .word buffer0           ; cib
-        .word 0                 ; ciblen
-        .word 0                 ; toin
-        .word 0                 ; ip
-        .word kernel_putc       ; output
-        .word kernel_getc       ; input
-        .word 0                 ; havekey
-        .word 0                 ; state (0 = interpret)
-        .word 10                ; base
-        .word 20                ; nc-limit
-        .word 0                 ; uf_strip (off by default)
-        .word cp0               ; up (user vars put right at beginning of
-                                ; available RAM)
-        .word 0                 ; status
-cold_zp_table_end:
-
-; No further ZP variables are initialized. The variables past this point are
-; all temporaries.
-
-; This table holds the initial values for forth user variables. This table is
-; used by COLD.  This must match the user variable offsets in definitions.aasm
-cold_user_table:
-        .word 0                         ;  0 BLK
-        .word 0                         ;  2 SCR
-        .byte 0                         ;  4 CURRENT = FORTH-WORDLIST
-        .byte 4                         ;  5 #WORDLISTS (FORTH EDITOR ASSEMBLER ROOT)
-        .word dictionary_start          ;  6 FORTH-WORDLIST
-        .word editor_dictionary_start   ;  8 EDITOR-WORDLIST
-        .word assembler_dictionary_start ; a ASSEMBLER-WORDLIST
-        .word root_dictionary_start     ;  c ROOT-WORDLIST
-        .word 0,0,0,0,0,0,0,0           ;  e User wordlists
-        .byte 1                         ; 1e #ORDER
-        .byte 0,0,0,0,0,0,0,0,0         ; 1f search-order
-        .word cp0+256                   ; 28 Address of buffer (right after USER vars)
-        .word 0                         ; 2a block in buffer
-        .word 0                         ; 2c buffer status (not in use)
-        .word xt_block_word_error       ; 2e block-read vector
-        .word xt_block_word_error       ; 30 block-write vector
-        .word 0                         ; 32 'COLD
-cold_user_table_end:
-
-
 ; ## ABORT_QUOTE ( "string" -- ) "If flag TOS is true, ABORT with message"
 ; ## "abort""  tested  ANS core
         ; """https://forth-standard.org/standard/core/ABORTq

--- a/taliforth.asm
+++ b/taliforth.asm
@@ -24,17 +24,15 @@ TALI_OPTION_TERSE :?= 0
 ; Default to ctrl-n/p accept history
 TALI_OPTION_HISTORY :?= 1
 
-; Label used to calculate UNUSED. Silly for Tali Forth, where we assume
-; 32 KiB RAM and 32 KiB ROM, but kept here to make the code more useful for
-; other hardware configurations
+; Label used to calculate UNUSED based on the hardware configuration in platform/
 code0:
 
-.include "definitions.asm"      ; Top-level definitions, memory map
-
-; Insert point for Tali Forth after kernel hardware setup
+; Entry point for Tali Forth after kernel hardware setup
 forth:
 
 .include "native_words.asm"     ; Native Forth words. Starts with COLD
+.include "definitions.asm"      ; Top-level definitions, memory map
+                                ; included here to put relocatable tables after native words
 .include "assembler.asm"        ; SAN assembler
 .include "disassembler.asm"     ; SAN disassembler
 .include "ed.asm"               ; Line-based editor ed6502

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -3309,7 +3309,7 @@ here 5       ' blank         cycle_test            CYCLES:    325 ok
 \ skipping     [']  ok
 \ skipping     branch  ok
 \ skipping     bye  ok
-5            ' c,            cycle_test            CYCLES:     61 ok
+5            ' c,            cycle_test            CYCLES:     62 ok
 5            ' c@            cycle_test drop       CYCLES:     42 ok
 5 here       ' c!            cycle_test            CYCLES:     46 ok
 5            ' cell+         cycle_test drop       CYCLES:     46 ok
@@ -3319,12 +3319,12 @@ here 5       ' blank         cycle_test            CYCLES:    325 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  15735 ok
+             ' :             cycle_test wrd ;      CYCLES:  15728 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:     66 ok
 ' aword      ' compile,      cycle_test            CYCLES:    784 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
-5            ' constant      cycle_test mycnst     CYCLES:  16233 ok
+5            ' constant      cycle_test mycnst     CYCLES:  16226 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3355,7 +3355,7 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     87 ok
 \ skipping     does  ok
 \ skipping     .  ok
 \ skipping     ."  ok
-             ' s"            cycle_test " 2drop    CYCLES:    252 ok
+             ' s"            cycle_test " 2drop    CYCLES:    255 ok
 5            ' drop          cycle_test            CYCLES:     32 ok
 \ skipping     dump  ok
 5            ' dup           cycle_test 2drop      CYCLES:     48 ok
@@ -3363,7 +3363,7 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     87 ok
 5 5          ' =             cycle_test drop       CYCLES:     64 ok
 here 5       ' erase         cycle_test            CYCLES:    321 ok
 here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17539 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17532 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3396,7 +3396,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    792 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    650 ok
-             ' marker        cycle_test marka      CYCLES:  18225 ok
+             ' marker        cycle_test marka      CYCLES:  18260 ok
              ' marka         cycle_test            CYCLES:    848 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     55 ok
@@ -3438,7 +3438,7 @@ drop \ refill  ok
 \ skipping     ]  ok
 5 5 5        ' rot           cycle_test 2drop drop CYCLES:     76 ok
 5 5          ' rshift        cycle_test drop       CYCLES:    126 ok
-             ' s"            cycle_test " 2drop    CYCLES:    252 ok
+             ' s"            cycle_test " 2drop    CYCLES:    255 ok
 5            ' s>d           cycle_test 2drop      CYCLES:     47 ok
 \ skipping     ;  ok
 \ skipping     sign  ok
@@ -3473,7 +3473,7 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  16848 ok
+             ' 2variable     cycle_test eword      CYCLES:  16841 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
 s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5            ' u.            cycle_test          5 CYCLES:   3615 ok
@@ -3484,10 +3484,10 @@ s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    474 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  17069 ok
+5            ' value         cycle_test fword      CYCLES:  17062 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
 5            ' to            cycle_test fword      CYCLES:   1143 ok
-             ' variable      cycle_test gword      CYCLES:  16851 ok
+             ' variable      cycle_test gword      CYCLES:  16844 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    676 ok
 \ skipping     words  ok

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -3303,7 +3303,7 @@ drop \ accept test complete  ok
 \ skipping     begin  ok
              ' bell          cycle_test            CYCLES:     36 ok
              ' bl            cycle_test drop       CYCLES:     26 ok
-here 5       ' blank         cycle_test            CYCLES:    326 ok
+here 5       ' blank         cycle_test            CYCLES:    325 ok
 5 5          ' bounds        cycle_test 2drop      CYCLES:     70 ok
 \ skipping     [char]  ok
 \ skipping     [']  ok
@@ -3319,12 +3319,12 @@ here 5       ' blank         cycle_test            CYCLES:    326 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  15154 ok
+             ' :             cycle_test wrd ;      CYCLES:  15735 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:     66 ok
-' aword      ' compile,      cycle_test            CYCLES:    785 ok
+' aword      ' compile,      cycle_test            CYCLES:    784 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
-5            ' constant      cycle_test mycnst     CYCLES:  15648 ok
+5            ' constant      cycle_test mycnst     CYCLES:  16233 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3335,7 +3335,7 @@ here         ' count         cycle_test 2drop      CYCLES:     59 ok
              ' decimal       cycle_test            CYCLES:     20 ok
 \ skipping     defer  ok
              ' depth         cycle_test drop       CYCLES:     36 ok
-char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
+char w       ' digit?        cycle_test 2drop      CYCLES:     87 ok
 \ skipping     disasm  ok
 5.           ' dnegate       cycle_test 2drop      CYCLES:     72 ok
 : do?word1 5 5 ?do loop ;  ok
@@ -3363,7 +3363,7 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 5 5          ' =             cycle_test drop       CYCLES:     64 ok
 here 5       ' erase         cycle_test            CYCLES:    321 ok
 here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17001 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17539 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3371,8 +3371,8 @@ here         ' @             cycle_test drop       CYCLES:     59 ok
 \ making counted string for find  ok
 here 5 c, char a c, char w c, char o c,  ok
 char r c, char d c,  ok
-             ' find          cycle_test 2drop      CYCLES:   1097 ok
-s" aword"    ' find-name     cycle_test drop       CYCLES:    765 ok
+             ' find          cycle_test 2drop      CYCLES:   1124 ok
+s" aword"    ' find-name     cycle_test drop       CYCLES:    792 ok
 5. 5         ' fm/mod        cycle_test 2drop      CYCLES:   1311 ok
 5 5          ' >             cycle_test drop       CYCLES:     81 ok
              ' here          cycle_test drop       CYCLES:     30 ok
@@ -3381,7 +3381,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    765 ok
 \ skipping     i  ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   2148 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   2159 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
@@ -3395,11 +3395,11 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    765 ok
 \ skipping     loop  ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
-5 5          ' m*            cycle_test 2drop      CYCLES:    679 ok
-             ' marker        cycle_test marka      CYCLES:  17622 ok
+5 5          ' m*            cycle_test 2drop      CYCLES:    650 ok
+             ' marker        cycle_test marka      CYCLES:  18225 ok
              ' marka         cycle_test            CYCLES:    848 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
-5 5          ' min           cycle_test drop       CYCLES:     54 ok
+5 5          ' min           cycle_test drop       CYCLES:     55 ok
 5 5          ' -             cycle_test drop       CYCLES:     58 ok
 s" txt   "   ' -trailing     cycle_test 2drop      CYCLES:    218 ok
 here s" a"   ' move          cycle_test            CYCLES:    148 ok
@@ -3411,7 +3411,7 @@ here s" a"   ' move          cycle_test            CYCLES:    148 ok
 5 5          ' nip           cycle_test drop       CYCLES:     48 ok
 5 5          ' <>            cycle_test drop       CYCLES:     68 ok
 5 5 5        ' -rot          cycle_test 2drop drop CYCLES:     76 ok
-s" 5"        ' number        cycle_test drop       CYCLES:   1710 ok
+s" 5"        ' number        cycle_test drop       CYCLES:   1648 ok
 \ skipping     #  ok
 \ skipping     #>  ok
 \ skipping     #s  ok
@@ -3429,7 +3429,7 @@ char "       ' parse         cycle_test " 2drop    CYCLES:    215 ok
 5 5          ' +             cycle_test drop       CYCLES:     58 ok
 5 here       ' +!            cycle_test            CYCLES:     86 ok
 \ skipping     postpone  ok
-myvar        ' ?             cycle_test          5 CYCLES:   3897 ok
+myvar        ' ?             cycle_test          5 CYCLES:   3894 ok
 5            ' ?dup          cycle_test 2drop      CYCLES:     58 ok
 \ skipping     r>  ok
 \ skipping     recurse  ok
@@ -3449,15 +3449,15 @@ s" abc" 1    ' /string       cycle_test 2drop      CYCLES:     84 ok
              ' source-id     cycle_test drop       CYCLES:     30 ok
              ' space         cycle_test            CYCLES:     36 ok
 1            ' spaces        cycle_test            CYCLES:    159 ok
-5 5          ' *             cycle_test drop       CYCLES:    535 ok
+5 5          ' *             cycle_test drop       CYCLES:    506 ok
              ' state         cycle_test drop       CYCLES:     28 ok
 5 here       ' !             cycle_test            CYCLES:     65 ok
 5 5          ' swap          cycle_test 2drop      CYCLES:     60 ok
-             ' '             cycle_test aword drop CYCLES:   1647 ok
+             ' '             cycle_test aword drop CYCLES:   1678 ok
 \ postponing   to ( see value )  ok
 ' aword      ' >body         cycle_test drop       CYCLES:   1063 ok
              ' >in           cycle_test drop       CYCLES:     28 ok
-0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2546 ok
+0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2423 ok
 \ skipping     >r  ok
              ' true          cycle_test drop       CYCLES:     26 ok
 5 5          ' tuck          cycle_test 2drop drop CYCLES:     72 ok
@@ -3473,21 +3473,21 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  16243 ok
+             ' 2variable     cycle_test eword      CYCLES:  16848 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
-s" *"        ' type          cycle_test           *CYCLES:    124 ok
-5            ' u.            cycle_test          5 CYCLES:   3618 ok
+s" *"        ' type          cycle_test           *CYCLES:    121 ok
+5            ' u.            cycle_test          5 CYCLES:   3615 ok
 5 5          ' u>            cycle_test drop       CYCLES:     60 ok
 5 5          ' u<            cycle_test drop       CYCLES:     60 ok
              ' strip-underflow   cycle_test drop       CYCLES:     28 ok
 5. 5         ' um/mod        cycle_test 2drop      CYCLES:   1260 ok
-5 5          ' um*           cycle_test 2drop      CYCLES:    503 ok
+5 5          ' um*           cycle_test 2drop      CYCLES:    474 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  16462 ok
+5            ' value         cycle_test fword      CYCLES:  17069 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
-5            ' to            cycle_test fword      CYCLES:   1135 ok
-             ' variable      cycle_test gword      CYCLES:  16242 ok
+5            ' to            cycle_test fword      CYCLES:   1143 ok
+             ' variable      cycle_test gword      CYCLES:  16851 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    676 ok
 \ skipping     words  ok


### PR DESCRIPTION
the extra asm pass is a good idea.  This has no functional change, it just merges the definition and declaration of the relocatable zero page and user page tables which makes them much easier to understand and keep in sync.  

The tables end up at the end of native words instead of just after cold but that doesn't change any behavior.

Let me know if you're OK with this approach before I make any changes to where variables live etc.