### PR TITLE
inline literals and two-literals, faster non-native two-literals

### DIFF
--- a/tests/results.txt
+++ b/tests/results.txt
@@ -870,11 +870,11 @@ create result  ok
 92 c, ( \\ )  ok
   ok
 T{ result here result - 2dup dump ( Make a string out of result ) 
-0F81  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-0F91   ok
+0F8A  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+0F9A   ok
    s\" \a\b\e\f\l\m\n\q\r\t\v\z\"\x41\\" 2dup dump compare -> 0 }T 
-0F94  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-0FA4   ok
+0F9D  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+0FAD   ok
 hex  ok
   ok
 \ ------------------------------------------------------------------------  ok
@@ -3317,9 +3317,9 @@ drop \ accept test complete  ok
              ' \             cycle_test            CYCLES:     41 ok
              ' base          cycle_test drop       CYCLES:     26 ok
 : beginuntil 100 begin 1- ?dup 0= until ;  ok
-             ' beginuntil    cycle_test            CYCLES:  13063 ok
+             ' beginuntil    cycle_test            CYCLES:  13004 ok
 : beginwhile 100 begin 1- ?dup while repeat ;  ok
-             ' beginwhile    cycle_test            CYCLES:  10463 ok
+             ' beginwhile    cycle_test            CYCLES:  10405 ok
              ' bell          cycle_test            CYCLES:     36 ok
              ' bl            cycle_test drop       CYCLES:     26 ok
 here 5       ' blank         cycle_test            CYCLES:    327 ok
@@ -3333,17 +3333,17 @@ here 5       ' blank         cycle_test            CYCLES:    327 ok
 5 here       ' c!            cycle_test            CYCLES:     46 ok
 5            ' cell+         cycle_test drop       CYCLES:     46 ok
 5            ' cells         cycle_test drop       CYCLES:     40 ok
-             ' char          cycle_test w drop     CYCLES:    449 ok
+             ' char          cycle_test w drop     CYCLES:    451 ok
 5            ' char+         cycle_test drop       CYCLES:     37 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  15519 ok
+             ' :             cycle_test wrd ;      CYCLES:  15816 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:     66 ok
-' aword      ' compile,      cycle_test            CYCLES:    921 ok
+' aword      ' compile,      cycle_test            CYCLES:    917 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
-5            ' constant      cycle_test mycnst     CYCLES:  15990 ok
+5            ' constant      cycle_test mycnst     CYCLES:  16287 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3358,21 +3358,21 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 \ skipping     disasm  ok
 5.           ' dnegate       cycle_test 2drop      CYCLES:     72 ok
 : do?word1 5 5 ?do loop ;  ok
-             ' do?word1      cycle_test            CYCLES:    327 ok
+             ' do?word1      cycle_test            CYCLES:    211 ok
 : do?word2 100 0 ?do i drop loop ;  ok
-             ' do?word2      cycle_test            CYCLES:   6658 ok
+             ' do?word2      cycle_test            CYCLES:   6600 ok
 : doword 100 0 do loop ;  ok
-             ' doword        cycle_test            CYCLES:   1310 ok
+             ' doword        cycle_test            CYCLES:   1252 ok
 : dowordi 100 0 do i drop loop ;  ok
-             ' dowordi       cycle_test            CYCLES:   6511 ok
+             ' dowordi       cycle_test            CYCLES:   6452 ok
 : dodoword 100 0 do 10 0 do loop loop ;  ok
-             ' dodoword      cycle_test            CYCLES:  33410 ok
+             ' dodoword      cycle_test            CYCLES:  27552 ok
 : dodowordij 100 0 do 10 0 do i drop j drop loop loop ;  ok
-             ' dodowordij    cycle_test            CYCLES: 156410 ok
+             ' dodowordij    cycle_test            CYCLES: 151552 ok
 : dodowordbigi 10 0 do 1024 0 do i drop loop loop ;  ok
-             ' dodowordbigi  cycle_test            CYCLES: 648060 ok
+             ' dodowordbigi  cycle_test            CYCLES: 647442 ok
 : doword+loop 100 0 do 5 +loop ;  ok
-             ' doword+loop   cycle_test            CYCLES:   2213 ok
+             ' doword+loop   cycle_test            CYCLES:    995 ok
 \ skipping     does  ok
 \ skipping     .  ok
 \ skipping     ."  ok
@@ -3384,7 +3384,7 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
 5 5          ' =             cycle_test drop       CYCLES:     66 ok
 here 5       ' erase         cycle_test            CYCLES:    321 ok
 here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17258 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17561 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3392,19 +3392,19 @@ here         ' @             cycle_test drop       CYCLES:     59 ok
 \ making counted string for find  ok
 here 5 c, char a c, char w c, char o c,  ok
 char r c, char d c,  ok
-             ' find          cycle_test 2drop      CYCLES:   1280 ok
-s" aword"    ' find-name     cycle_test drop       CYCLES:    946 ok
-5. 5         ' fm/mod        cycle_test 2drop      CYCLES:   1316 ok
+             ' find          cycle_test 2drop      CYCLES:   1290 ok
+s" aword"    ' find-name     cycle_test drop       CYCLES:    956 ok
+5. 5         ' fm/mod        cycle_test 2drop      CYCLES:   1314 ok
 5 5          ' >             cycle_test drop       CYCLES:     81 ok
              ' here          cycle_test drop       CYCLES:     30 ok
              ' hex           cycle_test decimal    CYCLES:     14 ok
 \ skipping     hold  ok
 \ skipping     i  ( exercised by doxxx above )  ok
 : ifloop 0 100 0 do i 2 and if 1 else -1 then + loop drop ;  ok
-             ' ifloop        cycle_test            CYCLES:  22042 ok
+             ' ifloop        cycle_test            CYCLES:  19184 ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   2351 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   2311 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
@@ -3419,18 +3419,18 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:    946 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    652 ok
-             ' marker        cycle_test marka      CYCLES:  18028 ok
-             ' marka         cycle_test            CYCLES:    883 ok
+             ' marker        cycle_test marka      CYCLES:  18336 ok
+             ' marka         cycle_test            CYCLES:    848 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
 5 5          ' -             cycle_test drop       CYCLES:     58 ok
 s" txt   "   ' -trailing     cycle_test 2drop      CYCLES:    224 ok
 here s" a"   ' move          cycle_test            CYCLES:    148 ok
-' + int>name ' name>int      cycle_test drop       CYCLES:     72 ok
-' + int>name ' name>string   cycle_test 2drop      CYCLES:     66 ok
+' + int>name ' name>int      cycle_test drop       CYCLES:     71 ok
+' + int>name ' name>string   cycle_test 2drop      CYCLES:     61 ok
              ' nc-limit      cycle_test drop       CYCLES:     40 ok
 5            ' negate        cycle_test drop       CYCLES:     50 ok
-: dword ;    ' never-native  cycle_test            CYCLES:     74 ok
+: dword ;    ' never-native  cycle_test            CYCLES:     75 ok
 5 5          ' nip           cycle_test drop       CYCLES:     48 ok
 \ various nops with x/y bytes/cyles with skipped dea (3A) bytes  ok
 \ EA: 1/2, 22: 2/2, 03: 1/1, FC: 3/4, 5C: 3/8 with skipped dea bytes  ok
@@ -3453,13 +3453,13 @@ s" 5"        ' number        cycle_test drop       CYCLES:   1650 ok
 5 5          ' over          cycle_test 2drop drop CYCLES:     48 ok
              ' pad           cycle_test drop       CYCLES:     36 ok
 \ skipping     page  ok
-             ' parse-name    cycle_test a 2drop    CYCLES:    408 ok
+             ' parse-name    cycle_test a 2drop    CYCLES:    410 ok
 char "       ' parse         cycle_test " 2drop    CYCLES:    210 ok
 5 0          ' pick          cycle_test 2drop      CYCLES:     42 ok
 5 5          ' +             cycle_test drop       CYCLES:     58 ok
 5 here       ' +!            cycle_test            CYCLES:     86 ok
 \ skipping     postpone  ok
-myvar        ' ?             cycle_test          5 CYCLES:   3900 ok
+myvar        ' ?             cycle_test          5 CYCLES:   3898 ok
 5            ' ?dup          cycle_test 2drop      CYCLES:     58 ok
 \ skipping     r>  ok
 \ skipping     recurse  ok
@@ -3474,7 +3474,7 @@ drop \ refill  ok
 \ skipping     sign  ok
 s" abc" 1    ' /string       cycle_test 2drop      CYCLES:     84 ok
 \ skipping     sliteral  ok
-5. 5         ' sm/rem        cycle_test 2drop      CYCLES:   1402 ok
+5. 5         ' sm/rem        cycle_test 2drop      CYCLES:   1400 ok
              ' source        cycle_test 2drop      CYCLES:     48 ok
              ' source-id     cycle_test drop       CYCLES:     30 ok
              ' space         cycle_test            CYCLES:     36 ok
@@ -3483,11 +3483,11 @@ s" abc" 1    ' /string       cycle_test 2drop      CYCLES:     84 ok
              ' state         cycle_test drop       CYCLES:     28 ok
 5 here       ' !             cycle_test            CYCLES:     65 ok
 5 5          ' swap          cycle_test 2drop      CYCLES:     60 ok
-             ' '             cycle_test aword drop CYCLES:   1915 ok
+             ' '             cycle_test aword drop CYCLES:   1938 ok
 \ postponing   to ( see value )  ok
-' aword      ' >body         cycle_test drop       CYCLES:   1360 ok
+' aword      ' >body         cycle_test drop       CYCLES:   1353 ok
              ' >in           cycle_test drop       CYCLES:     28 ok
-0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2431 ok
+0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2434 ok
 \ skipping     >r  ok
              ' true          cycle_test drop       CYCLES:     26 ok
 5 5          ' tuck          cycle_test 2drop drop CYCLES:     72 ok
@@ -3503,21 +3503,21 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  16685 ok
+             ' 2variable     cycle_test eword      CYCLES:  16996 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
 s" *"        ' type          cycle_test           *CYCLES:    123 ok
-5            ' u.            cycle_test          5 CYCLES:   3619 ok
+5            ' u.            cycle_test          5 CYCLES:   3617 ok
 5 5          ' u>            cycle_test drop       CYCLES:     60 ok
 5 5          ' u<            cycle_test drop       CYCLES:     60 ok
              ' strip-underflow   cycle_test drop   CYCLES:     40 ok
-5. 5         ' um/mod        cycle_test 2drop      CYCLES:   1264 ok
+5. 5         ' um/mod        cycle_test 2drop      CYCLES:   1262 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    476 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  16902 ok
+5            ' value         cycle_test fword      CYCLES:  17214 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
-5            ' to            cycle_test fword      CYCLES:   1169 ok
-             ' variable      cycle_test gword      CYCLES:  16692 ok
+5            ' to            cycle_test fword      CYCLES:   1174 ok
+             ' variable      cycle_test gword      CYCLES:  17008 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    668 ok
 \ skipping     words  ok
@@ -3530,4 +3530,4 @@ char "       ' word          cycle_test "txt" drop CYCLES:    668 ok
 5            ' 0<            cycle_test drop       CYCLES:     47 ok
 5            ' 0<>           cycle_test drop       CYCLES:     48 ok
   ok
-$ff $f010 ! c65: PC=93af A=ff X=74 Y=01 S=f9 FLAGS=<N1 V0 B0 D0 I1 Z0 C0> ticks=147200909
+$ff $f010 ! c65: PC=93e9 A=ff X=74 Y=01 S=f9 FLAGS=<N1 V0 B0 D0 I1 Z0 C0> ticks=148929097

--- a/words/double.asm
+++ b/words/double.asm
@@ -223,17 +223,25 @@ z_two_constant: rts
 ; ## TWO_LITERAL (C: d -- ) ( -- d) "Compile a literal double word"
 ; ## "2literal"  auto  ANS double
         ; """https://forth-standard.org/standard/double/TwoLITERAL"""
-        ; Based on the Forth code
-        ; : 2LITERAL ( D -- ) SWAP POSTPONE LITERAL POSTPONE LITERAL ; IMMEDIATE
+        ; Shares code with xt_sliteral for compiling a double word
         ; """
 xt_two_literal:
                 jsr underflow_2 ; double number
 
+                lda # z_template_push_tos - template_push_tos
+                asl
+                jsr check_nc_limit
+                bcs _no_inline
+
                 jsr xt_swap
                 jsr xt_literal
-                jsr xt_literal
+                jmp xt_literal
+
+_no_inline:
+                jsr cmpl_two_literal
 
 z_two_literal:  rts
+
 
 
 ; ## TWO_VARIABLE ( "name" -- ) "Create a variable for a double word"

--- a/words/string.asm
+++ b/words/string.asm
@@ -535,78 +535,36 @@ xt_sliteral:
                 jsr underflow_2
 
                 ; We can't assume that ( addr u ) of the current string is in
-                ; a stable area (eg. already in the dictionary.) Copy the
-                ; string data into the dictionary using move.
+                ; a stable area (eg. already in the dictionary.)
+                ; We'll compile the string data into the dictionary using move
+                ; along with code that stacks the new ( addr' u )
+                ;   jmp _end
+                ; _str:
+                ;   < u data bytes >
+                ; _end: jsr sliteral_runtime
+                ;   < _str u >
 
-                ; Put a jmp over the string data with address to be filled
-                ; in later.
-                jsr cmpl_jump
+                jsr cmpl_jump_later
+                jsr xt_to_r
+                ; ( addr u  R: jmp-target )
+                jsr xt_here
+                jsr xt_swap
+                ; ( addr addr' u )
+                jsr xt_dup
+                jsr xt_allot            ; reserve u bytes for string
+                jsr xt_here
+                ; ( addr addr' u addr'+u )
+                jsr xt_r_from
+                jsr xt_store            ; point jmp past string
+                jsr xt_two_dup
+                jsr xt_two_to_r
+                ; ( addr addr' u  R: addr' u )
+                jsr xt_move             ; copy u bytes from addr -> addr'
+                jsr xt_two_r_from
+                ; Stack is now ( addr' u ) with the new string location
 
-                ; Turn the data stack from ( addr u ) into
-                ; ( here u addr here u ) so move can be called with
-                ; the remaining items on the stack ready for processing.
-                ; Reserve three extra words on the stack.
-                txa
-                sec
-                sbc #6
-                tax
-
-                ; Move addr down from TOS-4 to TOS-2
-                lda 8,x
-                sta 4,x
-                lda 9,x
-                sta 5,x
-
-                ; Copy u from TOS-3 to TOS
-                lda 6,x
-                sta 0,x
-                lda 7,x
-                sta 1,x
-
-                ; Put HERE into TOS-1 and TOS-4
-                lda cp
-                sta 8,x
-                sta 2,x
-                lda cp+1
-                sta 9,x
-                sta 3,x
-
-                ; Copy the string into the dictionary.
-                jsr xt_move
-
-                ; Update cp.
-                clc
-                lda cp
-                adc 0,x
-                sta cp
-                lda cp+1
-                adc 1,x
-                sta cp+1
-
-                ; Update the address of the jump-over jmp instruction.
-                ; First determine location of jmp instructions address.
-                ; It should be 2 bytes before the start of the string.
-
-                ; Compute it into tmp1, which is no longer being used.
-                lda 2,x
-                sec
-                sbc #2
-                sta tmp1
-                lda 3,x
-                sbc #0          ; Propagate borrow
-                sta tmp1+1
-
-                ; Update the address of the jump to HERE.
-                lda cp
-                sta (tmp1)
-                ldy #1
-                lda cp+1
-                sta (tmp1),y
-
-                ; Stack is now ( addr2 u ) where addr2 is the new
-                ; location in the dictionary.
-
-sliteral_const_str:
+cmpl_sliteral:
+cmpl_two_literal:
                 ; Compile a subroutine jump to the runtime of SLITERAL that
                 ; pushes the new ( addr u ) pair to the Data Stack.
                 ; When we're done, the code will look like this:
@@ -643,23 +601,37 @@ sliteral_const_str:
 z_sliteral:     rts
 
 
+
+two_literal_runtime:
 sliteral_runtime:
 
         ; """Run time behaviour of SLITERAL: Push ( addr u ) of string to
         ; the Data Stack. We arrive here with the return address as the
-        ; top of Return Stack, which points to the address of the string
+        ; top of Return Stack, which points to the address of the string.
+        ; Also used for double word where we have ( lo hi ).
         ; """
                 dex
                 dex
                 dex
                 dex
 
-                ; Get the address of the string address off the stack and
-                ; increase by one because of the RTS mechanics
+                ; We arrived from code like
+                ;   jsr sliteral_runtime
+                ;   .word addr
+                ;   .word length
+                ; So the return address points one byte before addr.
+                ; Pull that to tmp1 and put tmp1+4 to return past two data words
                 pla
                 sta tmp1        ; LSB of address
-                pla
-                sta tmp1+1      ; MSB of address
+                ply
+                sty tmp1+1      ; MSB of address
+                clc
+                adc #4
+                bcc +
+                iny
++
+                phy
+                pha
 
                 ; Walk through both and save them
                 ldy #1          ; adjust for JSR/RTS mechanics on 65c02
@@ -677,15 +649,5 @@ sliteral_runtime:
 
                 lda (tmp1),y
                 sta 1,x         ; MSB of length
-
-                ; restore return address
-                clc
-                lda tmp1
-                adc #4
-                tay             ; LSB
-                lda tmp1+1
-                adc #0          ; we only need carry
-                pha             ; MSB
-                phy
 
                 rts


### PR DESCRIPTION
Adds support for inline literals (and two-literals) which are much faster than the `jsr` + payload version.   Inline literals require 6 bytes for byte-sized values and 8 bytes otherwise.  Doubles take twice the space so the default `nc-limit` of 20 inlines both single and double values. 

When 2literal is non-native it now shares sliteral_runtime using `jsr ...` with a four byte payload rather than two `jsr` each with two byte payload, which makes it more compact and almost twice as fast.

One minor issue is that disasm now shows both non-native string literals and doubles as SLITERAL (see below).
It might be possible to use the presence/absence of the preceding `jmp over-string` to decide whether to show SLITERAL or DLITERAL, and could then use `d.` to show the constant instead of `u. .` like SLITERAL does.
I was also wondering whether the `jmp over-string` in diasm should show the first 48ish characters of the string value alongside.   wdyt?

```
: foo 42 1234 12345678. ; see foo 
...
size (decimal): 36 

08E0  A9 2A CA CA 95 00 74 01  A0 04 A9 D2 CA CA 95 00  .*....t. ........
08F0  94 01 A0 61 A9 4E CA CA  95 00 94 01 A9 BC CA CA  ...a.N.. ........
0900  95 00 74 01  ..t.

8E0     2A lda.#
8E2        dex
8E3        dex
8E4      0 sta.zx
8E6      1 stz.zx
8E8      4 ldy.#
8EA     D2 lda.#
8EC        dex
8ED        dex
8EE      0 sta.zx
8F0      1 sty.zx
8F2     61 ldy.#
8F4     4E lda.#
8F6        dex
8F7        dex
8F8      0 sta.zx
8FA      1 sty.zx
8FC     BC lda.#
8FE        dex
8FF        dex
900      0 sta.zx
902      1 stz.zx
 ok


15 nc-limit !  ok
: foo 12345678. ; see foo 
...
size (decimal): 7 

0883  20 BC A1 4E 61 BC 00   ..Na..

883   A1BC jsr     SLITERAL 614E BC     <= DLITERAL d. would be better than SLITERAL u. .
 ok


: bar ." hello" 12345678. ;  ok
see bar 
...
size (decimal): 25 

0896  4C 9E 08 68 65 6C 6C 6F  20 BC A1 99 08 05 00 20  L..hello  ...... 
08A6  7F 96 20 BC A1 4E 61 BC  00  . ..Na. .

896    89E jmp          <= could show 'hello' here ?
89E   A1BC jsr     SLITERAL 899 5 
8A5   967F jsr     type
8A8   A1BC jsr     SLITERAL 614E BC 
```