### PR TITLE
Alternate loop optimization

### DIFF
--- a/definitions.asm
+++ b/definitions.asm
@@ -52,9 +52,8 @@ output:     .word kernel_putc       ; vector for EMIT
 input:      .word kernel_getc       ; vector for KEY
 havekey:    .word 0                 ; vector for KEY?
 
-state:      .word 0                 ; STATE: -1 compile, 0 interpret
 base:       .word 10                ; number radix, default decimal
-uf_strip:   .word 0                 ; flag to strip underflow detection code (0 off)
+state:      .word 0                 ; STATE: -1 compile, 0 interpret
 
 status:     .word 0                 ; internal status used by : :NONAME ; ACCEPT
         ; Bit 7 = Redefined word message postpone
@@ -83,8 +82,8 @@ loopdep:    .byte 0         ; nested loop depth
 
     .virtual
 tmpdsp:     .byte ?         ; temporary DSP (X) storage (single byte)
-loopend:    .word ?         ; the adjusted loop limit
-loopoff:    .word ?         ; the limit offset
+looplim:    .word ?         ; current loop adjusted limit
+loopoff:    .word ?         ; current loop limit offset
 tmptos:     .word ?         ; temporary TOS storage
 tmp1:       .word ?         ; temporary storage
 tmp2:       .word ?         ; temporary storage
@@ -109,6 +108,7 @@ cold_user_table:
     .logical 0          ; make labels here offsets that we can add to 'up'
 
 nc_limit_offset:        .word 20        ; byte limit for Native Compile size
+uf_strip_offset:        .word 0         ; flag to strip underflow detection (0 off)
 
 ; Block variables
 blk_offset:             .word 0         ; BLK

--- a/definitions.asm
+++ b/definitions.asm
@@ -84,6 +84,7 @@ loopdep:    .byte 0         ; nested loop depth
 tmpdsp:     .byte ?         ; temporary DSP (X) storage (single byte)
 looplim:    .word ?         ; current loop adjusted limit
 loopoff:    .word ?         ; current loop limit offset
+loopleave:  .word ?         ; LEAVE chaining ; TODO existing tmp
 tmptos:     .word ?         ; temporary TOS storage
 tmp1:       .word ?         ; temporary storage
 tmp2:       .word ?         ; temporary storage

--- a/definitions.asm
+++ b/definitions.asm
@@ -81,9 +81,12 @@ status:     .word 0                 ; internal status used by : :NONAME ; ACCEPT
 
     .virtual
 tmpdsp:     .byte ?         ; temporary DSP (X) storage (single byte)
-loopdepth:  .byte ?         ; global loop nesting depth (-1 outside any loop)
-loopindex:  .word ?         ; current loop adjusted index (must form dword with loopfufa)
-loopfufa:   .word ?         ; current loop fudge factor ($8000-limit)
+loopctrl:   .byte ?         ; offset to current loop control block (-4 outside any loop)
+    ; each loop control block is a 4 byte dword starting at $100 and growing upward toward
+    ; the CPU aka Return stack.  loopctrl increments by four and used to Y-index the
+    ; start of the current loop control block
+loopindex = $100            ; loopindex,y is the adjusted loop index (where Y=loopctrl)
+loopfufa  = $102            ; loopfufa,y is the offset adjustment
 loopleave:  .word ?         ; LEAVE chaining ; TODO existing tmp?
 tmptos:     .word ?         ; temporary TOS storage
 tmp1:       .word ?         ; temporary storage

--- a/definitions.asm
+++ b/definitions.asm
@@ -76,15 +76,15 @@ status:     .word 0                 ; internal status used by : :NONAME ; ACCEPT
         ; Bit 0 = Current history buffer lsb
         ;
         ; status+1 is used by ACCEPT to hold history lengths.
-loopdep:    .byte 0         ; nested loop depth
 
 ; The remaining ZP variables are uninitialized temporaries.
 
     .virtual
 tmpdsp:     .byte ?         ; temporary DSP (X) storage (single byte)
-looplim:    .word ?         ; current loop adjusted limit
-loopoff:    .word ?         ; current loop limit offset
-loopleave:  .word ?         ; LEAVE chaining ; TODO existing tmp
+loopdepth:  .byte ?         ; global loop nesting depth (-1 outside any loop)
+loopindex:  .word ?         ; current loop adjusted index (must form dword with loopfufa)
+loopfufa:   .word ?         ; current loop fudge factor ($8000-limit)
+loopleave:  .word ?         ; LEAVE chaining ; TODO existing tmp?
 tmptos:     .word ?         ; temporary TOS storage
 tmp1:       .word ?         ; temporary storage
 tmp2:       .word ?         ; temporary storage

--- a/docs/WORDLIST.md
+++ b/docs/WORDLIST.md
@@ -80,8 +80,8 @@ RTS instruction at the end of each word.
 | DIGIT_QUESTION | `digit?` | Tali Forth | 52 | **auto** |
 | DISASM | `disasm` | Tali Forth | 6 | tested |
 | DNEGATE | `dnegate` | ANS double | 26 | **auto** |
-| QUESTION_DO | `?do` | ANS core ext | 63 | **auto** |
-| DO | `do` | ANS core | 57 | **auto** |
+| QUESTION_DO | `?do` | ANS core ext | 36 | **auto** |
+| DO | `do` | ANS core | 32 | **auto** |
 | DOES | `does>` | ANS core | 14 | **auto** |
 | DOT | `.` | ANS core | 33 | **auto** |
 | DOT_PAREN | `.(` | ANS core | 14 | **auto** |
@@ -136,15 +136,15 @@ RTS instruction at the end of each word.
 | KEY | `key` | ANS core | 9 | tested |
 | LATESTNT | `latestnt` | Tali Forth | 13 | **auto** |
 | LATESTXT | `latestxt` | Gforth | 6 | **auto** |
-| LEAVE | `leave` | ANS core | 5 | **auto** |
+| LEAVE | `leave` | ANS core | 29 | **auto** |
 | LEFT_BRACKET | `[` | ANS core | 4 | **auto** |
 | LESS_NUMBER_SIGN | `<#` | ANS core | 13 | **auto** |
 | LESS_THAN | `<` | ANS core | 20 | **auto** |
 | LIST | `list` | ANS block ext | 12 | tested |
 | LITERAL | `literal` | ANS core | 13 | **auto** |
 | LOAD | `load` | ANS block | 67 | **auto** |
-| LOOP | `loop` | ANS core | 93 | **auto** |
-| PLUS_LOOP | `+loop` | ANS core | 76 | **auto** |
+| LOOP | `loop` | ANS core | 74 | **auto** |
+| PLUS_LOOP | `+loop` | ANS core | 57 | **auto** |
 | LSHIFT | `lshift` | ANS core | 19 | **auto** |
 | M_STAR | `m*` | ANS core | 26 | **auto** |
 | MARKER | `marker` | ANS core ext | 61 | **auto** |
@@ -261,7 +261,7 @@ RTS instruction at the end of each word.
 | UD_DOT_R | `ud.r` | Tali double | 30 | **auto** |
 | UM_SLASH_MOD | `um/mod` | ANS core | 65 | **auto** |
 | UM_STAR | `um*` | ANS core | 69 | **auto** |
-| UNLOOP | `unloop` | ANS core | 6 | **auto** |
+| UNLOOP | `unloop` | ANS core | 4 | **auto** |
 | UNTIL | `until` | ANS core | 20 | **auto** |
 | UNUSED | `unused` | ANS core ext | 15 | **auto** |
 | UPDATE | `update` | ANS block | 8 | **auto** |

--- a/docs/WORDLIST.md
+++ b/docs/WORDLIST.md
@@ -7,9 +7,9 @@ RTS instruction at the end of each word.
 
 | NAME | FORTH WORD | SOURCE | BYTES | STATUS |
 | :--- | :--------- | :---   | ----: | :----  |
-| COLD | `cold` | Tali Forth | 173 | tested |
-| ABORT | `abort` | ANS core | 77 | tested |
-| QUIT | `quit` | ANS core | 75 | tested |
+| COLD | `cold` | Tali Forth | 176 | tested |
+| ABORT | `abort` | ANS core | 80 | tested |
+| QUIT | `quit` | ANS core | 78 | tested |
 | ABORT_QUOTE | `abort"` | ANS core | 10 | tested |
 | ABS | `abs` | ANS core | 20 | **auto** |
 | ACCEPT | `accept` | ANS core | 248 | **auto** |
@@ -124,7 +124,7 @@ RTS instruction at the end of each word.
 | HEX | `hex` | ANS core ext | 6 | **auto** |
 | HEXSTORE | `hexstore` | Tali | 82 | **auto** |
 | HOLD | `hold` | ANS core | 17 | **auto** |
-| I | `i` | ANS core | 23 | **auto** |
+| I | `i` | ANS core | 15 | **auto** |
 | IF | `if` | ANS core | 16 | **auto** |
 | IMMEDIATE | `immediate` | ANS core | 11 | **auto** |
 | INPUT | `input` | Tali Forth | 10 | tested |
@@ -132,7 +132,7 @@ RTS instruction at the end of each word.
 | INT_TO_NAME | `int>name` | Tali Forth | 114 | **auto** |
 | INVERT | `invert` | ANS core | 15 | **auto** |
 | IS | `is` | ANS core ext | 24 | **auto** |
-| J | `j` | ANS core | 25 | **auto** |
+| J | `j` | ANS core | 23 | **auto** |
 | KEY | `key` | ANS core | 9 | tested |
 | LATESTNT | `latestnt` | Tali Forth | 13 | **auto** |
 | LATESTXT | `latestxt` | Gforth | 6 | **auto** |
@@ -143,8 +143,8 @@ RTS instruction at the end of each word.
 | LIST | `list` | ANS block ext | 12 | tested |
 | LITERAL | `literal` | ANS core | 13 | **auto** |
 | LOAD | `load` | ANS block | 67 | **auto** |
-| LOOP | `loop` | ANS core | 99 | **auto** |
-| PLUS_LOOP | `+loop` | ANS core | 82 | **auto** |
+| LOOP | `loop` | ANS core | 98 | **auto** |
+| PLUS_LOOP | `+loop` | ANS core | 81 | **auto** |
 | LSHIFT | `lshift` | ANS core | 19 | **auto** |
 | M_STAR | `m*` | ANS core | 26 | **auto** |
 | MARKER | `marker` | ANS core ext | 61 | **auto** |
@@ -261,7 +261,7 @@ RTS instruction at the end of each word.
 | UD_DOT_R | `ud.r` | Tali double | 30 | **auto** |
 | UM_SLASH_MOD | `um/mod` | ANS core | 65 | **auto** |
 | UM_STAR | `um*` | ANS core | 69 | **auto** |
-| UNLOOP | `unloop` | ANS core | 4 | **auto** |
+| UNLOOP | `unloop` | ANS core | 15 | **auto** |
 | UNTIL | `until` | ANS core | 20 | **auto** |
 | UNUSED | `unused` | ANS core ext | 15 | **auto** |
 | UPDATE | `update` | ANS block | 8 | **auto** |

--- a/docs/WORDLIST.md
+++ b/docs/WORDLIST.md
@@ -7,9 +7,9 @@ RTS instruction at the end of each word.
 
 | NAME | FORTH WORD | SOURCE | BYTES | STATUS |
 | :--- | :--------- | :---   | ----: | :----  |
-| COLD | `cold` | Tali Forth | 176 | tested |
-| ABORT | `abort` | ANS core | 80 | tested |
-| QUIT | `quit` | ANS core | 78 | tested |
+| COLD | `cold` | Tali Forth | 177 | tested |
+| ABORT | `abort` | ANS core | 81 | tested |
+| QUIT | `quit` | ANS core | 79 | tested |
 | ABORT_QUOTE | `abort"` | ANS core | 10 | tested |
 | ABS | `abs` | ANS core | 20 | **auto** |
 | ACCEPT | `accept` | ANS core | 248 | **auto** |
@@ -124,7 +124,7 @@ RTS instruction at the end of each word.
 | HEX | `hex` | ANS core ext | 6 | **auto** |
 | HEXSTORE | `hexstore` | Tali | 82 | **auto** |
 | HOLD | `hold` | ANS core | 17 | **auto** |
-| I | `i` | ANS core | 15 | **auto** |
+| I | `i` | ANS core | 21 | **auto** |
 | IF | `if` | ANS core | 16 | **auto** |
 | IMMEDIATE | `immediate` | ANS core | 11 | **auto** |
 | INPUT | `input` | Tali Forth | 10 | tested |
@@ -132,7 +132,7 @@ RTS instruction at the end of each word.
 | INT_TO_NAME | `int>name` | Tali Forth | 114 | **auto** |
 | INVERT | `invert` | ANS core | 15 | **auto** |
 | IS | `is` | ANS core ext | 24 | **auto** |
-| J | `j` | ANS core | 23 | **auto** |
+| J | `j` | ANS core | 25 | **auto** |
 | KEY | `key` | ANS core | 9 | tested |
 | LATESTNT | `latestnt` | Tali Forth | 13 | **auto** |
 | LATESTXT | `latestxt` | Gforth | 6 | **auto** |
@@ -261,7 +261,7 @@ RTS instruction at the end of each word.
 | UD_DOT_R | `ud.r` | Tali double | 30 | **auto** |
 | UM_SLASH_MOD | `um/mod` | ANS core | 65 | **auto** |
 | UM_STAR | `um*` | ANS core | 69 | **auto** |
-| UNLOOP | `unloop` | ANS core | 15 | **auto** |
+| UNLOOP | `unloop` | ANS core | 7 | **auto** |
 | UNTIL | `until` | ANS core | 20 | **auto** |
 | UNUSED | `unused` | ANS core ext | 15 | **auto** |
 | UPDATE | `update` | ANS block | 8 | **auto** |

--- a/docs/WORDLIST.md
+++ b/docs/WORDLIST.md
@@ -61,7 +61,7 @@ RTS instruction at the end of each word.
 | COLON_NONAME | `:NONAME` | ANS core | 27 | **auto** |
 | COMMA | `,` | ANS core | 25 | **auto** |
 | COMPARE | `compare` | ANS string | 100 | **auto** |
-| COMPILE_COMMA | `compile,` | ANS core ext | 297 | **auto** |
+| COMPILE_COMMA | `compile,` | ANS core ext | 300 | **auto** |
 | COMPILE_ONLY | `compile-only` | Tali Forth | 11 | tested |
 | CONSTANT | `constant` | ANS core | 61 | **auto** |
 | COUNT | `count` | ANS core | 19 | **auto** |
@@ -224,7 +224,7 @@ RTS instruction at the end of each word.
 | STAR_SLASH_MOD | `*/mod` | ANS core | 15 | **auto** |
 | STATE | `state` | ANS core | 10 | **auto** |
 | STORE | `!` | ANS core | 21 | **auto** |
-| STRIP_UNDERFLOW | `strip-underflow` | Tali Forth | 10 | tested |
+| STRIP_UNDERFLOW | `strip-underflow` | Tali Forth | 5 | tested |
 | SWAP | `swap` | ANS core | 19 | **auto** |
 | THEN | `then` | ANS core | 73 | **auto** |
 | THRU | `thru` | ANS block ext | 68 | tested |

--- a/docs/WORDLIST.md
+++ b/docs/WORDLIST.md
@@ -124,7 +124,7 @@ RTS instruction at the end of each word.
 | HEX | `hex` | ANS core ext | 6 | **auto** |
 | HEXSTORE | `hexstore` | Tali | 82 | **auto** |
 | HOLD | `hold` | ANS core | 17 | **auto** |
-| I | `i` | ANS core | 19 | **auto** |
+| I | `i` | ANS core | 34 | **auto** |
 | IF | `if` | ANS core | 16 | **auto** |
 | IMMEDIATE | `immediate` | ANS core | 11 | **auto** |
 | INPUT | `input` | Tali Forth | 10 | tested |
@@ -132,7 +132,7 @@ RTS instruction at the end of each word.
 | INT_TO_NAME | `int>name` | Tali Forth | 114 | **auto** |
 | INVERT | `invert` | ANS core | 15 | **auto** |
 | IS | `is` | ANS core ext | 24 | **auto** |
-| J | `j` | ANS core | 8 | **auto** |
+| J | `j` | ANS core | 25 | **auto** |
 | KEY | `key` | ANS core | 9 | tested |
 | LATESTNT | `latestnt` | Tali Forth | 13 | **auto** |
 | LATESTXT | `latestxt` | Gforth | 6 | **auto** |

--- a/docs/WORDLIST.md
+++ b/docs/WORDLIST.md
@@ -29,21 +29,21 @@ RTS instruction at the end of each word.
 | BEGIN | `begin` | ANS core | 3 | **auto** |
 | BELL | `bell` | Tali Forth | 5 | tested |
 | BL | `bl` | ANS core | 8 | **auto** |
-| BLK | `block` | ANS block | 15 | **auto** |
+| BLK | `block` | ANS block | 5 | **auto** |
 | BLKBUFFER | `blkbuffer` | Tali block | 13 | **auto** |
 | BLOCK | `block` | ANS block | 82 | **auto** |
 | BLOCK_RAMDRIVE_INIT | `block-ramdrive-init` | Tali block | 296 | **auto** |
 | BLOCK_READ | `block-read` | Tali block | 14 | **auto** |
-| BLOCK_READ_VECTOR | `block-read-vector` | Tali block | 15 | **auto** |
+| BLOCK_READ_VECTOR | `block-read-vector` | Tali block | 5 | **auto** |
 | BLOCK_WRITE | `block-write` | Tali block | 14 | **auto** |
-| BLOCK_WRITE_VECTOR | `block-write-vector` | Tali block | 15 | **auto** |
+| BLOCK_WRITE_VECTOR | `block-write-vector` | Tali block | 5 | **auto** |
 | BOUNDS | `bounds` | Gforth | 24 | **auto** |
 | BRACKET_CHAR | `[char]` | ANS core | 6 | **auto** |
 | BRACKET_TICK | `[']` | ANS core | 6 | **auto** |
-| BUFFBLOCKNUM | `buffblocknum` | Tali block | 15 | **auto** |
+| BUFFBLOCKNUM | `buffblocknum` | Tali block | 5 | **auto** |
 | BUFFER | `buffer` | ANS block | 48 | **auto** |
 | BUFFER_COLON | `buffer:` | ANS core ext | 6 | **auto** |
-| BUFFSTATUS | `buffstatus` | Tali block | 15 | **auto** |
+| BUFFSTATUS | `buffstatus` | Tali block | 5 | **auto** |
 | BYE | `bye` | ANS tools ext | 3 | tested |
 | C_COMMA | `c,` | ANS core | 10 | **auto** |
 | C_FETCH | `c@` | ANS core | 9 | **auto** |
@@ -61,7 +61,7 @@ RTS instruction at the end of each word.
 | COLON_NONAME | `:NONAME` | ANS core | 27 | **auto** |
 | COMMA | `,` | ANS core | 25 | **auto** |
 | COMPARE | `compare` | ANS string | 100 | **auto** |
-| COMPILE_COMMA | `compile,` | ANS core ext | 296 | **auto** |
+| COMPILE_COMMA | `compile,` | ANS core ext | 297 | **auto** |
 | COMPILE_ONLY | `compile-only` | Tali Forth | 11 | tested |
 | CONSTANT | `constant` | ANS core | 61 | **auto** |
 | COUNT | `count` | ANS core | 19 | **auto** |
@@ -157,13 +157,13 @@ RTS instruction at the end of each word.
 | MOVE | `move` | ANS core | 30 | **auto** |
 | NAME_TO_INT | `name>int` | Gforth | 28 | tested |
 | NAME_TO_STRING | `name>string` | Gforth | 25 | tested |
-| NC_LIMIT | `nc-limit` | Tali Forth | 10 | tested |
+| NC_LIMIT | `nc-limit` | Tali Forth | 5 | tested |
 | NEGATE | `negate` | ANS core | 16 | **auto** |
 | NEVER_NATIVE | `never-native` | Tali Forth | 13 | **auto** |
 | NIP | `nip` | ANS core ext | 13 | **auto** |
 | NOT_EQUALS | `<>` | ANS core ext | 29 | **auto** |
 | NOT_ROTE | `-rot` | Gforth | 27 | **auto** |
-| NUMBER | `number` | Tali Forth | 252 | **auto** |
+| NUMBER | `number` | Tali Forth | 249 | **auto** |
 | NUMBER_SIGN | `#` | ANS core | 52 | **auto** |
 | NUMBER_SIGN_GREATER | `#>` | ANS core | 33 | **auto** |
 | NUMBER_SIGN_S | `#s` | ANS core | 16 | **auto** |
@@ -206,7 +206,7 @@ RTS instruction at the end of each word.
 | S_QUOTE | `s"` | ANS core | 301 | **auto** |
 | S_TO_D | `s>d` | ANS core | 17 | **auto** |
 | SAVE_BUFFERS | `save-buffers` | ANS block | 26 | tested |
-| SCR | `scr` | ANS block ext | 15 | **auto** |
+| SCR | `scr` | ANS block ext | 5 | **auto** |
 | SEARCH | `search` | ANS string | 158 | **auto** |
 | SEMICOLON | `;` | ANS core | 94 | **auto** |
 | SIGN | `sign` | ANS core | 20 | **auto** |

--- a/docs/WORDLIST.md
+++ b/docs/WORDLIST.md
@@ -80,8 +80,8 @@ RTS instruction at the end of each word.
 | DIGIT_QUESTION | `digit?` | Tali Forth | 52 | **auto** |
 | DISASM | `disasm` | Tali Forth | 6 | tested |
 | DNEGATE | `dnegate` | ANS double | 26 | **auto** |
-| QUESTION_DO | `?do` | ANS core ext | 46 | **auto** |
-| DO | `do` | ANS core | 42 | **auto** |
+| QUESTION_DO | `?do` | ANS core ext | 62 | **auto** |
+| DO | `do` | ANS core | 58 | **auto** |
 | DOES | `does>` | ANS core | 14 | **auto** |
 | DOT | `.` | ANS core | 33 | **auto** |
 | DOT_PAREN | `.(` | ANS core | 14 | **auto** |
@@ -143,8 +143,8 @@ RTS instruction at the end of each word.
 | LIST | `list` | ANS block ext | 12 | tested |
 | LITERAL | `literal` | ANS core | 13 | **auto** |
 | LOAD | `load` | ANS block | 67 | **auto** |
-| LOOP | `loop` | ANS core | 84 | **auto** |
-| PLUS_LOOP | `+loop` | ANS core | 67 | **auto** |
+| LOOP | `loop` | ANS core | 99 | **auto** |
+| PLUS_LOOP | `+loop` | ANS core | 82 | **auto** |
 | LSHIFT | `lshift` | ANS core | 19 | **auto** |
 | M_STAR | `m*` | ANS core | 26 | **auto** |
 | MARKER | `marker` | ANS core ext | 61 | **auto** |

--- a/docs/WORDLIST.md
+++ b/docs/WORDLIST.md
@@ -124,7 +124,7 @@ RTS instruction at the end of each word.
 | HEX | `hex` | ANS core ext | 6 | **auto** |
 | HEXSTORE | `hexstore` | Tali | 82 | **auto** |
 | HOLD | `hold` | ANS core | 17 | **auto** |
-| I | `i` | ANS core | 21 | **auto** |
+| I | `i` | ANS core | 19 | **auto** |
 | IF | `if` | ANS core | 16 | **auto** |
 | IMMEDIATE | `immediate` | ANS core | 11 | **auto** |
 | INPUT | `input` | Tali Forth | 10 | tested |
@@ -132,7 +132,7 @@ RTS instruction at the end of each word.
 | INT_TO_NAME | `int>name` | Tali Forth | 114 | **auto** |
 | INVERT | `invert` | ANS core | 15 | **auto** |
 | IS | `is` | ANS core ext | 24 | **auto** |
-| J | `j` | ANS core | 25 | **auto** |
+| J | `j` | ANS core | 8 | **auto** |
 | KEY | `key` | ANS core | 9 | tested |
 | LATESTNT | `latestnt` | Tali Forth | 13 | **auto** |
 | LATESTXT | `latestxt` | Gforth | 6 | **auto** |

--- a/docs/WORDLIST.md
+++ b/docs/WORDLIST.md
@@ -80,8 +80,8 @@ RTS instruction at the end of each word.
 | DIGIT_QUESTION | `digit?` | Tali Forth | 52 | **auto** |
 | DISASM | `disasm` | Tali Forth | 6 | tested |
 | DNEGATE | `dnegate` | ANS double | 26 | **auto** |
-| QUESTION_DO | `?do` | ANS core ext | 36 | **auto** |
-| DO | `do` | ANS core | 32 | **auto** |
+| QUESTION_DO | `?do` | ANS core ext | 46 | **auto** |
+| DO | `do` | ANS core | 42 | **auto** |
 | DOES | `does>` | ANS core | 14 | **auto** |
 | DOT | `.` | ANS core | 33 | **auto** |
 | DOT_PAREN | `.(` | ANS core | 14 | **auto** |
@@ -143,8 +143,8 @@ RTS instruction at the end of each word.
 | LIST | `list` | ANS block ext | 12 | tested |
 | LITERAL | `literal` | ANS core | 13 | **auto** |
 | LOAD | `load` | ANS block | 67 | **auto** |
-| LOOP | `loop` | ANS core | 74 | **auto** |
-| PLUS_LOOP | `+loop` | ANS core | 57 | **auto** |
+| LOOP | `loop` | ANS core | 84 | **auto** |
+| PLUS_LOOP | `+loop` | ANS core | 67 | **auto** |
 | LSHIFT | `lshift` | ANS core | 19 | **auto** |
 | M_STAR | `m*` | ANS core | 26 | **auto** |
 | MARKER | `marker` | ANS core ext | 61 | **auto** |

--- a/ed.asm
+++ b/ed.asm
@@ -4,7 +4,7 @@
 ; This version: 28. Dec 2018
 
 .if "ed" in TALI_OPTIONAL_WORDS
-    
+
 ; Ed is a line-orientated editor for Tali Forth 2 based on the classic Unix
 ; editor of the same name. It is included because a) I like line editors and
 ; this is my project, so there, and b) as a very simple editor that will work
@@ -53,20 +53,19 @@
 ; that this means that we can't use two editors at the same time, which won't
 ; be a problem until we can multitask.
 
-ed_head  = editor1  ; pointer to first list element (addr) (2 bytes)
-ed_cur   = editor2  ; current line number (1 is first line) (2 bytes)
-ed_flags = editor3  ; Flags used by ed, where
+ed_head  = tmped    ; pointer to first list element (addr) (2 bytes)
+ed_cur   = tmped+2  ; current line number (1 is first line) (2 bytes)
+ed_flags = tmped+4  ; Flags used by ed, where
+ed_base  = tmped+5  ; used to hold BASE and put it back at the end.
 ;       bit 7 parameters - 0: none, 1: have at least one parameter
 ;       bit 6 changed    - 0: text not changed, 1: text was changed
 ;       bit 0 printing   - 0: no line numbers (p), 1: with line numbers (n)
-
-;  Byte editor3+1 is used to hold BASE and put it back at the end.
 
 
 ed6502:
                 ; Save the current base and set to decimal.
                 lda base
-                sta editor3+1
+                sta ed_base
                 lda #10
                 sta base
 
@@ -719,7 +718,7 @@ ed_all_done:
                 jsr xt_two_drop                 ; 2DROP ( addr-t u-t )
 
                 ; Restore the base
-                lda editor3+1
+                lda ed_base
                 sta base
 
                 rts
@@ -1244,13 +1243,13 @@ _cmd_p_done:
                 ; We arrive here with ( addr-t u-t para1 para2 f )
                 inx
                 inx                     ; fall through to _cmp_p_all_done
-                
+
                 ; Update the current line number with the last line printed.
                 lda 0,x
                 sta ed_cur
                 lda 1,x
                 sta ed_cur+1
-                
+
 _cmd_p_all_done:
                 jmp ed_next_command
 

--- a/headers.asm
+++ b/headers.asm
@@ -816,12 +816,12 @@ nt_question_do:
         .text "?do"
 
 nt_i:
-        .byte 1, CO+AN
+        .byte 1, CO
         .word nt_j, xt_i, z_i
         .text "i"
 
 nt_j:
-        .byte 1, CO+AN
+        .byte 1, CO
         .word nt_loop, xt_j, z_j
         .text "j"
 

--- a/headers.asm
+++ b/headers.asm
@@ -786,7 +786,7 @@ nt_allow_native:
         .text "allow-native"
 
 nt_nc_limit:
-        .byte 8, 0
+        .byte 8, NN
         .word nt_strip_underflow, xt_nc_limit, z_nc_limit
         .text "nc-limit"
 
@@ -1253,12 +1253,12 @@ nt_blkbuffer:
         .text "blkbuffer"
 
 nt_scr:
-        .byte 3, 0
+        .byte 3, NN
         .word nt_blk, xt_scr, z_scr
         .text "scr"
 
 nt_blk:
-        .byte 3, 0
+        .byte 3, NN
         .word nt_block_write, xt_blk, z_blk
         .text "blk"
 

--- a/headers.asm
+++ b/headers.asm
@@ -791,7 +791,7 @@ nt_nc_limit:
         .text "nc-limit"
 
 nt_strip_underflow:
-        .byte 15, 0
+        .byte 15, NN
         .word nt_abort, xt_strip_underflow, z_strip_underflow
         .text "strip-underflow"
 

--- a/headers.asm
+++ b/headers.asm
@@ -816,7 +816,7 @@ nt_question_do:
         .text "?do"
 
 nt_i:
-        .byte 1, AN+CO
+        .byte 1, CO
         .word nt_j, xt_i, z_i
         .text "i"
 

--- a/headers.asm
+++ b/headers.asm
@@ -821,7 +821,7 @@ nt_i:
         .text "i"
 
 nt_j:
-        .byte 1, AN+CO
+        .byte 1, CO
         .word nt_loop, xt_j, z_j
         .text "j"
 
@@ -841,7 +841,7 @@ nt_exit:
         .text "exit"
 
 nt_unloop:
-        .byte 6, AN+CO
+        .byte 6, CO
         .word nt_leave, xt_unloop, z_unloop
         .text "unloop"
 

--- a/headers.asm
+++ b/headers.asm
@@ -846,7 +846,7 @@ nt_unloop:
         .text "unloop"
 
 nt_leave:
-        .byte 5, AN+CO
+        .byte 5, CO+IM
         .word nt_recurse, xt_leave, z_leave
         .text "leave"
 

--- a/headers.asm
+++ b/headers.asm
@@ -816,12 +816,12 @@ nt_question_do:
         .text "?do"
 
 nt_i:
-        .byte 1, CO
+        .byte 1, CO+AN
         .word nt_j, xt_i, z_i
         .text "i"
 
 nt_j:
-        .byte 1, CO
+        .byte 1, CO+AN
         .word nt_loop, xt_j, z_j
         .text "j"
 

--- a/native_words.asm
+++ b/native_words.asm
@@ -5056,21 +5056,6 @@ xt_i:
 
                 lda loopctrl
                 bmi _fast       ; if bit 7, I=1 we have I precalculated
-                jsr calc_loop_index
-                bra z_i
-
-_fast:          lda loopi
-                sta 0,x
-                lda loopi+1
-                sta 1,x
-
-z_i:            rts
-
-
-calc_loop_index:
-        ; with A containing LCB index (not offset)
-        ; calculate corresponding loop index and write to TOS
-        ; used by xt_i and xt_j
                 asl
                 asl             ; x4 for LCB offset, dropping flag bits
                 tay
@@ -5080,8 +5065,14 @@ calc_loop_index:
                 sta 0,x
                 lda loopindex+1,y
                 sbc loopfufa+1,y
-                sta 1,x
-                rts
+                bra _msb
+
+_fast:          lda loopi
+                sta 0,x
+                lda loopi+1
+_msb:           sta 1,x
+
+z_i:            rts
 
 
 ; ## IF (C: -- orig) (flag -- ) "Conditional flow control"
@@ -5435,10 +5426,19 @@ xt_j:
                 dex                 ; make space on the stack
                 dex
 
-                ; get the previous loop control
+                ; 4 x (loopctrl-1) gives outer LCB offset
                 lda loopctrl
                 dea
-                jsr calc_loop_index
+                asl
+                asl             ; x4 for LCB offset, dropping flag bits
+                tay
+                sec
+                lda loopindex,y
+                sbc loopfufa,y
+                sta 0,x
+                lda loopindex+1,y
+                sbc loopfufa+1,y
+                sta 1,x
 z_j:            rts
 
 

--- a/taliforth.asm
+++ b/taliforth.asm
@@ -227,6 +227,20 @@ dovar:
 ; =====================================================================
 ; LOW LEVEL HELPER FUNCTIONS
 
+push_upvar_tos:
+        ; """Write addr of user page variable with offset A to TOS"""
+                dex
+                dex
+                clc
+                adc up
+                sta 0,x
+                lda up+1
+                bcc +
+                ina
++
+                sta 1,x
+                rts
+
 byte_to_ascii:
         ; """Convert byte in A to two ASCII hex digits and EMIT them"""
                 pha

--- a/tests/cycles.fs
+++ b/tests/cycles.fs
@@ -12,6 +12,7 @@ testing cycle counts
 \ desired to keep the CYCLE: counts lined up.
 
 hex
+20 nc-limit !  \ restore default that tali.fs messes with
 
 \ The location of the result
 F008 constant cycles
@@ -126,6 +127,8 @@ char w       ' digit?        cycle_test 2drop
              ' dodoword      cycle_test           
 : dodowordij 100 0 do 10 0 do i drop j drop loop loop ;
              ' dodowordij    cycle_test           
+: dodowordbigi 10 0 do 1024 0 do i drop loop loop ;
+             ' dodowordbigi  cycle_test           
 : doword+loop 100 0 do 5 +loop ;
              ' doword+loop   cycle_test           
 \ skipping     does

--- a/tests/cycles.fs
+++ b/tests/cycles.fs
@@ -11,8 +11,8 @@ testing cycle counts
 \ Take care when editing this file as the whitespace on the ends of lines is
 \ desired to keep the CYCLE: counts lined up.
 
-hex
 20 nc-limit !  \ restore default that tali.fs messes with
+hex
 
 \ The location of the result
 F008 constant cycles

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -866,11 +866,11 @@ create result  ok
 92 c, ( \\ )  ok
   ok
 T{ result here result - 2dup dump ( Make a string out of result ) 
-0F44  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-0F54   ok
+0F7A  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+0F8A   ok
    s\" \a\b\e\f\l\m\n\q\r\t\v\z\"\x41\\" 2dup dump compare -> 0 }T 
-0F57  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-0F67   ok
+0F8D  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+0F9D   ok
 hex  ok
   ok
 \ ------------------------------------------------------------------------  ok
@@ -2223,8 +2223,8 @@ T{ saved-string s\"  ok\ned \nq  ok\nrestore-output  " compare -> 0 }T  ok
 \ Test --- q --- Don't quit if we have unsaved changes  ok
 test-ed  ok
 saved-string dump 
-0F26  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
-0F36  0A 51 20  .Q  ok
+0F5C  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
+0F6C  0A 51 20  .Q  ok
 T{ s\" \na \nzzz \n. \nq \n?\nQ " compare -> 0 }T  ok
   ok
   ok
@@ -3307,7 +3307,7 @@ drop \ accept test complete  ok
 : beginuntil 100 begin 1- ?dup 0= until ;  ok
              ' beginuntil    cycle_test            CYCLES:  15462 ok
 : beginwhile 100 begin 1- ?dup while repeat ;  ok
-             ' beginwhile    cycle_test            CYCLES:  11763 ok
+             ' beginwhile    cycle_test            CYCLES:  11663 ok
              ' bell          cycle_test            CYCLES:     36 ok
              ' bl            cycle_test drop       CYCLES:     26 ok
 here 5       ' blank         cycle_test            CYCLES:    325 ok
@@ -3348,15 +3348,15 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 : do?word1 5 5 ?do loop ;  ok
              ' do?word1      cycle_test            CYCLES:    325 ok
 : do?word2 100 0 ?do i drop loop ;  ok
-             ' do?word2      cycle_test            CYCLES:   8852 ok
+             ' do?word2      cycle_test            CYCLES:   7652 ok
 : doword 100 0 do loop ;  ok
              ' doword        cycle_test            CYCLES:   2204 ok
 : dowordi 100 0 do i drop loop ;  ok
-             ' dowordi       cycle_test            CYCLES:   8704 ok
+             ' dowordi       cycle_test            CYCLES:   7504 ok
 : dodoword 100 0 do 10 0 do loop loop ;  ok
              ' dodoword      cycle_test            CYCLES:  41404 ok
 : dodowordij 100 0 do 10 0 do i drop j drop loop loop ;  ok
-             ' dodowordij    cycle_test            CYCLES: 177404 ok
+             ' dodowordij    cycle_test            CYCLES: 153404 ok
 : doword+loop 100 0 do 5 +loop ;  ok
              ' doword+loop   cycle_test            CYCLES:   2468 ok
 \ skipping     does  ok
@@ -3387,10 +3387,10 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    881 ok
 \ skipping     hold  ok
 \ skipping     i  ( exercised by doxxx above )  ok
 : ifloop 0 100 0 do i 2 and if 1 else -1 then + loop drop ;  ok
-             ' ifloop        cycle_test            CYCLES:  26636 ok
+             ' ifloop        cycle_test            CYCLES:  25436 ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   2346 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   2357 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
@@ -3405,8 +3405,8 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    881 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    650 ok
-             ' marker        cycle_test marka      CYCLES:  18364 ok
-             ' marka         cycle_test            CYCLES:    848 ok
+             ' marker        cycle_test marka      CYCLES:  18368 ok
+             ' marka         cycle_test            CYCLES:    855 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
 5 5          ' -             cycle_test drop       CYCLES:     58 ok
@@ -3482,7 +3482,7 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  16987 ok
+             ' 2variable     cycle_test eword      CYCLES:  16988 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
 s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5            ' u.            cycle_test          5 CYCLES:   3615 ok
@@ -3493,10 +3493,10 @@ s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    474 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  17208 ok
+5            ' value         cycle_test fword      CYCLES:  17209 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
 5            ' to            cycle_test fword      CYCLES:   1138 ok
-             ' variable      cycle_test gword      CYCLES:  16990 ok
+             ' variable      cycle_test gword      CYCLES:  16991 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    676 ok
 \ skipping     words  ok

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -866,11 +866,11 @@ create result  ok
 92 c, ( \\ )  ok
   ok
 T{ result here result - 2dup dump ( Make a string out of result ) 
-0F7A  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-0F8A   ok
+1014  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+1024   ok
    s\" \a\b\e\f\l\m\n\q\r\t\v\z\"\x41\\" 2dup dump compare -> 0 }T 
-0F8D  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-0F9D   ok
+1027  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+1037   ok
 hex  ok
   ok
 \ ------------------------------------------------------------------------  ok
@@ -2223,8 +2223,8 @@ T{ saved-string s\"  ok\ned \nq  ok\nrestore-output  " compare -> 0 }T  ok
 \ Test --- q --- Don't quit if we have unsaved changes  ok
 test-ed  ok
 saved-string dump 
-0F5C  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
-0F6C  0A 51 20  .Q  ok
+0FF6  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
+1006  0A 51 20  .Q  ok
 T{ s\" \na \nzzz \n. \nq \n?\nQ " compare -> 0 }T  ok
   ok
   ok
@@ -3326,12 +3326,12 @@ here 5       ' blank         cycle_test            CYCLES:    325 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  15828 ok
+             ' :             cycle_test wrd ;      CYCLES:  15832 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:     66 ok
-' aword      ' compile,      cycle_test            CYCLES:    919 ok
+' aword      ' compile,      cycle_test            CYCLES:    930 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
-5            ' constant      cycle_test mycnst     CYCLES:  16326 ok
+5            ' constant      cycle_test mycnst     CYCLES:  16330 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3348,17 +3348,17 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 : do?word1 5 5 ?do loop ;  ok
              ' do?word1      cycle_test            CYCLES:    325 ok
 : do?word2 100 0 ?do i drop loop ;  ok
-             ' do?word2      cycle_test            CYCLES:   7652 ok
+             ' do?word2      cycle_test            CYCLES:   8430 ok
 : doword 100 0 do loop ;  ok
-             ' doword        cycle_test            CYCLES:   2204 ok
+             ' doword        cycle_test            CYCLES:   2651 ok
 : dowordi 100 0 do i drop loop ;  ok
-             ' dowordi       cycle_test            CYCLES:   7504 ok
+             ' dowordi       cycle_test            CYCLES:   8282 ok
 : dodoword 100 0 do 10 0 do loop loop ;  ok
-             ' dodoword      cycle_test            CYCLES:  41404 ok
+             ' dodoword      cycle_test            CYCLES:  52417 ok
 : dodowordij 100 0 do 10 0 do i drop j drop loop loop ;  ok
-             ' dodowordij    cycle_test            CYCLES: 153404 ok
+             ' dodowordij    cycle_test            CYCLES: 183517 ok
 : doword+loop 100 0 do 5 +loop ;  ok
-             ' doword+loop   cycle_test            CYCLES:   2468 ok
+             ' doword+loop   cycle_test            CYCLES:   2601 ok
 \ skipping     does  ok
 \ skipping     .  ok
 \ skipping     ."  ok
@@ -3370,7 +3370,7 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 5 5          ' =             cycle_test drop       CYCLES:     64 ok
 here 5       ' erase         cycle_test            CYCLES:    321 ok
 here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17628 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17633 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3378,8 +3378,8 @@ here         ' @             cycle_test drop       CYCLES:     59 ok
 \ making counted string for find  ok
 here 5 c, char a c, char w c, char o c,  ok
 char r c, char d c,  ok
-             ' find          cycle_test 2drop      CYCLES:   1213 ok
-s" aword"    ' find-name     cycle_test drop       CYCLES:    881 ok
+             ' find          cycle_test 2drop      CYCLES:   1214 ok
+s" aword"    ' find-name     cycle_test drop       CYCLES:    882 ok
 5. 5         ' fm/mod        cycle_test 2drop      CYCLES:   1311 ok
 5 5          ' >             cycle_test drop       CYCLES:     81 ok
              ' here          cycle_test drop       CYCLES:     30 ok
@@ -3387,10 +3387,10 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    881 ok
 \ skipping     hold  ok
 \ skipping     i  ( exercised by doxxx above )  ok
 : ifloop 0 100 0 do i 2 and if 1 else -1 then + loop drop ;  ok
-             ' ifloop        cycle_test            CYCLES:  25436 ok
+             ' ifloop        cycle_test            CYCLES:  26315 ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   2357 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   2349 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
@@ -3405,8 +3405,8 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    881 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    650 ok
-             ' marker        cycle_test marka      CYCLES:  18368 ok
-             ' marka         cycle_test            CYCLES:    855 ok
+             ' marker        cycle_test marka      CYCLES:  18367 ok
+             ' marka         cycle_test            CYCLES:    848 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
 5 5          ' -             cycle_test drop       CYCLES:     58 ok
@@ -3420,7 +3420,7 @@ here s" a"   ' move          cycle_test            CYCLES:    148 ok
 5 5          ' nip           cycle_test drop       CYCLES:     48 ok
 5 5          ' <>            cycle_test drop       CYCLES:     68 ok
 5 5 5        ' -rot          cycle_test 2drop drop CYCLES:     76 ok
-s" 5"        ' number        cycle_test drop       CYCLES:   1645 ok
+s" 5"        ' number        cycle_test drop       CYCLES:   1646 ok
 \ skipping     #  ok
 \ skipping     #>  ok
 \ skipping     #s  ok
@@ -3442,7 +3442,7 @@ myvar        ' ?             cycle_test          5 CYCLES:   3894 ok
 5            ' ?dup          cycle_test 2drop      CYCLES:     58 ok
 \ skipping     r>  ok
 \ skipping     recurse  ok
-             ' refill        cycle_test            CYCLES:    335 ok
+             ' refill        cycle_test            CYCLES:    334 ok
 drop \ refill  ok
 \ skipping     ]  ok
 5 5 5        ' rot           cycle_test 2drop drop CYCLES:     76 ok
@@ -3457,14 +3457,14 @@ s" abc" 1    ' /string       cycle_test 2drop      CYCLES:     84 ok
              ' source        cycle_test 2drop      CYCLES:     48 ok
              ' source-id     cycle_test drop       CYCLES:     30 ok
              ' space         cycle_test            CYCLES:     36 ok
-1            ' spaces        cycle_test            CYCLES:    160 ok
+1            ' spaces        cycle_test            CYCLES:    159 ok
 5 5          ' *             cycle_test drop       CYCLES:    506 ok
              ' state         cycle_test drop       CYCLES:     28 ok
 5 here       ' !             cycle_test            CYCLES:     65 ok
 5 5          ' swap          cycle_test 2drop      CYCLES:     60 ok
-             ' '             cycle_test aword drop CYCLES:   1814 ok
+             ' '             cycle_test aword drop CYCLES:   1815 ok
 \ postponing   to ( see value )  ok
-' aword      ' >body         cycle_test drop       CYCLES:   1261 ok
+' aword      ' >body         cycle_test drop       CYCLES:   1264 ok
              ' >in           cycle_test drop       CYCLES:     28 ok
 0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2423 ok
 \ skipping     >r  ok
@@ -3493,10 +3493,10 @@ s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    474 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  17209 ok
+5            ' value         cycle_test fword      CYCLES:  17210 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
-5            ' to            cycle_test fword      CYCLES:   1138 ok
-             ' variable      cycle_test gword      CYCLES:  16991 ok
+5            ' to            cycle_test fword      CYCLES:   1139 ok
+             ' variable      cycle_test gword      CYCLES:  16994 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    676 ok
 \ skipping     words  ok

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -3310,7 +3310,7 @@ drop \ accept test complete  ok
              ' beginwhile    cycle_test            CYCLES:  11663 ok
              ' bell          cycle_test            CYCLES:     36 ok
              ' bl            cycle_test drop       CYCLES:     26 ok
-here 5       ' blank         cycle_test            CYCLES:    336 ok
+here 5       ' blank         cycle_test            CYCLES:    325 ok
 5 5          ' bounds        cycle_test 2drop      CYCLES:     70 ok
 \ skipping     [char]  ok
 \ skipping     [']  ok
@@ -3321,17 +3321,17 @@ here 5       ' blank         cycle_test            CYCLES:    336 ok
 5 here       ' c!            cycle_test            CYCLES:     46 ok
 5            ' cell+         cycle_test drop       CYCLES:     46 ok
 5            ' cells         cycle_test drop       CYCLES:     40 ok
-             ' char          cycle_test w drop     CYCLES:    451 ok
+             ' char          cycle_test w drop     CYCLES:    450 ok
 5            ' char+         cycle_test drop       CYCLES:     37 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  15798 ok
+             ' :             cycle_test wrd ;      CYCLES:  15828 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:     66 ok
-' aword      ' compile,      cycle_test            CYCLES:    907 ok
+' aword      ' compile,      cycle_test            CYCLES:    912 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
-5            ' constant      cycle_test mycnst     CYCLES:  16294 ok
+5            ' constant      cycle_test mycnst     CYCLES:  16327 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3342,7 +3342,7 @@ here         ' count         cycle_test 2drop      CYCLES:     59 ok
              ' decimal       cycle_test            CYCLES:     20 ok
 \ skipping     defer  ok
              ' depth         cycle_test drop       CYCLES:     36 ok
-char w       ' digit?        cycle_test 2drop      CYCLES:     87 ok
+char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 \ skipping     disasm  ok
 5.           ' dnegate       cycle_test 2drop      CYCLES:     72 ok
 : do?word1 5 5 ?do loop ;  ok
@@ -3368,9 +3368,9 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     87 ok
 5            ' dup           cycle_test 2drop      CYCLES:     48 ok
 42           ' emit          cycle_test           *CYCLES:     46 ok
 5 5          ' =             cycle_test drop       CYCLES:     64 ok
-here 5       ' erase         cycle_test            CYCLES:    338 ok
-here 5 5     ' fill          cycle_test            CYCLES:    326 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17606 ok
+here 5       ' erase         cycle_test            CYCLES:    327 ok
+here 5 5     ' fill          cycle_test            CYCLES:    315 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17629 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3378,8 +3378,8 @@ here         ' @             cycle_test drop       CYCLES:     59 ok
 \ making counted string for find  ok
 here 5 c, char a c, char w c, char o c,  ok
 char r c, char d c,  ok
-             ' find          cycle_test 2drop      CYCLES:   1209 ok
-s" aword"    ' find-name     cycle_test drop       CYCLES:    877 ok
+             ' find          cycle_test 2drop      CYCLES:   1213 ok
+s" aword"    ' find-name     cycle_test drop       CYCLES:    881 ok
 5. 5         ' fm/mod        cycle_test 2drop      CYCLES:   1311 ok
 5 5          ' >             cycle_test drop       CYCLES:     81 ok
              ' here          cycle_test drop       CYCLES:     30 ok
@@ -3390,7 +3390,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    877 ok
              ' ifloop        cycle_test            CYCLES:  26180 ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   2357 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   2346 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
@@ -3405,7 +3405,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    877 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    650 ok
-             ' marker        cycle_test marka      CYCLES:  18321 ok
+             ' marker        cycle_test marka      CYCLES:  18368 ok
              ' marka         cycle_test            CYCLES:    848 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
@@ -3414,13 +3414,13 @@ s" txt   "   ' -trailing     cycle_test 2drop      CYCLES:    218 ok
 here s" a"   ' move          cycle_test            CYCLES:    148 ok
 ' + int>name ' name>int      cycle_test drop       CYCLES:     71 ok
 ' + int>name ' name>string   cycle_test 2drop      CYCLES:     70 ok
-             ' nc-limit      cycle_test drop       CYCLES:     28 ok
+             ' nc-limit      cycle_test drop       CYCLES:     40 ok
 5            ' negate        cycle_test drop       CYCLES:     50 ok
 : dword ;    ' never-native  cycle_test            CYCLES:     74 ok
 5 5          ' nip           cycle_test drop       CYCLES:     48 ok
 5 5          ' <>            cycle_test drop       CYCLES:     68 ok
 5 5 5        ' -rot          cycle_test 2drop drop CYCLES:     76 ok
-s" 5"        ' number        cycle_test drop       CYCLES:   1648 ok
+s" 5"        ' number        cycle_test drop       CYCLES:   1646 ok
 \ skipping     #  ok
 \ skipping     #>  ok
 \ skipping     #s  ok
@@ -3432,7 +3432,7 @@ s" 5"        ' number        cycle_test drop       CYCLES:   1648 ok
 5 5          ' over          cycle_test 2drop drop CYCLES:     48 ok
              ' pad           cycle_test drop       CYCLES:     36 ok
 \ skipping     page  ok
-             ' parse-name    cycle_test a 2drop    CYCLES:    410 ok
+             ' parse-name    cycle_test a 2drop    CYCLES:    409 ok
 char "       ' parse         cycle_test " 2drop    CYCLES:    215 ok
 5 0          ' pick          cycle_test 2drop      CYCLES:     42 ok
 5 5          ' +             cycle_test drop       CYCLES:     58 ok
@@ -3457,12 +3457,12 @@ s" abc" 1    ' /string       cycle_test 2drop      CYCLES:     84 ok
              ' source        cycle_test 2drop      CYCLES:     48 ok
              ' source-id     cycle_test drop       CYCLES:     30 ok
              ' space         cycle_test            CYCLES:     36 ok
-1            ' spaces        cycle_test            CYCLES:    160 ok
+1            ' spaces        cycle_test            CYCLES:    159 ok
 5 5          ' *             cycle_test drop       CYCLES:    506 ok
              ' state         cycle_test drop       CYCLES:     28 ok
 5 here       ' !             cycle_test            CYCLES:     65 ok
 5 5          ' swap          cycle_test 2drop      CYCLES:     60 ok
-             ' '             cycle_test aword drop CYCLES:   1809 ok
+             ' '             cycle_test aword drop CYCLES:   1814 ok
 \ postponing   to ( see value )  ok
 ' aword      ' >body         cycle_test drop       CYCLES:   1261 ok
              ' >in           cycle_test drop       CYCLES:     28 ok
@@ -3482,7 +3482,7 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  16943 ok
+             ' 2variable     cycle_test eword      CYCLES:  16989 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
 s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5            ' u.            cycle_test          5 CYCLES:   3615 ok
@@ -3493,10 +3493,10 @@ s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    474 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  17163 ok
+5            ' value         cycle_test fword      CYCLES:  17210 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
-5            ' to            cycle_test fword      CYCLES:   1137 ok
-             ' variable      cycle_test gword      CYCLES:  16944 ok
+5            ' to            cycle_test fword      CYCLES:   1138 ok
+             ' variable      cycle_test gword      CYCLES:  16995 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    676 ok
 \ skipping     words  ok

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -866,11 +866,11 @@ create result  ok
 92 c, ( \\ )  ok
   ok
 T{ result here result - 2dup dump ( Make a string out of result ) 
-0F6B  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-0F7B   ok
+0F3F  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+0F4F   ok
    s\" \a\b\e\f\l\m\n\q\r\t\v\z\"\x41\\" 2dup dump compare -> 0 }T 
-0F7E  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-0F8E   ok
+0F52  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+0F62   ok
 hex  ok
   ok
 \ ------------------------------------------------------------------------  ok
@@ -2223,8 +2223,8 @@ T{ saved-string s\"  ok\ned \nq  ok\nrestore-output  " compare -> 0 }T  ok
 \ Test --- q --- Don't quit if we have unsaved changes  ok
 test-ed  ok
 saved-string dump 
-0F4D  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
-0F5D  0A 51 20  .Q  ok
+0F21  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
+0F31  0A 51 20  .Q  ok
 T{ s\" \na \nzzz \n. \nq \n?\nQ " compare -> 0 }T  ok
   ok
   ok
@@ -3326,12 +3326,12 @@ here 5       ' blank         cycle_test            CYCLES:    325 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  15826 ok
+             ' :             cycle_test wrd ;      CYCLES:  15828 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:     66 ok
 ' aword      ' compile,      cycle_test            CYCLES:    920 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
-5            ' constant      cycle_test mycnst     CYCLES:  16324 ok
+5            ' constant      cycle_test mycnst     CYCLES:  16327 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3346,19 +3346,19 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 \ skipping     disasm  ok
 5.           ' dnegate       cycle_test 2drop      CYCLES:     72 ok
 : do?word1 5 5 ?do loop ;  ok
-             ' do?word1      cycle_test            CYCLES:    322 ok
+             ' do?word1      cycle_test            CYCLES:    325 ok
 : do?word2 100 0 ?do i drop loop ;  ok
-             ' do?word2      cycle_test            CYCLES:   8384 ok
+             ' do?word2      cycle_test            CYCLES:   8371 ok
 : doword 100 0 do loop ;  ok
-             ' doword        cycle_test            CYCLES:   2148 ok
+             ' doword        cycle_test            CYCLES:   2123 ok
 : dowordi 100 0 do i drop loop ;  ok
-             ' dowordi       cycle_test            CYCLES:   8248 ok
+             ' dowordi       cycle_test            CYCLES:   8223 ok
 : dodoword 100 0 do 10 0 do loop loop ;  ok
-             ' dodoword      cycle_test            CYCLES:  44748 ok
+             ' dodoword      cycle_test            CYCLES:  42223 ok
 : dodowordij 100 0 do 10 0 do i drop j drop loop loop ;  ok
-             ' dodowordij    cycle_test            CYCLES: 165748 ok
+             ' dodowordij    cycle_test            CYCLES: 163223 ok
 : doword+loop 100 0 do 5 +loop ;  ok
-             ' doword+loop   cycle_test            CYCLES:   2418 ok
+             ' doword+loop   cycle_test            CYCLES:   2393 ok
 \ skipping     does  ok
 \ skipping     .  ok
 \ skipping     ."  ok
@@ -3368,9 +3368,9 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 5            ' dup           cycle_test 2drop      CYCLES:     48 ok
 42           ' emit          cycle_test           *CYCLES:     46 ok
 5 5          ' =             cycle_test drop       CYCLES:     64 ok
-here 5       ' erase         cycle_test            CYCLES:    327 ok
-here 5 5     ' fill          cycle_test            CYCLES:    315 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17626 ok
+here 5       ' erase         cycle_test            CYCLES:    321 ok
+here 5 5     ' fill          cycle_test            CYCLES:    309 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17629 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3387,10 +3387,10 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    881 ok
 \ skipping     hold  ok
 \ skipping     i  ( exercised by doxxx above )  ok
 : ifloop 0 100 0 do i 2 and if 1 else -1 then + loop drop ;  ok
-             ' ifloop        cycle_test            CYCLES:  26180 ok
+             ' ifloop        cycle_test            CYCLES:  26155 ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   2346 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   2357 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
@@ -3405,7 +3405,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    881 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    650 ok
-             ' marker        cycle_test marka      CYCLES:  18363 ok
+             ' marker        cycle_test marka      CYCLES:  18364 ok
              ' marka         cycle_test            CYCLES:    848 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
@@ -3482,7 +3482,7 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  16984 ok
+             ' 2variable     cycle_test eword      CYCLES:  16987 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
 s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5            ' u.            cycle_test          5 CYCLES:   3615 ok
@@ -3493,7 +3493,7 @@ s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    474 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  17205 ok
+5            ' value         cycle_test fword      CYCLES:  17208 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
 5            ' to            cycle_test fword      CYCLES:   1138 ok
              ' variable      cycle_test gword      CYCLES:  16990 ok

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -866,11 +866,11 @@ create result  ok
 92 c, ( \\ )  ok
   ok
 T{ result here result - 2dup dump ( Make a string out of result ) 
-0F63  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-0F73   ok
+0F44  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+0F54   ok
    s\" \a\b\e\f\l\m\n\q\r\t\v\z\"\x41\\" 2dup dump compare -> 0 }T 
-0F76  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-0F86   ok
+0F57  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+0F67   ok
 hex  ok
   ok
 \ ------------------------------------------------------------------------  ok
@@ -2223,8 +2223,8 @@ T{ saved-string s\"  ok\ned \nq  ok\nrestore-output  " compare -> 0 }T  ok
 \ Test --- q --- Don't quit if we have unsaved changes  ok
 test-ed  ok
 saved-string dump 
-0F45  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
-0F55  0A 51 20  .Q  ok
+0F26  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
+0F36  0A 51 20  .Q  ok
 T{ s\" \na \nzzz \n. \nq \n?\nQ " compare -> 0 }T  ok
   ok
   ok
@@ -3294,7 +3294,7 @@ decimal  ok
 \ skipping     quit  ok
 \ skipping     abort"  ok
 5            ' abs           cycle_test drop       CYCLES:     35 ok
-pad 20       ' accept        cycle_test some text  CYCLES:   1286 ok
+pad 20       ' accept        cycle_test some text  CYCLES:   1287 ok
 drop \ accept test complete  ok
              ' align         cycle_test            CYCLES:     12 ok
 5            ' aligned       cycle_test drop       CYCLES:     12 ok
@@ -3307,7 +3307,7 @@ drop \ accept test complete  ok
 : beginuntil 100 begin 1- ?dup 0= until ;  ok
              ' beginuntil    cycle_test            CYCLES:  15462 ok
 : beginwhile 100 begin 1- ?dup while repeat ;  ok
-             ' beginwhile    cycle_test            CYCLES:  11663 ok
+             ' beginwhile    cycle_test            CYCLES:  11763 ok
              ' bell          cycle_test            CYCLES:     36 ok
              ' bl            cycle_test drop       CYCLES:     26 ok
 here 5       ' blank         cycle_test            CYCLES:    325 ok
@@ -3326,12 +3326,12 @@ here 5       ' blank         cycle_test            CYCLES:    325 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  15823 ok
+             ' :             cycle_test wrd ;      CYCLES:  15828 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:     66 ok
 ' aword      ' compile,      cycle_test            CYCLES:    919 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
-5            ' constant      cycle_test mycnst     CYCLES:  16322 ok
+5            ' constant      cycle_test mycnst     CYCLES:  16326 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3348,17 +3348,17 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 : do?word1 5 5 ?do loop ;  ok
              ' do?word1      cycle_test            CYCLES:    325 ok
 : do?word2 100 0 ?do i drop loop ;  ok
-             ' do?word2      cycle_test            CYCLES:   6151 ok
+             ' do?word2      cycle_test            CYCLES:   8852 ok
 : doword 100 0 do loop ;  ok
-             ' doword        cycle_test            CYCLES:   1304 ok
+             ' doword        cycle_test            CYCLES:   2204 ok
 : dowordi 100 0 do i drop loop ;  ok
-             ' dowordi       cycle_test            CYCLES:   5904 ok
+             ' dowordi       cycle_test            CYCLES:   8704 ok
 : dodoword 100 0 do 10 0 do loop loop ;  ok
-             ' dodoword      cycle_test            CYCLES:  42705 ok
+             ' dodoword      cycle_test            CYCLES:  41404 ok
 : dodowordij 100 0 do 10 0 do i drop j drop loop loop ;  ok
-             ' dodowordij    cycle_test            CYCLES: 149704 ok
+             ' dodowordij    cycle_test            CYCLES: 177404 ok
 : doword+loop 100 0 do 5 +loop ;  ok
-             ' doword+loop   cycle_test            CYCLES:   2291 ok
+             ' doword+loop   cycle_test            CYCLES:   2468 ok
 \ skipping     does  ok
 \ skipping     .  ok
 \ skipping     ."  ok
@@ -3368,9 +3368,9 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 5            ' dup           cycle_test 2drop      CYCLES:     48 ok
 42           ' emit          cycle_test           *CYCLES:     46 ok
 5 5          ' =             cycle_test drop       CYCLES:     64 ok
-here 5       ' erase         cycle_test            CYCLES:    327 ok
-here 5 5     ' fill          cycle_test            CYCLES:    315 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17624 ok
+here 5       ' erase         cycle_test            CYCLES:    321 ok
+here 5 5     ' fill          cycle_test            CYCLES:    309 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17628 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3378,8 +3378,8 @@ here         ' @             cycle_test drop       CYCLES:     59 ok
 \ making counted string for find  ok
 here 5 c, char a c, char w c, char o c,  ok
 char r c, char d c,  ok
-             ' find          cycle_test 2drop      CYCLES:   1217 ok
-s" aword"    ' find-name     cycle_test drop       CYCLES:    885 ok
+             ' find          cycle_test 2drop      CYCLES:   1213 ok
+s" aword"    ' find-name     cycle_test drop       CYCLES:    881 ok
 5. 5         ' fm/mod        cycle_test 2drop      CYCLES:   1311 ok
 5 5          ' >             cycle_test drop       CYCLES:     81 ok
              ' here          cycle_test drop       CYCLES:     30 ok
@@ -3387,10 +3387,10 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    885 ok
 \ skipping     hold  ok
 \ skipping     i  ( exercised by doxxx above )  ok
 : ifloop 0 100 0 do i 2 and if 1 else -1 then + loop drop ;  ok
-             ' ifloop        cycle_test            CYCLES:  23836 ok
+             ' ifloop        cycle_test            CYCLES:  26636 ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   2360 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   2346 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
@@ -3405,7 +3405,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    885 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    650 ok
-             ' marker        cycle_test marka      CYCLES:  18360 ok
+             ' marker        cycle_test marka      CYCLES:  18364 ok
              ' marka         cycle_test            CYCLES:    848 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
@@ -3420,7 +3420,7 @@ here s" a"   ' move          cycle_test            CYCLES:    148 ok
 5 5          ' nip           cycle_test drop       CYCLES:     48 ok
 5 5          ' <>            cycle_test drop       CYCLES:     68 ok
 5 5 5        ' -rot          cycle_test 2drop drop CYCLES:     76 ok
-s" 5"        ' number        cycle_test drop       CYCLES:   1646 ok
+s" 5"        ' number        cycle_test drop       CYCLES:   1645 ok
 \ skipping     #  ok
 \ skipping     #>  ok
 \ skipping     #s  ok
@@ -3442,7 +3442,7 @@ myvar        ' ?             cycle_test          5 CYCLES:   3894 ok
 5            ' ?dup          cycle_test 2drop      CYCLES:     58 ok
 \ skipping     r>  ok
 \ skipping     recurse  ok
-             ' refill        cycle_test            CYCLES:    333 ok
+             ' refill        cycle_test            CYCLES:    335 ok
 drop \ refill  ok
 \ skipping     ]  ok
 5 5 5        ' rot           cycle_test 2drop drop CYCLES:     76 ok
@@ -3457,12 +3457,12 @@ s" abc" 1    ' /string       cycle_test 2drop      CYCLES:     84 ok
              ' source        cycle_test 2drop      CYCLES:     48 ok
              ' source-id     cycle_test drop       CYCLES:     30 ok
              ' space         cycle_test            CYCLES:     36 ok
-1            ' spaces        cycle_test            CYCLES:    159 ok
+1            ' spaces        cycle_test            CYCLES:    160 ok
 5 5          ' *             cycle_test drop       CYCLES:    506 ok
              ' state         cycle_test drop       CYCLES:     28 ok
 5 here       ' !             cycle_test            CYCLES:     65 ok
 5 5          ' swap          cycle_test 2drop      CYCLES:     60 ok
-             ' '             cycle_test aword drop CYCLES:   1818 ok
+             ' '             cycle_test aword drop CYCLES:   1814 ok
 \ postponing   to ( see value )  ok
 ' aword      ' >body         cycle_test drop       CYCLES:   1261 ok
              ' >in           cycle_test drop       CYCLES:     28 ok
@@ -3482,7 +3482,7 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  16983 ok
+             ' 2variable     cycle_test eword      CYCLES:  16987 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
 s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5            ' u.            cycle_test          5 CYCLES:   3615 ok
@@ -3493,9 +3493,9 @@ s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    474 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  17204 ok
+5            ' value         cycle_test fword      CYCLES:  17208 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
-5            ' to            cycle_test fword      CYCLES:   1142 ok
+5            ' to            cycle_test fword      CYCLES:   1138 ok
              ' variable      cycle_test gword      CYCLES:  16990 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    676 ok

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -866,11 +866,11 @@ create result  ok
 92 c, ( \\ )  ok
   ok
 T{ result here result - 2dup dump ( Make a string out of result ) 
-1014  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-1024   ok
+1041  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+1051   ok
    s\" \a\b\e\f\l\m\n\q\r\t\v\z\"\x41\\" 2dup dump compare -> 0 }T 
-1027  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-1037   ok
+1054  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+1064   ok
 hex  ok
   ok
 \ ------------------------------------------------------------------------  ok
@@ -2223,8 +2223,8 @@ T{ saved-string s\"  ok\ned \nq  ok\nrestore-output  " compare -> 0 }T  ok
 \ Test --- q --- Don't quit if we have unsaved changes  ok
 test-ed  ok
 saved-string dump 
-0FF6  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
-1006  0A 51 20  .Q  ok
+1023  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
+1033  0A 51 20  .Q  ok
 T{ s\" \na \nzzz \n. \nq \n?\nQ " compare -> 0 }T  ok
   ok
   ok
@@ -3326,12 +3326,12 @@ here 5       ' blank         cycle_test            CYCLES:    325 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  15832 ok
+             ' :             cycle_test wrd ;      CYCLES:  15826 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:     66 ok
-' aword      ' compile,      cycle_test            CYCLES:    930 ok
+' aword      ' compile,      cycle_test            CYCLES:    919 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
-5            ' constant      cycle_test mycnst     CYCLES:  16330 ok
+5            ' constant      cycle_test mycnst     CYCLES:  16323 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3348,15 +3348,15 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 : do?word1 5 5 ?do loop ;  ok
              ' do?word1      cycle_test            CYCLES:    325 ok
 : do?word2 100 0 ?do i drop loop ;  ok
-             ' do?word2      cycle_test            CYCLES:   8430 ok
+             ' do?word2      cycle_test            CYCLES:   7218 ok
 : doword 100 0 do loop ;  ok
              ' doword        cycle_test            CYCLES:   2651 ok
 : dowordi 100 0 do i drop loop ;  ok
-             ' dowordi       cycle_test            CYCLES:   8282 ok
+             ' dowordi       cycle_test            CYCLES:   7171 ok
 : dodoword 100 0 do 10 0 do loop loop ;  ok
-             ' dodoword      cycle_test            CYCLES:  52417 ok
+             ' dodoword      cycle_test            CYCLES:  51317 ok
 : dodowordij 100 0 do 10 0 do i drop j drop loop loop ;  ok
-             ' dodowordij    cycle_test            CYCLES: 183517 ok
+             ' dodowordij    cycle_test            CYCLES: 158217 ok
 : doword+loop 100 0 do 5 +loop ;  ok
              ' doword+loop   cycle_test            CYCLES:   2601 ok
 \ skipping     does  ok
@@ -3370,7 +3370,7 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 5 5          ' =             cycle_test drop       CYCLES:     64 ok
 here 5       ' erase         cycle_test            CYCLES:    321 ok
 here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17633 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17627 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3378,8 +3378,8 @@ here         ' @             cycle_test drop       CYCLES:     59 ok
 \ making counted string for find  ok
 here 5 c, char a c, char w c, char o c,  ok
 char r c, char d c,  ok
-             ' find          cycle_test 2drop      CYCLES:   1214 ok
-s" aword"    ' find-name     cycle_test drop       CYCLES:    882 ok
+             ' find          cycle_test 2drop      CYCLES:   1213 ok
+s" aword"    ' find-name     cycle_test drop       CYCLES:    881 ok
 5. 5         ' fm/mod        cycle_test 2drop      CYCLES:   1311 ok
 5 5          ' >             cycle_test drop       CYCLES:     81 ok
              ' here          cycle_test drop       CYCLES:     30 ok
@@ -3387,10 +3387,10 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    882 ok
 \ skipping     hold  ok
 \ skipping     i  ( exercised by doxxx above )  ok
 : ifloop 0 100 0 do i 2 and if 1 else -1 then + loop drop ;  ok
-             ' ifloop        cycle_test            CYCLES:  26315 ok
+             ' ifloop        cycle_test            CYCLES:  25002 ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   2349 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   2357 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
@@ -3406,7 +3406,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    882 ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    650 ok
              ' marker        cycle_test marka      CYCLES:  18367 ok
-             ' marka         cycle_test            CYCLES:    848 ok
+             ' marka         cycle_test            CYCLES:    885 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
 5 5          ' -             cycle_test drop       CYCLES:     58 ok
@@ -3420,7 +3420,7 @@ here s" a"   ' move          cycle_test            CYCLES:    148 ok
 5 5          ' nip           cycle_test drop       CYCLES:     48 ok
 5 5          ' <>            cycle_test drop       CYCLES:     68 ok
 5 5 5        ' -rot          cycle_test 2drop drop CYCLES:     76 ok
-s" 5"        ' number        cycle_test drop       CYCLES:   1646 ok
+s" 5"        ' number        cycle_test drop       CYCLES:   1645 ok
 \ skipping     #  ok
 \ skipping     #>  ok
 \ skipping     #s  ok
@@ -3464,9 +3464,9 @@ s" abc" 1    ' /string       cycle_test 2drop      CYCLES:     84 ok
 5 5          ' swap          cycle_test 2drop      CYCLES:     60 ok
              ' '             cycle_test aword drop CYCLES:   1815 ok
 \ postponing   to ( see value )  ok
-' aword      ' >body         cycle_test drop       CYCLES:   1264 ok
+' aword      ' >body         cycle_test drop       CYCLES:   1261 ok
              ' >in           cycle_test drop       CYCLES:     28 ok
-0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2423 ok
+0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2424 ok
 \ skipping     >r  ok
              ' true          cycle_test drop       CYCLES:     26 ok
 5 5          ' tuck          cycle_test 2drop drop CYCLES:     72 ok
@@ -3482,7 +3482,7 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  16988 ok
+             ' 2variable     cycle_test eword      CYCLES:  16985 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
 s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5            ' u.            cycle_test          5 CYCLES:   3615 ok
@@ -3493,10 +3493,10 @@ s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    474 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  17210 ok
+5            ' value         cycle_test fword      CYCLES:  17206 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
-5            ' to            cycle_test fword      CYCLES:   1139 ok
-             ' variable      cycle_test gword      CYCLES:  16994 ok
+5            ' to            cycle_test fword      CYCLES:   1138 ok
+             ' variable      cycle_test gword      CYCLES:  16991 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    676 ok
 \ skipping     words  ok

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -3244,6 +3244,7 @@ testing cycle counts  ok
 \ desired to keep the CYCLE: counts lined up.  ok
   ok
 hex  ok
+20 nc-limit !  \ restore default that tali.fs messes with  ok
   ok
 \ The location of the result  ok
 F008 constant cycles  ok
@@ -3305,9 +3306,9 @@ drop \ accept test complete  ok
              ' \             cycle_test            CYCLES:     41 ok
              ' base          cycle_test drop       CYCLES:     26 ok
 : beginuntil 100 begin 1- ?dup 0= until ;  ok
-             ' beginuntil    cycle_test            CYCLES:  15462 ok
+             ' beginuntil    cycle_test            CYCLES:  13062 ok
 : beginwhile 100 begin 1- ?dup while repeat ;  ok
-             ' beginwhile    cycle_test            CYCLES:  11663 ok
+             ' beginwhile    cycle_test            CYCLES:  10463 ok
              ' bell          cycle_test            CYCLES:     36 ok
              ' bl            cycle_test drop       CYCLES:     26 ok
 here 5       ' blank         cycle_test            CYCLES:    325 ok
@@ -3350,13 +3351,15 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 : do?word2 100 0 ?do i drop loop ;  ok
              ' do?word2      cycle_test            CYCLES:   7218 ok
 : doword 100 0 do loop ;  ok
-             ' doword        cycle_test            CYCLES:   2651 ok
+             ' doword        cycle_test            CYCLES:   2752 ok
 : dowordi 100 0 do i drop loop ;  ok
-             ' dowordi       cycle_test            CYCLES:   7171 ok
+             ' dowordi       cycle_test            CYCLES:   7070 ok
 : dodoword 100 0 do 10 0 do loop loop ;  ok
-             ' dodoword      cycle_test            CYCLES:  51317 ok
+             ' dodoword      cycle_test            CYCLES:  52217 ok
 : dodowordij 100 0 do 10 0 do i drop j drop loop loop ;  ok
              ' dodowordij    cycle_test            CYCLES: 158217 ok
+: dodowordbigi 10 0 do 1024 0 do i drop loop loop ;  ok
+             ' dodowordbigi  cycle_test            CYCLES: 700327 ok
 : doword+loop 100 0 do 5 +loop ;  ok
              ' doword+loop   cycle_test            CYCLES:   2601 ok
 \ skipping     does  ok
@@ -3370,7 +3373,7 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 5 5          ' =             cycle_test drop       CYCLES:     64 ok
 here 5       ' erase         cycle_test            CYCLES:    321 ok
 here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17627 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17674 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3378,8 +3381,8 @@ here         ' @             cycle_test drop       CYCLES:     59 ok
 \ making counted string for find  ok
 here 5 c, char a c, char w c, char o c,  ok
 char r c, char d c,  ok
-             ' find          cycle_test 2drop      CYCLES:   1213 ok
-s" aword"    ' find-name     cycle_test drop       CYCLES:    881 ok
+             ' find          cycle_test 2drop      CYCLES:   1260 ok
+s" aword"    ' find-name     cycle_test drop       CYCLES:    928 ok
 5. 5         ' fm/mod        cycle_test 2drop      CYCLES:   1311 ok
 5 5          ' >             cycle_test drop       CYCLES:     81 ok
              ' here          cycle_test drop       CYCLES:     30 ok
@@ -3387,10 +3390,10 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    881 ok
 \ skipping     hold  ok
 \ skipping     i  ( exercised by doxxx above )  ok
 : ifloop 0 100 0 do i 2 and if 1 else -1 then + loop drop ;  ok
-             ' ifloop        cycle_test            CYCLES:  25002 ok
+             ' ifloop        cycle_test            CYCLES:  22602 ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   2357 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   2413 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
@@ -3405,8 +3408,8 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    881 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    650 ok
-             ' marker        cycle_test marka      CYCLES:  18367 ok
-             ' marka         cycle_test            CYCLES:    885 ok
+             ' marker        cycle_test marka      CYCLES:  18410 ok
+             ' marka         cycle_test            CYCLES:    848 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
 5 5          ' -             cycle_test drop       CYCLES:     58 ok
@@ -3462,9 +3465,9 @@ s" abc" 1    ' /string       cycle_test 2drop      CYCLES:     84 ok
              ' state         cycle_test drop       CYCLES:     28 ok
 5 here       ' !             cycle_test            CYCLES:     65 ok
 5 5          ' swap          cycle_test 2drop      CYCLES:     60 ok
-             ' '             cycle_test aword drop CYCLES:   1815 ok
+             ' '             cycle_test aword drop CYCLES:   1861 ok
 \ postponing   to ( see value )  ok
-' aword      ' >body         cycle_test drop       CYCLES:   1261 ok
+' aword      ' >body         cycle_test drop       CYCLES:   1328 ok
              ' >in           cycle_test drop       CYCLES:     28 ok
 0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2424 ok
 \ skipping     >r  ok
@@ -3482,7 +3485,7 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  16985 ok
+             ' 2variable     cycle_test eword      CYCLES:  17031 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
 s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5            ' u.            cycle_test          5 CYCLES:   3615 ok
@@ -3493,10 +3496,10 @@ s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    474 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  17206 ok
+5            ' value         cycle_test fword      CYCLES:  17252 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
 5            ' to            cycle_test fword      CYCLES:   1138 ok
-             ' variable      cycle_test gword      CYCLES:  16991 ok
+             ' variable      cycle_test gword      CYCLES:  17037 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    676 ok
 \ skipping     words  ok

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -3326,12 +3326,12 @@ here 5       ' blank         cycle_test            CYCLES:    325 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  15828 ok
+             ' :             cycle_test wrd ;      CYCLES:  15826 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:     66 ok
-' aword      ' compile,      cycle_test            CYCLES:    912 ok
+' aword      ' compile,      cycle_test            CYCLES:    920 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
-5            ' constant      cycle_test mycnst     CYCLES:  16327 ok
+5            ' constant      cycle_test mycnst     CYCLES:  16324 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3370,7 +3370,7 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 5 5          ' =             cycle_test drop       CYCLES:     64 ok
 here 5       ' erase         cycle_test            CYCLES:    327 ok
 here 5 5     ' fill          cycle_test            CYCLES:    315 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17629 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17626 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3405,7 +3405,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    881 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    650 ok
-             ' marker        cycle_test marka      CYCLES:  18368 ok
+             ' marker        cycle_test marka      CYCLES:  18363 ok
              ' marka         cycle_test            CYCLES:    848 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
@@ -3482,21 +3482,21 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  16989 ok
+             ' 2variable     cycle_test eword      CYCLES:  16984 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
 s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5            ' u.            cycle_test          5 CYCLES:   3615 ok
 5 5          ' u>            cycle_test drop       CYCLES:     60 ok
 5 5          ' u<            cycle_test drop       CYCLES:     60 ok
-             ' strip-underflow   cycle_test drop   CYCLES:     28 ok
+             ' strip-underflow   cycle_test drop   CYCLES:     40 ok
 5. 5         ' um/mod        cycle_test 2drop      CYCLES:   1260 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    474 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  17210 ok
+5            ' value         cycle_test fword      CYCLES:  17205 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
 5            ' to            cycle_test fword      CYCLES:   1138 ok
-             ' variable      cycle_test gword      CYCLES:  16995 ok
+             ' variable      cycle_test gword      CYCLES:  16990 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    676 ok
 \ skipping     words  ok

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -3243,8 +3243,8 @@ testing cycle counts  ok
 \ Take care when editing this file as the whitespace on the ends of lines is  ok
 \ desired to keep the CYCLE: counts lined up.  ok
   ok
-hex  ok
 20 nc-limit !  \ restore default that tali.fs messes with  ok
+hex  ok
   ok
 \ The location of the result  ok
 F008 constant cycles  ok
@@ -3330,7 +3330,7 @@ pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
              ' :             cycle_test wrd ;      CYCLES:  15826 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:     66 ok
-' aword      ' compile,      cycle_test            CYCLES:    919 ok
+' aword      ' compile,      cycle_test            CYCLES:    920 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
 5            ' constant      cycle_test mycnst     CYCLES:  16323 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
@@ -3351,15 +3351,15 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 : do?word2 100 0 ?do i drop loop ;  ok
              ' do?word2      cycle_test            CYCLES:   7218 ok
 : doword 100 0 do loop ;  ok
-             ' doword        cycle_test            CYCLES:   2752 ok
+             ' doword        cycle_test            CYCLES:   2651 ok
 : dowordi 100 0 do i drop loop ;  ok
-             ' dowordi       cycle_test            CYCLES:   7070 ok
+             ' dowordi       cycle_test            CYCLES:   7169 ok
 : dodoword 100 0 do 10 0 do loop loop ;  ok
-             ' dodoword      cycle_test            CYCLES:  52217 ok
+             ' dodoword      cycle_test            CYCLES:  51318 ok
 : dodowordij 100 0 do 10 0 do i drop j drop loop loop ;  ok
              ' dodowordij    cycle_test            CYCLES: 158217 ok
 : dodowordbigi 10 0 do 1024 0 do i drop loop loop ;  ok
-             ' dodowordbigi  cycle_test            CYCLES: 700327 ok
+             ' dodowordbigi  cycle_test            CYCLES: 700317 ok
 : doword+loop 100 0 do 5 +loop ;  ok
              ' doword+loop   cycle_test            CYCLES:   2601 ok
 \ skipping     does  ok
@@ -3373,7 +3373,7 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 5 5          ' =             cycle_test drop       CYCLES:     64 ok
 here 5       ' erase         cycle_test            CYCLES:    321 ok
 here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17674 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17676 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3381,8 +3381,8 @@ here         ' @             cycle_test drop       CYCLES:     59 ok
 \ making counted string for find  ok
 here 5 c, char a c, char w c, char o c,  ok
 char r c, char d c,  ok
-             ' find          cycle_test 2drop      CYCLES:   1260 ok
-s" aword"    ' find-name     cycle_test drop       CYCLES:    928 ok
+             ' find          cycle_test 2drop      CYCLES:   1262 ok
+s" aword"    ' find-name     cycle_test drop       CYCLES:    930 ok
 5. 5         ' fm/mod        cycle_test 2drop      CYCLES:   1311 ok
 5 5          ' >             cycle_test drop       CYCLES:     81 ok
              ' here          cycle_test drop       CYCLES:     30 ok
@@ -3393,7 +3393,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    928 ok
              ' ifloop        cycle_test            CYCLES:  22602 ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   2413 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   2415 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
@@ -3408,7 +3408,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    928 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    650 ok
-             ' marker        cycle_test marka      CYCLES:  18410 ok
+             ' marker        cycle_test marka      CYCLES:  18412 ok
              ' marka         cycle_test            CYCLES:    848 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
@@ -3465,9 +3465,9 @@ s" abc" 1    ' /string       cycle_test 2drop      CYCLES:     84 ok
              ' state         cycle_test drop       CYCLES:     28 ok
 5 here       ' !             cycle_test            CYCLES:     65 ok
 5 5          ' swap          cycle_test 2drop      CYCLES:     60 ok
-             ' '             cycle_test aword drop CYCLES:   1861 ok
+             ' '             cycle_test aword drop CYCLES:   1863 ok
 \ postponing   to ( see value )  ok
-' aword      ' >body         cycle_test drop       CYCLES:   1328 ok
+' aword      ' >body         cycle_test drop       CYCLES:   1330 ok
              ' >in           cycle_test drop       CYCLES:     28 ok
 0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2424 ok
 \ skipping     >r  ok
@@ -3485,7 +3485,7 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  17031 ok
+             ' 2variable     cycle_test eword      CYCLES:  17033 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
 s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5            ' u.            cycle_test          5 CYCLES:   3615 ok
@@ -3496,10 +3496,10 @@ s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    474 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  17252 ok
+5            ' value         cycle_test fword      CYCLES:  17254 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
 5            ' to            cycle_test fword      CYCLES:   1138 ok
-             ' variable      cycle_test gword      CYCLES:  17037 ok
+             ' variable      cycle_test gword      CYCLES:  17039 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    676 ok
 \ skipping     words  ok

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -866,11 +866,11 @@ create result  ok
 92 c, ( \\ )  ok
   ok
 T{ result here result - 2dup dump ( Make a string out of result ) 
-0F3F  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-0F4F   ok
+0F63  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+0F73   ok
    s\" \a\b\e\f\l\m\n\q\r\t\v\z\"\x41\\" 2dup dump compare -> 0 }T 
-0F52  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-0F62   ok
+0F76  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+0F86   ok
 hex  ok
   ok
 \ ------------------------------------------------------------------------  ok
@@ -2223,8 +2223,8 @@ T{ saved-string s\"  ok\ned \nq  ok\nrestore-output  " compare -> 0 }T  ok
 \ Test --- q --- Don't quit if we have unsaved changes  ok
 test-ed  ok
 saved-string dump 
-0F21  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
-0F31  0A 51 20  .Q  ok
+0F45  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
+0F55  0A 51 20  .Q  ok
 T{ s\" \na \nzzz \n. \nq \n?\nQ " compare -> 0 }T  ok
   ok
   ok
@@ -3326,12 +3326,12 @@ here 5       ' blank         cycle_test            CYCLES:    325 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  15828 ok
+             ' :             cycle_test wrd ;      CYCLES:  15823 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:     66 ok
-' aword      ' compile,      cycle_test            CYCLES:    920 ok
+' aword      ' compile,      cycle_test            CYCLES:    919 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
-5            ' constant      cycle_test mycnst     CYCLES:  16327 ok
+5            ' constant      cycle_test mycnst     CYCLES:  16322 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3348,17 +3348,17 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 : do?word1 5 5 ?do loop ;  ok
              ' do?word1      cycle_test            CYCLES:    325 ok
 : do?word2 100 0 ?do i drop loop ;  ok
-             ' do?word2      cycle_test            CYCLES:   8371 ok
+             ' do?word2      cycle_test            CYCLES:   6151 ok
 : doword 100 0 do loop ;  ok
-             ' doword        cycle_test            CYCLES:   2123 ok
+             ' doword        cycle_test            CYCLES:   1304 ok
 : dowordi 100 0 do i drop loop ;  ok
-             ' dowordi       cycle_test            CYCLES:   8223 ok
+             ' dowordi       cycle_test            CYCLES:   5904 ok
 : dodoword 100 0 do 10 0 do loop loop ;  ok
-             ' dodoword      cycle_test            CYCLES:  42223 ok
+             ' dodoword      cycle_test            CYCLES:  42705 ok
 : dodowordij 100 0 do 10 0 do i drop j drop loop loop ;  ok
-             ' dodowordij    cycle_test            CYCLES: 163223 ok
+             ' dodowordij    cycle_test            CYCLES: 149704 ok
 : doword+loop 100 0 do 5 +loop ;  ok
-             ' doword+loop   cycle_test            CYCLES:   2393 ok
+             ' doword+loop   cycle_test            CYCLES:   2291 ok
 \ skipping     does  ok
 \ skipping     .  ok
 \ skipping     ."  ok
@@ -3368,9 +3368,9 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 5            ' dup           cycle_test 2drop      CYCLES:     48 ok
 42           ' emit          cycle_test           *CYCLES:     46 ok
 5 5          ' =             cycle_test drop       CYCLES:     64 ok
-here 5       ' erase         cycle_test            CYCLES:    321 ok
-here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17629 ok
+here 5       ' erase         cycle_test            CYCLES:    327 ok
+here 5 5     ' fill          cycle_test            CYCLES:    315 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17624 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3378,8 +3378,8 @@ here         ' @             cycle_test drop       CYCLES:     59 ok
 \ making counted string for find  ok
 here 5 c, char a c, char w c, char o c,  ok
 char r c, char d c,  ok
-             ' find          cycle_test 2drop      CYCLES:   1213 ok
-s" aword"    ' find-name     cycle_test drop       CYCLES:    881 ok
+             ' find          cycle_test 2drop      CYCLES:   1217 ok
+s" aword"    ' find-name     cycle_test drop       CYCLES:    885 ok
 5. 5         ' fm/mod        cycle_test 2drop      CYCLES:   1311 ok
 5 5          ' >             cycle_test drop       CYCLES:     81 ok
              ' here          cycle_test drop       CYCLES:     30 ok
@@ -3387,10 +3387,10 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    881 ok
 \ skipping     hold  ok
 \ skipping     i  ( exercised by doxxx above )  ok
 : ifloop 0 100 0 do i 2 and if 1 else -1 then + loop drop ;  ok
-             ' ifloop        cycle_test            CYCLES:  26155 ok
+             ' ifloop        cycle_test            CYCLES:  23836 ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   2357 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   2360 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
@@ -3405,7 +3405,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    881 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    650 ok
-             ' marker        cycle_test marka      CYCLES:  18364 ok
+             ' marker        cycle_test marka      CYCLES:  18360 ok
              ' marka         cycle_test            CYCLES:    848 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
@@ -3462,7 +3462,7 @@ s" abc" 1    ' /string       cycle_test 2drop      CYCLES:     84 ok
              ' state         cycle_test drop       CYCLES:     28 ok
 5 here       ' !             cycle_test            CYCLES:     65 ok
 5 5          ' swap          cycle_test 2drop      CYCLES:     60 ok
-             ' '             cycle_test aword drop CYCLES:   1814 ok
+             ' '             cycle_test aword drop CYCLES:   1818 ok
 \ postponing   to ( see value )  ok
 ' aword      ' >body         cycle_test drop       CYCLES:   1261 ok
              ' >in           cycle_test drop       CYCLES:     28 ok
@@ -3482,7 +3482,7 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  16987 ok
+             ' 2variable     cycle_test eword      CYCLES:  16983 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
 s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5            ' u.            cycle_test          5 CYCLES:   3615 ok
@@ -3493,9 +3493,9 @@ s" *"        ' type          cycle_test           *CYCLES:    121 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    474 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  17208 ok
+5            ' value         cycle_test fword      CYCLES:  17204 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
-5            ' to            cycle_test fword      CYCLES:   1138 ok
+5            ' to            cycle_test fword      CYCLES:   1142 ok
              ' variable      cycle_test gword      CYCLES:  16990 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    676 ok


### PR DESCRIPTION
This version takes all the loop control off the CPU/R stack and puts it at the bottom of page 1.  This gives an upward growing loop control stack where we never need to move anything around, just change an index.   This simplifies various things and doesn't cause any more risk to the CPU stack since items that once were there are just at the bottom of the stack page instead.