### PR TITLE
refactor xt_spaces

### DIFF
--- a/words/core.asm
+++ b/words/core.asm
@@ -5570,64 +5570,23 @@ z_space:        rts
 xt_spaces:
                 jsr underflow_1
 
-                ; ANS says this word takes a signed value but prints no spaces
-                ; for negative values.
-                jsr xt_zero
-                jsr xt_max
-
-                ; catch any zero in TOS fast
-                lda 0,x
-                ora 1,x
-                beq _done
-
-                ; Usually we're only going to print far less than 256 spaces,
-                ; so we create a quick loop for that. Short loop could be realized
-                ; as a separate subroutine, but unless we're really pressed for
-                ; memory at some point, this is faster
-                ldy 1,x
-                bne _lots_of_spaces
+                lda 1,x         ; ANS says this word takes a signed value
+                bmi _done       ; but prints no spaces for negative values.
 
                 ldy 0,x
-_quick_loop:
-                ; we reach here knowing that there must be a number that is not
-                ; zero in the TOS
+                beq _msb
+_loop:                          ; loop to zero out LSB
                 lda #AscSP
-                jsr emit_a
+                jsr emit_a      ; user routine preserves X and Y
                 dey
-                beq _done
-                bra _quick_loop
+                bne _loop       ; Y is zero on exit so looping again emits 256 more spaces
+_msb:
+                dec 1,x         ; when decrementing MSB goes negative, it was zero so we're done
+                bpl _loop       ; otherwise emit another 256 spaces
 
-_lots_of_spaces:
-                ; We go through the first loop once to get rid of the lower
-                ; counter byte. This could be zero
-                ldy 0,x
-
-_first_slow_loop:
-                beq _slow_outer_loop
-                lda #AscSP
-                jsr emit_a
-                dey
-                bra _first_slow_loop
-
-_slow_outer_loop:
-                ; we arrive here knowing that the MSB of TOS cannot be a zero
-                ldy #00
-
-_slow_inner_loop:
-                lda #AscSP
-                jsr emit_a
-                dey
-                bne _slow_inner_loop
-
-                dec 1,x
-                bne _slow_outer_loop
-
-_done:
-                inx             ; drop
+_done:          inx
                 inx
-
 z_spaces:       rts
-
 
 
 ; ## STAR ( n n -- n ) "16*16 --> 16 "


### PR DESCRIPTION
i refactored this after noticing the `_lots_of_spaces` specialization wasn't exercised by tests (see #91).  this is smaller and faster and all covered by the tests.

```
size:
before: | SPACES | `spaces` | ANS core | 59 | **auto** |
after:  | SPACES | `spaces` | ANS core | 25 | **auto** |

speed (cycles) for various n spaces:

n       after       before

42      1263        1466
442     12871       13768
-1      33          131
0       47          131
```
