### PR TITLE
Update loop docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ taliforth-%.prg: platform/platform-%.asm $(COMMON_SOURCES)
 # Automatically update the wordlist which also gives us the status of the words
 # We need for the binary to be generated first or else we won't be able to find
 # new words in the label listing
-docs/WORDLIST.md: taliforth-py65mon.bin
+docs/WORDLIST.md: tools/generate_wordlist.py taliforth-py65mon.bin
 	$(PYTHON) tools/generate_wordlist.py > docs/WORDLIST.md
 
 
@@ -120,7 +120,7 @@ csim: $(C65) taliforth-py65mon.bin
 docs/manual.html: docs/*.adoc
 	cd docs && asciidoctor -a toc=left manual.adoc
 
-docs/ch_glossary.adoc:	$(wildcard words/*.asm)
+docs/ch_glossary.adoc: tools/generate_glossary.py $(wildcard words/*.asm)
 	$(PYTHON) tools/generate_glossary.py > docs/ch_glossary.adoc
 
 # The diagrams use ditaa to generate pretty diagrams from text files.

--- a/docs/ch_developing.adoc
+++ b/docs/ch_developing.adoc
@@ -7,6 +7,8 @@ in their right mind would want to program in this godforsaken language! <<DH>>
 
 To run Tali Forth 2 in a simulator, you will need `python3` and `py65` installed to be
 able to run `py65mon`.
+Tali Forth 2 also ships with the bare-bones `c65` simulator.
+This is much faster than `py65mon` but lacks the debugging and monitor capabilities.
 
 To assemble Tali Forth 2, you will need `64tass` (version 1.56.2625 or later) and `make`.
 
@@ -137,13 +139,17 @@ installed). This also updates the file listings in the `docs` folder.
 * The Y register, however, is free to be changed by subroutines. This also means
   it should not be expected to survive subroutines unchanged.
 
-* Natively coded words generally should have exactly one point of entry -- the 
+* Natively coded words generally should have exactly one point of entry -- the
   `xt_word` link -- and exactly one point of exit at `z_word`. In may cases,
   this requires a branch to an internal label `_done` right before `z_word`.
 
 * Because of the way native compiling works, the trick of combining
   `jsr`-`rts` pairs to a single `jmp` instruction (usually) doesn't work.
 
+* In broad terms Tali Forth 2 should be easy to understand and use.
+  When adding new code you should prefer simplicity over complexity,
+  particularly for compile-time words.
+  Speed is a virtue for core run-time words and reducing code size is always a virtue.
 
 ==== Coding Style
 
@@ -166,7 +172,7 @@ way gofmt does for Go (golang), the following format is suggested.
 * Assembler mnemonics are lower case. I get enough uppercase insanity writing German,
   thank you very much.
 
-* Hex numbers are, however, upper case, such as `$FFFE`. 
+* Hex numbers are, however, upper case, such as `$FFFE`.
 
 * Numbers in mnemonics are a stripped-down as possible to reduce
   visual clutter: use `lda 0,x` instead of `lda $00,x`.
@@ -198,18 +204,18 @@ numbers and symbols) of the word.
 
 As an example, let's turn the following definition into assembly:
 
----- 
-: getstate state @ ; 
----- 
-Translates into: 
----- 
-; ## GETSTATE ( -- n ) "Get the current state" 
-; ## "getstate" coded Custom 
-xt_getstate: 
+----
+: getstate state @ ;
+----
+Translates into:
+----
+; ## GETSTATE ( -- n ) "Get the current state"
+; ## "getstate" coded Custom
+xt_getstate:
                 jsr xt_state
                 jsr xt_fetch ; @ is pronounced "fetch" in Forth.
-z_getstate: 
-                rts 
+z_getstate:
+                rts
 ----
 
 The above code would be added to native_words.asm, probably right after
@@ -276,21 +282,21 @@ translated into assembly as a JSR.
 
 When we go to add our word to native_words.asm, we discover that the name
 xt_star is already in use (for the multiplication word `*`), so this will show how
-to deal with that complication as well.  
+to deal with that complication as well.
 
----- 
-; ## STAR_WORD ( -- ) "Print a * on the screen" 
-; ## "star" coded Custom 
-xt_star_word: 
-                ; Put a * character on the stack.  
-                dex             ; Make room on the data stack.  
-                dex 
+----
+; ## STAR_WORD ( -- ) "Print a * on the screen"
+; ## "star" coded Custom
+xt_star_word:
+                ; Put a * character on the stack.
+                dex             ; Make room on the data stack.
+                dex
                 lda #42         ; * is ASCII character 42.
                 sta 0,x         ; Store in low byte of stack cell.
                 stz 1,x         ; high byte is zeroed for characters.
                 jsr xt_emit     ; Print the character to the screen.
-z_star_word: 
-                rts 
+z_star_word:
+                rts
 ----
 
 We chose the labels xt_star_word and z_star_word for this word, but it will be
@@ -362,7 +368,7 @@ _compiling:
 _interpreting:
                 jsr xt_tick
                 jsr xt_defer_store
-_done:          
+_done:
 z_is:           rts
 ----
 
@@ -433,16 +439,16 @@ xt_two_constant:
                 jsr xt_swap
                 jsr xt_comma
                 jsr xt_comma
-                
+
                 jsr does_runtime    ; does> turns into these two routines.
                 jsr dodoes
-                
+
                 jsr xt_dup
                 jsr xt_fetch
                 jsr xt_swap
                 jsr xt_cell_plus
                 jsr xt_fetch
-                
+
 z_two_constant: rts
 ----
 
@@ -480,7 +486,7 @@ Before we dicuss adding a word, let's go over the form a dictionary header.  The
 fields we will be filling in are described right at the top of headers.asm for
 reference. We'll look at an easy to locate word, `drop`, which is used to
 remove the top item on the stack. It's right near the top of the list.  We'll also
-show the word `dup`, which is the next word is the dictionary. 
+show the word `dup`, which is the next word is the dictionary.
 The headers for these two words currently look like:
 
 ----
@@ -516,7 +522,7 @@ compiled (even when in compiling mode).
 NN:: Never Native Compile (must always be called by JSR when compiled).  Add
 this when your word contains a JMP instruction, or if it plays with the return
 address it is called from.
-AN:: Always Native Compile (will be native compiled when compiled).  
+AN:: Always Native Compile (will be native compiled when compiled).
 The opcodes for this word will be copied (native compiling)
 into a new word when this word is used in the definition.  For short simple words that
 are just a sequence of JSRs, you can safely set this bit.  This bit should not
@@ -622,7 +628,7 @@ value" version, which could increment the DSP twice before storing a value. We
 try to keep these in the same sequence (a "dialect" or "code mannerism" if you
 will) so we have the option of adding code analysis tools later.
 
-* `drop` cell of top of the Data Stack 
+* `drop` cell of top of the Data Stack
 
 ----
                 inx
@@ -632,7 +638,7 @@ will) so we have the option of adding code analysis tools later.
 * `push` a value to the Data Stack. Remember the Data Stack Pointer (DSP, the
   X register of the 65c02) points to the LSB of the TOS value.
 
----- 
+----
                 dex
                 dex
                 lda <LSB>      ; or pla, jsr key_a, etc.

--- a/docs/ch_glossary.adoc
+++ b/docs/ch_glossary.adoc
@@ -555,7 +555,7 @@ https://forth-standard.org/standard/tools/DUMP
 `dup`:: _ANS core_ ( u -- u u ) "Duplicate TOS"
 https://forth-standard.org/standard/core/DUP
 
-`ed`:: _Tali Forth_ ( -- u ) "Line-based editor"
+`ed:`:: _Tali Forth_ ( -- u ) "Line-based editor"
 Start the line-based editor ed6502. See separate file
 ed.asm or the manual for details.
 
@@ -682,7 +682,7 @@ Insert a character at the current position of a pictured numeric
 output string on
 https://github.com/philburk/pforth/blob/master/fth/numberio.fth
 
-`i`:: _ANS core_ ( -- n )(R: n -- n)  "Copy loop counter to stack"
+`i`:: _ANS core_ ( -- n )  "Copy loop counter to stack"
 https://forth-standard.org/standard/core/I
 See definitions.asm and the Control Flow section of the manual.
 
@@ -712,7 +712,7 @@ https://forth-standard.org/standard/core/INVERT
 `is`:: _ANS core ext_ ( xt "name" -- ) "Set named word to execute xt"
 http://forth-standard.org/standard/core/IS
 
-`j`:: _ANS core_ ( -- n ) (R: n -- n ) "Copy second loop counter to stack"
+`j`:: _ANS core_ ( -- n ) "Copy second loop counter to stack"
 https://forth-standard.org/standard/core/J
 Copy second loop counter from Return Stack to stack. Note we use
 a fudge factor for loop control; see the Control Flow section of
@@ -720,6 +720,8 @@ the manual for more details.
 
 `key`:: _ANS core_ ( -- char ) "Get one character from the input"
 `l`:: _Tali Editor_ ( -- ) "List the current screen"
+note "l" is used by LIST in the block words
+
 `latestnt`:: _Tali Forth_ ( -- nt ) "Push most recent nt to the stack"
 www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html
 The Gforth version of this word is called LATEST
@@ -1074,7 +1076,7 @@ This is the basic division operation all others use. Based on FIG
 Forth code, modified by Garth Wilson, see
 http://6502.org/source/integers/ummodfix/ummodfix.htm
 
-`unloop`:: _ANS core_ ( -- )(R: n1 n2 n3 ---) "Drop loop control from Return stack"
+`unloop`:: _ANS core_ ( -- )(R: n1 n2 n3 ---) "Drop current loop control block"
 https://forth-standard.org/standard/core/UNLOOP
 
 `until`:: _ANS core_ (C: dest -- ) ( -- ) "Loop flow control"

--- a/docs/ch_internals.adoc
+++ b/docs/ch_internals.adoc
@@ -55,10 +55,10 @@ image::pics/stack_diagram.png[]
 
 Note that the 65c02 system stack -- used as the Return Stack (RS) by Tali --
 pushes the MSB on first and then the LSB (preserving little endian), so the
-basic structure is the same for both stacks. 
+basic structure is the same for both stacks.
 
 Because of this stack design, the second entry ("next on stack", NOS) starts at
-`02,X` and the third entry ("third on stack", 3OS) at `04,X`. 
+`02,X` and the third entry ("third on stack", 3OS) at `04,X`.
 
 ==== Underflow Detection
 
@@ -76,12 +76,12 @@ However, it increases the stability of the program. There is an option for
 stripping it out when compiling user-defined words (see below).
 
 Tali Forth does not check for overflow, which in normal operation is too rare
-to justify the computing expense. 
+to justify the computing expense.
 
 
 ==== Double Cell Values
 
-The double cell is stored on top of the single cell. 
+The double cell is stored on top of the single cell.
 
 image::pics/double_cell.png[]
 
@@ -97,37 +97,37 @@ to allow various tricks in the code.
 
 ==== Elements of the Header
 
-Each header is at least eight bytes long: 
+Each header is at least eight bytes long:
 
 image::pics/header_diagram.png[]
 
 Each word has a `name token` (nt, `nt_word` in the code) that points to the
 first byte of the header. This is the length of the word's name string, which
-is limited to 255 characters. 
+is limited to 255 characters.
 
 The second byte in the header (index 1) is the status byte. It is created by
-the flags defined in the file `definitions.asm`: 
+the flags defined in the file `definitions.asm`:
 
 [horizontal]
-CO:: 
+CO::
   *Compile Only.* This word may only be used inside definitions of new words.
-IM:: 
+IM::
   *Immediate.* This Word is executed immediately during definitions of new words.
-NN:: 
+NN::
   *Never Native.* This Word is never inlined. Usually means that the return address
   from a subroutine jump is required for processing.  Any words containing flow control
   should have this flag set and it is set by default for new words.
-AN:: 
+AN::
   *Always Native.* This word must always be inlined.
-UF:: 
+UF::
   *Undeflow Detection.* This word checks for Data Stack underflow before it is
-  executed. 
+  executed.
 HC::
-  *Has CFA.* Consider first three bytes of the word's code the Code Field 
+  *Has CFA.* Consider first three bytes of the word's code the Code Field
   Area (CFA) of the word. Used by words defined with `create` so `>body` returns
   the correct value.
 
-Note there are currently two bits unused. 
+Note there are currently two bits unused.
 
 The status byte is followed by the **pointer to the next header** in the linked
 list, which makes it the name token of the next word. A 0000 in this position
@@ -136,17 +136,17 @@ the native code words.
 
 This is followed by the current word's **execution token** (xt, `xt_word`) that
 points to the start of the actual code. Some words that have the same
-functionality point to the same code block. 
+functionality point to the same code block.
 
 NOTE: Because Tali uses a subroutine threaded model (STC), the classic Forth
 distinction between the Code Field Area (CFA) and the Parameter Field Area
-(PFA, also Data Field Area) is meaningless -- it's all "payload". 
+(PFA, also Data Field Area) is meaningless -- it's all "payload".
 
 The next pointer is for the **end of the code** (`z_word`) to enable native
-compilation of the word (if allowed and requested). 
+compilation of the word (if allowed and requested).
 
 The **name string** starts at the eighth byte. The string is _not_
-zero-terminated.  Tali Forth lowercases names as they are copied into the 
+zero-terminated.  Tali Forth lowercases names as they are copied into the
 dictionary and also lowercases during lookup, so `quarian` is the same word as
 `QUARIAN`.  If the name in the dictionary is directly modified, it is important
 to ensure that only lowercase letters are used, or else Tali will not be able
@@ -159,7 +159,7 @@ Tali Forth distinguishes between three different word sources: The **native
 words** that are hard-coded in the file `native_words.asm`, the **Forth words**
 from `forth_words.asm` which are defined as high-level words and then generated
 at run-time when Tali Forth starts up, and **user words** in the file
-`user_words.asm`. 
+`user_words.asm`.
 
 Tali has an unusually high number of native words in an attempt to make the
 Forth as fast as possible on the 65c02 and compensate for the disadvantages of
@@ -167,14 +167,14 @@ the subroutine threading model (STC). The first word on that list -- the one
 that is checked first -- is always `drop`, the last one -- the one checked for
 last -- is always `bye`. The words which are (or are assumed to be) used more
 than others come first. Since humans are slow, words that are used more
-interactively like `words` always come later. 
+interactively like `words` always come later.
 
 The list of Forth words ends with the intro strings. This functions as a
 primitive form of a self-test: If you see the welcome message, compilation of
 the Forth words worked.
 
 
-=== Input 
+=== Input
 
 Tali Forth follows the ANS Forth input model with `refill` instead of older
 forms. There are four possible input sources:
@@ -225,7 +225,7 @@ The initial commands after reboot flow into each other: `cold` to `abort` to
 four input sources (see above) is active:
 
 [horizontal]
-Keyboard entry:: 
+Keyboard entry::
 	This is the default. Get line of input via `accept` and return `true`
 	even if the input string was empty.
 `evaluate` string:: Return a `false` flag
@@ -247,7 +247,7 @@ buffer.
 The word `evaluate`is used to execute commands that are in a string. A simple example:
 
 ----
-s" 1 2 + ." evaluate 
+s" 1 2 + ." evaluate
 ----
 
 Tali Forth uses `evaluate` to load high-level Forth words from the file
@@ -262,7 +262,7 @@ startup.
 The tandem of words `create` and `does>` is the most complex, but also most
 powerful part of Forth. Understanding how it works in Tali Forth is important
 if you want to be able to modify the code. In this text, we walk through the
-generation process for a subroutine threaded code (STC) such as Tali Forth. 
+generation process for a subroutine threaded code (STC) such as Tali Forth.
 
 NOTE: For a more general explanation, see Brad Rodriguez' series of articles at
 http://www.bradrodriguez.com/papers/moving3.htm There is a discussion of this
@@ -272,7 +272,7 @@ We start with the following standard example, a high-level Forth version of the
 word `constant`.
 
 ----
-: constant  ( "name" -- )  create , does> @ ; 
+: constant  ( "name" -- )  create , does> @ ;
 ----
 
 We examine this in three phases or "sequences", following Rodriguez (based on
@@ -327,11 +327,11 @@ This pushes the `rts` of the calling routine -- call it "main" -- to the
 65c02's stack (the Return Stack, as Forth calls it), which now looks like this:
 
 ----
-        (1) rts                 ; to main routine 
+        (1) rts                 ; to main routine
 ----
 
 Without going into detail, the first two subroutine jumps of `constant` give us
-this word: 
+this word:
 
 ----
         (Header "LIFE")
@@ -340,16 +340,16 @@ this word:
 ----
 
 Next, we `jsr` to `(does>)`. The address that this pushes on the Return Stack
-is the instruction of `constant` we had labeled `a`. 
+is the instruction of `constant` we had labeled `a`.
 
 ----
-        (2) rts to CONSTANT ("a") 
-        (1) rts to main routine 
+        (2) rts to CONSTANT ("a")
+        (1) rts to main routine
 ----
 
 Now the tricks start. `(does>)` takes this address off the stack and uses it to
 replace the `dovar jsr` target in the CFA of our freshly created `life` word.
-We now have this: 
+We now have this:
 
 ----
         (Header "LIFE")
@@ -360,7 +360,7 @@ We now have this:
 Note we added a label `c`. Now, when `(does>)` reaches its own `rts`, it finds
 the `rts` to the main routine on its stack. This is a Good Thing(TM), because it
 aborts the execution of the rest of `constant`, and we don't want to do
-`dodoes` or `fetch` now. We're back at the main routine. 
+`dodoes` or `fetch` now. We're back at the main routine.
 
 
 ==== Sequence 3: Executing `life`
@@ -448,7 +448,7 @@ can be annoying, because it requires a sequence like:
         inc z
         bne +
         inc z+1
-*       
+*
         (...)
 ----
 
@@ -478,7 +478,7 @@ it's address in the second step. Until then, a dummy value is compiled after
 NOTE: This section and the next one are based on a discussion at
 http://forum.6502.org/viewtopic.php?f=9\&t=3176 see there for more details.
 Another take on this subject that handles things a bit differently is at
-http://blogs.msdn.com/b/ashleyf/archive/2011/02/06/loopty-do-i-loop.aspx 
+http://blogs.msdn.com/b/ashleyf/archive/2011/02/06/loopty-do-i-loop.aspx
 
 In Forth, this can be realized by
 
@@ -508,71 +508,96 @@ except that this value now comes from `else`, not `if`.
 ==== Loops
 
 Loops are more complicated, because we have `do`, `?do`, `loop`, `+loop`,
-`unloop`, and `leave` to take care of. These can call up to three addresses: One
+`unloop`, and `leave` to think about. These can involve up to three branches: One
 for the normal looping action (`loop` and `+loop`), one to skip over the loop at
 the beginning (`?do`) and one to skip out of the loop (`leave`).
 
-Based on a suggestion by Garth Wilson, we begin each loop in run-time by saving
-the address after the whole loop construct to the Return Stack. That way,
-`leave` and `?do` know where to jump to when called, and we don't interfere with
-any `if`-`then` structures. On top of that address, we place the limit and start
-values for the loop.
+Like many other forth implementations,
+Tali Forth 2 originally used the return stack to manage loop control,
+including the loop exit address and the loop step and limit values.
+However this required extensive stack juggling which slowed loop performance.
+After https://github.com/SamCoVT/TaliForth2/issues/53[investigating several alternatives]
+we switched to a separate loop control stack.
+Each loop uses a four byte (double word) loop control block (LCB) to store
+the current loop limits.
+All branch addresses including the loop exit are now directly compiled into code
+rather than stored on the stack.
 
-The key to staying sane while designing these constructs is to first make
-a list of what we want to happen at compile time and what at run time. Let's
-start with a simple `do`-`loop`.
+NOTE: In order to simplify the loop completion check after each iteration,
+we don't store the actual loop index and limit values in the LCB.
+Instead we calculate a fudge factor (sometimes referred to as 'fufa' in the code)
+that makes every loop appear to finish at exactly $8000, and use this to adjust the loop index.
+This lets us use a simple 16 bit overflow test to see if we're done.
+One side effect is that the `i` and `j` words get a little more complicated.
+For more details see http://forum.6502.org/viewtopic.php?f=9&t=2026
+and the `do_runtime` implementation.
 
-===== `do` at compile-time:
+Remembering state across nested loops means a stack of LCBs.
+Whereas the return stack grows downward from $1ff, our current loop control stack
+grows upward from $100.
+The zero-page `loopctrl` byte forms our loop stack pointer,
+limiting us to at most 64 nested loops if the return stack is empty.
+We also cache the least significant byte of the active loop index
+in the zero-page `loopidx0` which often lets us avoid indexed access to the LCB.
 
-* Remember current address (in other words, `here`) on the Return Stack (!) so
-  we can later compile the code for the post-loop address to the Return Stack
+The key to staying sane while designing these constructs is to make
+a list of what we should happen at compile time and what at run time.
+Let's start with a high-level view of what happens at run time to manage a `do` loop:
 
-* Compile some dummy values to reserve the space for said code
+- `do` adds four to the loop control stack pointer in `loopctrl` to assign a new LCB.
+  It writes the initial loop index and offset to the LCB and
+  updates the cached `loopidx0`.  `?do` is very similar.
 
-* Compile the run-time code; we'll call that fragment (`do`)
+- most of the time `loop` just increments the cached `loopidx0`.  It only touches
+  the LCB when the low byte overflows.
 
-* Push the current address (the new `here`) to the Data Stack so `loop` knows
-  where the loop contents begin
+- `+loop` updates `loopidx0` and (if needed) the high byte in the LCB.
+  It only touches the LCB when we have a step size larger than 255 or an overflow
+  on the low index byte.
 
-===== `do` at run-time:
+- `unloop` subtracts four from `loopctrl` to drop the current LCB.
+  It caches the low byte of the now current loop index in `loopidx0`
+  so that any enclosing loop sees the correct value.
 
-* Take limit and start off Data Stack and push them to the Return Stack
+- the `i` and `j` words use 16-bit math to calculate the actual loop index from the LCB
+  offset and fudge factor values.  Although it's certainly not portable forth,
+  our LCB approach means that `i` and `j` can be safely referenced by words called within a loop.
+  (This isn't the case in Forths that use the return stack for loop control.)
 
-Since `loop` is just a special case of `+loop` with an index of one, we can get
-away with considering them at the same time.
+- `leave` simply jumps out of the loop to an address hard-coded at compile time.
 
+And what about compile time?
 
-===== `loop` at compile time:
+- `do` emits the runtime code to set up the loop from the limit values.
+  The `?do` variant includes a conditional jump that skips the loop entirely, dropping the limits.
+  Since we won't know the exit address until we're finished compiling
+  the loop body, we emit placeholder bytes and save the placeholder's address on the stack
+  so `loop` can update it later.
+  We also stash the current `loopleave` variable so that we
+  can handle `leave` in nested loops (see below).
 
-* Compile the run-time part `(+loop)`
+- `loop` and `+loop` generate the runtime code that increment the loop offset
+  with an efficient check for whether we've crossed the completion limit.
+  Now that we've finished compiling the loop contents we can
+  also patch up the exit addresses needed for `?do` and `leave`.
 
-* Consume the address that is on top of the Data Stack as the jump target for
-  normal looping and compile it
+- `unloop`, `i`, and `j` don't have any compile-time behavior.
 
-* Compile `unloop` for when we're done with the loop, getting rid of the
-  limit/start and post-loop addresses on the Return Stack
+- `leave` also needs to jump to the end of the loop but we don't yet
+  know where that is.
+  Because `leave` can appear multiple times in a loop,
+  we need some trickery to keep a list of all `leave` placeholders to update.
+  The address of the first `leave` placholder is stored in a variable called `loopleave`.
+  Then the next `leave` placeholder address is stored *as* the placeholde value of the previous `leave`!
+  This can be repeated indefinitely and forms a linked list.
+  Once we've finished compiling `loop` can walk the list and write the exit address into each placeholder.
+  (To safely handle nested loops we also need to push and pop `loopleave` whenever we start or finish
+  compiling a new loop.)
 
-* Get the address on the top of the Return Stack which points to
-  the dummy code compiled by `do`
-
-* At that address, compile the code that pushes the address after the list
-  construct to the Return Stack at run-time
-
-
-===== `loop` at run-time (which is `(+loop)`)
-
-* Add loop step to count
-
-* Loop again if we haven't crossed the limit, otherwise continue after loop
-
-
-At one glance, we can see that the complicated stuff happens at compile-time.
+It's clear that all the complicated stuff happens at compile-time.
 This is good, because we only have to do that once for each loop.
-
-In Tali Forth, these routines are coded in assembler. With this setup, `unloop`
-becomes simple (six `pla` instructions -- four for the limit/count of `do`, two
-for the address pushed to the stack just before it) and `leave` even simpler
-(four `pla` instructions for the address).
+In Tali Forth all of loop control is coded in assembler.
+You can see all of the gory details of the loop word implementations in `words/core.asm`.
 
 === Native Compiling
 
@@ -603,7 +628,7 @@ the actual code. Take for instance `drop`, which in its naive form is simply
 
 for two bytes and four cycles. If we jump to this word as is assumed with pure
 subroutine threaded Forth, we add four bytes and 12 cycles -- double the space
-and three times the time required by the actual working code. 
+and three times the time required by the actual working code.
 
 (In practice, it's even worse, because `drop` checks for underflow. The actual
 assembler code is
@@ -631,9 +656,9 @@ when compiled with an `nc-limit` of 0 and check the actual code with `see`
 
 ----
 see aaa
-nt: 800  xt: 80B 
-flags (CO AN IM NN UF HC): 0 0 0 1 0 1 
-size (decimal): 6 
+nt: 800  xt: 80B
+flags (CO AN IM NN UF HC): 0 0 0 1 0 1
+size (decimal): 6
 
 080B  20 A2 A7 20 2E 8D   .. ..
 
@@ -650,13 +675,13 @@ and define a new word with the same instructions with
 : bbb 0 drop ;
 ----
 
-we get different code: 
+we get different code:
 
 ----
-see bbb 
-nt: 812  xt: 81D 
-flags (CO AN IM NN UF HC): 0 0 0 1 0 1 
-size (decimal): 11 
+see bbb
+nt: 812  xt: 81D
+flags (CO AN IM NN UF HC): 0 0 0 1 0 1
+size (decimal): 11
 
 081D  CA CA 74 00 74 01 20 29  D8 E8 E8  ..t.t. ) ...
 
@@ -701,7 +726,7 @@ words are flagged Never-Native by default because a word needs to meet some
 special criteria to be safe to native compile.  In particular, the word cannot
 have any control structures (if, loop, begin, again, etc) and, if written in
 assembly, cannot have any JMP instructions in it (except for error handling,
-such as underflow detection).  
+such as underflow detection).
 
 If you are certain your new word meets these criteria, then you can enable
 native compilation of this word into other words by invoking the word

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -3825,105 +3825,129 @@ compiles its address where the value on the top of the Data Stack told it to&#82
 <h4 id="_loops">Loops</h4>
 <div class="paragraph">
 <p>Loops are more complicated, because we have <code>do</code>, <code>?do</code>, <code>loop</code>, <code>+loop</code>,
-<code>unloop</code>, and <code>leave</code> to take care of. These can call up to three addresses: One
+<code>unloop</code>, and <code>leave</code> to think about. These can involve up to three branches: One
 for the normal looping action (<code>loop</code> and <code>+loop</code>), one to skip over the loop at
 the beginning (<code>?do</code>) and one to skip out of the loop (<code>leave</code>).</p>
 </div>
 <div class="paragraph">
-<p>Based on a suggestion by Garth Wilson, we begin each loop in run-time by saving
-the address after the whole loop construct to the Return Stack. That way,
-<code>leave</code> and <code>?do</code> know where to jump to when called, and we don&#8217;t interfere with
-any <code>if</code>-<code>then</code> structures. On top of that address, we place the limit and start
-values for the loop.</p>
+<p>Like many other forth implementations,
+Tali Forth 2 originally used the return stack to manage loop control,
+including the loop exit address and the loop step and limit values.
+However this required extensive stack juggling which slowed loop performance.
+After <a href="https://github.com/SamCoVT/TaliForth2/issues/53">investigating several alternatives</a>
+we switched to a separate loop control stack.
+Each loop uses a four byte (double word) loop control block (LCB) to store
+the current loop limits.
+All branch addresses including the loop exit are now directly compiled into code
+rather than stored on the stack.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+In order to simplify the loop completion check after each iteration,
+we don&#8217;t store the actual loop index and limit values in the LCB.
+Instead we calculate a fudge factor (sometimes referred to as 'fufa' in the code)
+that makes every loop appear to finish at exactly $8000, and use this to adjust the loop index.
+This lets us use a simple 16 bit overflow test to see if we&#8217;re done.
+One side effect is that the <code>i</code> and <code>j</code> words get a little more complicated.
+For more details see <a href="http://forum.6502.org/viewtopic.php?f=9&amp;t=2026" class="bare">http://forum.6502.org/viewtopic.php?f=9&amp;t=2026</a>
+and the <code>do_runtime</code> implementation.
+</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
-<p>The key to staying sane while designing these constructs is to first make
-a list of what we want to happen at compile time and what at run time. Let&#8217;s
-start with a simple <code>do</code>-<code>loop</code>.</p>
-</div>
-<div class="sect4">
-<h5 id="_do_at_compile_time"><code>do</code> at compile-time:</h5>
-<div class="ulist">
-<ul>
-<li>
-<p>Remember current address (in other words, <code>here</code>) on the Return Stack (!) so
-we can later compile the code for the post-loop address to the Return Stack</p>
-</li>
-<li>
-<p>Compile some dummy values to reserve the space for said code</p>
-</li>
-<li>
-<p>Compile the run-time code; we&#8217;ll call that fragment (<code>do</code>)</p>
-</li>
-<li>
-<p>Push the current address (the new <code>here</code>) to the Data Stack so <code>loop</code> knows
-where the loop contents begin</p>
-</li>
-</ul>
-</div>
-</div>
-<div class="sect4">
-<h5 id="_do_at_run_time"><code>do</code> at run-time:</h5>
-<div class="ulist">
-<ul>
-<li>
-<p>Take limit and start off Data Stack and push them to the Return Stack</p>
-</li>
-</ul>
+<p>Remembering state across nested loops means a stack of LCBs.
+Whereas the return stack grows downward from $1ff, our current loop control stack
+grows upward from $100.
+The zero-page <code>loopctrl</code> byte forms our loop stack pointer,
+limiting us to at most 64 nested loops if the return stack is empty.
+We also cache the least significant byte of the active loop index
+in the zero-page <code>loopidx0</code> which often lets us avoid indexed access to the LCB.</p>
 </div>
 <div class="paragraph">
-<p>Since <code>loop</code> is just a special case of <code>+loop</code> with an index of one, we can get
-away with considering them at the same time.</p>
+<p>The key to staying sane while designing these constructs is to make
+a list of what we should happen at compile time and what at run time.
+Let&#8217;s start with a high-level view of what happens at run time to manage a <code>do</code> loop:</p>
 </div>
-</div>
-<div class="sect4">
-<h5 id="_loop_at_compile_time"><code>loop</code> at compile time:</h5>
 <div class="ulist">
 <ul>
 <li>
-<p>Compile the run-time part <code>(+loop)</code></p>
+<p><code>do</code> adds four to the loop control stack pointer in <code>loopctrl</code> to assign a new LCB.
+It writes the initial loop index and offset to the LCB and
+updates the cached <code>loopidx0</code>.  <code>?do</code> is very similar.</p>
 </li>
 <li>
-<p>Consume the address that is on top of the Data Stack as the jump target for
-normal looping and compile it</p>
+<p>most of the time <code>loop</code> just increments the cached <code>loopidx0</code>.  It only touches
+the LCB when the low byte overflows.</p>
 </li>
 <li>
-<p>Compile <code>unloop</code> for when we&#8217;re done with the loop, getting rid of the
-limit/start and post-loop addresses on the Return Stack</p>
+<p><code>+loop</code> updates <code>loopidx0</code> and (if needed) the high byte in the LCB.
+It only touches the LCB when we have a step size larger than 255 or an overflow
+on the low index byte.</p>
 </li>
 <li>
-<p>Get the address on the top of the Return Stack which points to
-the dummy code compiled by <code>do</code></p>
+<p><code>unloop</code> subtracts four from <code>loopctrl</code> to drop the current LCB.
+It caches the low byte of the now current loop index in <code>loopidx0</code>
+so that any enclosing loop sees the correct value.</p>
 </li>
 <li>
-<p>At that address, compile the code that pushes the address after the list
-construct to the Return Stack at run-time</p>
-</li>
-</ul>
-</div>
-</div>
-<div class="sect4">
-<h5 id="_loop_at_run_time_which_is_loop"><code>loop</code> at run-time (which is <code>(+loop)</code>)</h5>
-<div class="ulist">
-<ul>
-<li>
-<p>Add loop step to count</p>
+<p>the <code>i</code> and <code>j</code> words use 16-bit math to calculate the actual loop index from the LCB
+offset and fudge factor values.  Although it&#8217;s certainly not portable forth,
+our LCB approach means that <code>i</code> and <code>j</code> can be safely referenced by words called within a loop.
+(This isn&#8217;t the case in Forths that use the return stack for loop control.)</p>
 </li>
 <li>
-<p>Loop again if we haven&#8217;t crossed the limit, otherwise continue after loop</p>
+<p><code>leave</code> simply jumps out of the loop to an address hard-coded at compile time.</p>
 </li>
 </ul>
 </div>
 <div class="paragraph">
-<p>At one glance, we can see that the complicated stuff happens at compile-time.
-This is good, because we only have to do that once for each loop.</p>
+<p>And what about compile time?</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>do</code> emits the runtime code to set up the loop from the limit values.
+The <code>?do</code> variant includes a conditional jump that skips the loop entirely, dropping the limits.
+Since we won&#8217;t know the exit address until we&#8217;re finished compiling
+the loop body, we emit placeholder bytes and save the placeholder&#8217;s address on the stack
+so <code>loop</code> can update it later.
+We also stash the current <code>loopleave</code> variable so that we
+can handle <code>leave</code> in nested loops (see below).</p>
+</li>
+<li>
+<p><code>loop</code> and <code>+loop</code> generate the runtime code that increment the loop offset
+with an efficient check for whether we&#8217;ve crossed the completion limit.
+Now that we&#8217;ve finished compiling the loop contents we can
+also patch up the exit addresses needed for <code>?do</code> and <code>leave</code>.</p>
+</li>
+<li>
+<p><code>unloop</code>, <code>i</code>, and <code>j</code> don&#8217;t have any compile-time behavior.</p>
+</li>
+<li>
+<p><code>leave</code> also needs to jump to the end of the loop but we don&#8217;t yet
+know where that is.
+Because <code>leave</code> can appear multiple times in a loop,
+we need some trickery to keep a list of all <code>leave</code> placeholders to update.
+The address of the first <code>leave</code> placholder is stored in a variable called <code>loopleave</code>.
+Then the next <code>leave</code> placeholder address is stored <strong>as</strong> the placeholde value of the previous <code>leave</code>!
+This can be repeated indefinitely and forms a linked list.
+Once we&#8217;ve finished compiling <code>loop</code> can walk the list and write the exit address into each placeholder.
+(To safely handle nested loops we also need to push and pop <code>loopleave</code> whenever we start or finish
+compiling a new loop.)</p>
+</li>
+</ul>
 </div>
 <div class="paragraph">
-<p>In Tali Forth, these routines are coded in assembler. With this setup, <code>unloop</code>
-becomes simple (six <code>pla</code> instructions&#8201;&#8212;&#8201;four for the limit/count of <code>do</code>, two
-for the address pushed to the stack just before it) and <code>leave</code> even simpler
-(four <code>pla</code> instructions for the address).</p>
-</div>
+<p>It&#8217;s clear that all the complicated stuff happens at compile-time.
+This is good, because we only have to do that once for each loop.
+In Tali Forth all of loop control is coded in assembler.
+You can see all of the gory details of the loop word implementations in <code>words/core.asm</code>.</p>
 </div>
 </div>
 </div>
@@ -4295,7 +4319,9 @@ in their right mind would want to program in this godforsaken language! <a href=
 <h3 id="_required_tools">Required Tools</h3>
 <div class="paragraph">
 <p>To run Tali Forth 2 in a simulator, you will need <code>python3</code> and <code>py65</code> installed to be
-able to run <code>py65mon</code>.</p>
+able to run <code>py65mon</code>.
+Tali Forth 2 also ships with the bare-bones <code>c65</code> simulator.
+This is much faster than <code>py65mon</code> but lacks the debugging and monitor capabilities.</p>
 </div>
 <div class="paragraph">
 <p>To assemble Tali Forth 2, you will need <code>64tass</code> (version 1.56.2625 or later) and <code>make</code>.</p>
@@ -4470,6 +4496,12 @@ this requires a branch to an internal label <code>_done</code> right before <cod
 <li>
 <p>Because of the way native compiling works, the trick of combining
 <code>jsr</code>-<code>rts</code> pairs to a single <code>jmp</code> instruction (usually) doesn&#8217;t work.</p>
+</li>
+<li>
+<p>In broad terms Tali Forth 2 should be easy to understand and use.
+When adding new code you should prefer simplicity over complexity,
+particularly for compile-time words.
+Speed is a virtue for core run-time words and reducing code size is always a virtue.</p>
 </li>
 </ul>
 </div>
@@ -5242,7 +5274,7 @@ complete, you will have 4 blocks (numbered 0-3) available to play with.</p>
 <p>If you want to use persistent storage instead, create a writable file
 and start the simulator as shown.  The <code>block-c65-init</code> word takes no
 arguments and returns true if block storage is available.
-You can read/write up to 65536 1K blocks in your file (64Mb of storage).</p>
+You can read/write up to 65536 1K blocks in your file providing 64Mb of storage.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -8215,7 +8247,7 @@ DOES&gt;'s internal workings. This uses tmp1 and tmp2.</p>
 </tr>
 <tr>
 <td class="hdlist1">
-<code>ed</code>
+<code>ed:</code>
 </td>
 <td class="hdlist2">
 <p><em>Tali Forth</em> (&#8201;&#8212;&#8201;u ) "Line-based editor"
@@ -8529,7 +8561,7 @@ output string on
 <code>i</code>
 </td>
 <td class="hdlist2">
-<p><em>ANS core</em> (&#8201;&#8212;&#8201;n )(R: n&#8201;&#8212;&#8201;n)  "Copy loop counter to stack"
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;n )  "Copy loop counter to stack"
 <a href="https://forth-standard.org/standard/core/I" class="bare">https://forth-standard.org/standard/core/I</a>
 See definitions.asm and the Control Flow section of the manual.</p>
 </td>
@@ -8608,7 +8640,7 @@ INT&gt;NAME to match NAME&gt;INT</p>
 <code>j</code>
 </td>
 <td class="hdlist2">
-<p><em>ANS core</em> (&#8201;&#8212;&#8201;n ) (R: n&#8201;&#8212;&#8201;n ) "Copy second loop counter to stack"
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;n ) "Copy second loop counter to stack"
 <a href="https://forth-standard.org/standard/core/J" class="bare">https://forth-standard.org/standard/core/J</a>
 Copy second loop counter from Return Stack to stack. Note we use
 a fudge factor for loop control; see the Control Flow section of
@@ -8628,7 +8660,8 @@ the manual for more details.</p>
 <code>l</code>
 </td>
 <td class="hdlist2">
-<p><em>Tali Editor</em> (&#8201;&#8212;&#8201;) "List the current screen"</p>
+<p><em>Tali Editor</em> (&#8201;&#8212;&#8201;) "List the current screen"
+note "l" is used by LIST in the block words</p>
 </td>
 </tr>
 <tr>
@@ -9478,7 +9511,7 @@ Forth code, modified by Garth Wilson, see
 <code>unloop</code>
 </td>
 <td class="hdlist2">
-<p><em>ANS core</em> (&#8201;&#8212;&#8201;)(R: n1 n2 n3 ---) "Drop loop control from Return stack"
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;)(R: n1 n2 n3 ---) "Drop current loop control block"
 <a href="https://forth-standard.org/standard/core/UNLOOP" class="bare">https://forth-standard.org/standard/core/UNLOOP</a></p>
 </td>
 </tr>

--- a/tools/generate_glossary.py
+++ b/tools/generate_glossary.py
@@ -9,14 +9,16 @@
 comments in native_words.asm.
 """
 
+from glob import glob
 import sys
 import re
 from enum import Enum
 
-SOURCE = 'native_words.asm'
+
+SOURCES = 'words/*.asm'
 MARKER = '; ## '
 
-# This runs as a state machine to capture the wordname, short 
+# This runs as a state machine to capture the wordname, short
 # description, and the first comment block for each word.
 class State(Enum):
     IDLE = 0
@@ -31,10 +33,12 @@ second_line_re = re.compile(r"; ## \"(\S+)\"\s+\w+\s+(.*)$")
 
 def main():
 
-    with open(SOURCE) as f:
-        raw_list = f.readlines()
+    raw_list = []
+    for name in glob(SOURCES):
+        with open(name) as f:
+            raw_list += f.readlines()
 
-    # Set up dictionaries to store the data using the word name as 
+    # Set up dictionaries to store the data using the word name as
     # the key.
     short_descr = {}
     source      = {}
@@ -78,7 +82,7 @@ def main():
                 print("Error determining short description on line:")
                 print(line)
         elif current_state == State.COMMENT:
-            # Save the multi-line comments up until the first 
+            # Save the multi-line comments up until the first
             # non-comment line or blank (only ; on line) comment line.
             line = line.strip()
             if line.startswith(';'):

--- a/words/core.asm
+++ b/words/core.asm
@@ -1834,9 +1834,7 @@ xt_question_do:
         ;
         ; Compile-time part of DO. Could be realized in Forth as
         ;       : DO POSTPONE (DO) HERE ; IMMEDIATE COMPILE-ONLY
-        ; but we do it in assembler for speed. To work with LEAVE, we compile
-        ; a routine that pushes the end address to the Return Stack at run
-        ; time. This is based on a suggestion by Garth Wilson, see
+        ; but we do it in assembler for speed. See
         ; the Control Flow section of the manual for details.
         ;
         ; This is never native compile. Don't check for a stack underflow
@@ -1886,7 +1884,7 @@ _compile_do:
                 ; will link backward to any prior LEAVE.
                 ; To handle nested loops we stack the current value
                 ; of loopleave here and restore it in xt_loop
-                ; after we write any chained jmps for the current loop
+                ; after we write any chained jumps for the current loop
 
                 ; save current loopleave in case we're nested
                 dex
@@ -3168,7 +3166,7 @@ z_hold:         rts
 
 
 
-; ## I ( -- n )(R: n -- n)  "Copy loop counter to stack"
+; ## I ( -- n )  "Copy loop counter to stack"
 ; ## "i"  auto  ANS core
         ; """https://forth-standard.org/standard/core/I
         ; See definitions.asm and the Control Flow section of the manual.
@@ -3352,7 +3350,7 @@ z_is:           rts
 
 
 
-; ## J ( -- n ) (R: n -- n ) "Copy second loop counter to stack"
+; ## J ( -- n ) "Copy second loop counter to stack"
 ; ## "j"  auto  ANS core
         ; """https://forth-standard.org/standard/core/J
         ; Copy second loop counter from Return Stack to stack. Note we use
@@ -7302,7 +7300,7 @@ z_um_star:      rts
 
 
 
-; ## UNLOOP ( -- )(R: n1 n2 n3 ---) "Drop loop control from Return stack"
+; ## UNLOOP ( -- )(R: n1 n2 n3 ---) "Drop current loop control block"
 ; ## "unloop"  auto  ANS core
         ; """https://forth-standard.org/standard/core/UNLOOP"""
 xt_unloop:

--- a/words/core.asm
+++ b/words/core.asm
@@ -1820,7 +1820,7 @@ z_depth:        rts
 
 
 
-; ## QUESTION_DO ( limit start -- )(R: -- limit start) "Conditional loop start"
+; ## QUESTION_DO ( limit start -- ) "Conditional loop start"
 ; ## "?do"  auto  ANS core ext
         ; """https://forth-standard.org/standard/core/qDO"""
 xt_question_do:
@@ -1828,7 +1828,7 @@ xt_question_do:
                 ldy #1                  ; 1 is ?DO, jump to common code
                 bra do_common           ; skip flag for DO
 
-; ## DO ( limit start -- )(R: -- limit start)  "Start a loop"
+; ## DO ( limit start -- )  "Start a loop"
 ; ## "do"  auto  ANS core
         ; """https://forth-standard.org/standard/core/DO
         ;
@@ -1958,7 +1958,8 @@ do_runtime:
 
                 ; data stack has ( limit index -- )
                 ;
-                ; We're going to calculate adjusted loop bounds:
+                ; We're going to calculate adjusted loop bounds
+                ; and store the values in the current LCB:
                 ;
                 ;   loopfufa = $8000 - limit
                 ;   loopindex = loopfufa + index
@@ -1979,8 +1980,6 @@ do_runtime:
                 sbc 3,x             ; MSB of limit
                 sta loopfufa+1,y
 
-                ; ( $8000-limit index --  R: $8000-limit )
-
                 ; Second step: index is FUFA plus original index
                 clc
                 lda 0,x             ; LSB of original index
@@ -1994,8 +1993,6 @@ do_runtime:
                 inx
                 inx
                 inx
-
-                ; ( R: $8000-limit  $8000-limit+index )
 
                 rts
 
@@ -7300,7 +7297,7 @@ z_um_star:      rts
 
 
 
-; ## UNLOOP ( -- )(R: n1 n2 n3 ---) "Drop current loop control block"
+; ## UNLOOP ( -- ) "Drop current loop control block"
 ; ## "unloop"  auto  ANS core
         ; """https://forth-standard.org/standard/core/UNLOOP"""
 xt_unloop:


### PR DESCRIPTION
Fixes #53

Updates a few comments in the code and fixes the glossary which I broke with the native_words split.

No functional change.
