### PR TITLE
Adds m*/ along with test coverage for literal_runtime, d_dot, ud_dot, m_star_slash

### DIFF
--- a/headers.asm
+++ b/headers.asm
@@ -206,8 +206,13 @@ nt_d_dot:
 
 nt_d_dot_r:
         .byte 3, UF
-        .word nt_ud_dot, xt_d_dot_r, z_d_dot_r
+        .word nt_m_star_slash, xt_d_dot_r, z_d_dot_r
         .text "d.r"
+
+nt_m_star_slash:
+        .byte 3, UF
+        .word nt_ud_dot, xt_m_star_slash, z_m_star_slash
+        .text "m*/"
 
 nt_ud_dot:
         .byte 3, UF

--- a/tests/double.fs
+++ b/tests/double.fs
@@ -24,21 +24,21 @@ T{ 2v3 2@ -> 5 6 }T
 0 invert 1 rshift  constant max-int
 0 invert 1 rshift invert  constant min-int
 
-T{  0.  5. d+ ->  5. }T                         \ small integers 
-T{ -5.  0. d+ -> -5. }T 
-T{  1.  2. d+ ->  3. }T 
-T{  1. -2. d+ -> -1. }T 
-T{ -1.  2. d+ ->  1. }T 
-T{ -1. -2. d+ -> -3. }T 
+T{  0.  5. d+ ->  5. }T                         \ small integers
+T{ -5.  0. d+ -> -5. }T
+T{  1.  2. d+ ->  3. }T
+T{  1. -2. d+ -> -1. }T
+T{ -1.  2. d+ ->  1. }T
+T{ -1. -2. d+ -> -3. }T
 T{ -1.  1. d+ ->  0. }T
-T{  0  0  0  5 d+ ->  0  5 }T                  \ mid range integers 
-T{ -1  5  0  0 d+ -> -1  5 }T 
-T{  0  0  0 -5 d+ ->  0 -5 }T 
-T{  0 -5 -1  0 d+ -> -1 -5 }T 
-T{  0  1  0  2 d+ ->  0  3 }T 
-T{ -1  1  0 -2 d+ -> -1 -1 }T 
-T{  0 -1  0  2 d+ ->  0  1 }T 
-T{  0 -1 -1 -2 d+ -> -1 -3 }T 
+T{  0  0  0  5 d+ ->  0  5 }T                  \ mid range integers
+T{ -1  5  0  0 d+ -> -1  5 }T
+T{  0  0  0 -5 d+ ->  0 -5 }T
+T{  0 -5 -1  0 d+ -> -1 -5 }T
+T{  0  1  0  2 d+ ->  0  3 }T
+T{ -1  1  0 -2 d+ -> -1 -1 }T
+T{  0 -1  0  2 d+ ->  0  1 }T
+T{  0 -1 -1 -2 d+ -> -1 -3 }T
 T{ -1 -1  0  1 d+ -> -1  0 }T
 
 T{ min-int 0 2dup d+ -> 0 1 }T
@@ -54,12 +54,12 @@ T{ 2c2 -> -1 -2 }T
 T{ 4 5 2constant 2c3 immediate 2c3 -> 4 5 }T
 T{ : cd6 2c3 2literal ; cd6 -> 4 5 }T
 
-max-int 2/ constant hi-int \ 001...1 
+max-int 2/ constant hi-int \ 001...1
 min-int 2/ constant lo-int \ 110...1
 
-1s max-int  2constant max-2int \ 01...1 
-0 min-int   2constant min-2int \ 10...0 
-max-2int 2/ 2constant hi-2int  \ 001...1 
+1s max-int  2constant max-2int \ 01...1
+0 min-int   2constant min-2int \ 10...0
+max-2int 2/ 2constant hi-2int  \ 001...1
 min-2int 2/ 2constant lo-2int  \ 110...0
 
 T{ : cd1 [ max-2int ] 2literal ; -> }T
@@ -68,65 +68,64 @@ T{ 2variable 2v4 immediate 5 6 2v4 2! -> }T
 T{ : cd7 2v4 [ 2@ ] 2literal ; cd7 -> 5 6 }T
 T{ : cd8 [ 6 7 ] 2v4 [ 2! ] ; 2v4 2@ -> 6 7 }T
 
-T{  hi-2int       1. d+ -> 0 hi-int 1+ }T     \ large double integers 
+T{  hi-2int       1. d+ -> 0 hi-int 1+ }T     \ large double integers
 T{  hi-2int     2dup d+ -> 1s 1- max-int }T
 T{ max-2int min-2int d+ -> -1. }T
 T{ max-2int  lo-2int d+ -> hi-2int }T
 T{  lo-2int     2dup d+ -> min-2int }T
 T{  hi-2int min-2int d+ 1. d+ -> lo-2int }T
 
-T{  0.  5. d- -> -5. }T              \ small integers 
-T{  5.  0. d- ->  5. }T 
-T{  0. -5. d- ->  5. }T 
-T{  1.  2. d- -> -1. }T 
-T{  1. -2. d- ->  3. }T 
-T{ -1.  2. d- -> -3. }T 
-T{ -1. -2. d- ->  1. }T 
-T{ -1. -1. d- ->  0. }T 
-T{  0  0  0  5 d- ->  0 -5 }T        \ mid-range integers 
-T{ -1  5  0  0 d- -> -1  5 }T 
-T{  0  0 -1 -5 d- ->  1  4 }T 
-T{  0 -5  0  0 d- ->  0 -5 }T 
-T{ -1  1  0  2 d- -> -1 -1 }T 
-T{  0  1 -1 -2 d- ->  1  2 }T 
-T{  0 -1  0  2 d- ->  0 -3 }T 
-T{  0 -1  0 -2 d- ->  0  1 }T 
+T{  0.  5. d- -> -5. }T              \ small integers
+T{  5.  0. d- ->  5. }T
+T{  0. -5. d- ->  5. }T
+T{  1.  2. d- -> -1. }T
+T{  1. -2. d- ->  3. }T
+T{ -1.  2. d- -> -3. }T
+T{ -1. -2. d- ->  1. }T
+T{ -1. -1. d- ->  0. }T
+T{  0  0  0  5 d- ->  0 -5 }T        \ mid-range integers
+T{ -1  5  0  0 d- -> -1  5 }T
+T{  0  0 -1 -5 d- ->  1  4 }T
+T{  0 -5  0  0 d- ->  0 -5 }T
+T{ -1  1  0  2 d- -> -1 -1 }T
+T{  0  1 -1 -2 d- ->  1  2 }T
+T{  0 -1  0  2 d- ->  0 -3 }T
+T{  0 -1  0 -2 d- ->  0  1 }T
 T{  0  0  0  1 d- ->  0 -1 }T
-T{ min-int 0 2dup d- -> 0. }T 
-T{ min-int s>d max-int 0 d- -> 1 1s }T 
+T{ min-int 0 2dup d- -> 0. }T
+T{ min-int s>d max-int 0 d- -> 1 1s }T
 
-T{ max-2int max-2int d- -> 0. }T    \ large integers 
+T{ max-2int max-2int d- -> 0. }T    \ large integers
 T{ min-2int min-2int d- -> 0. }T
-T{ max-2int  hi-2int d- -> lo-2int dnegate }T 
+T{ max-2int  hi-2int d- -> lo-2int dnegate }T
 T{  hi-2int  lo-2int d- -> max-2int }T
 T{  lo-2int  hi-2int d- -> min-2int 1. d+ }T
 T{ min-2int min-2int d- -> 0. }T
 T{ min-2int  lo-2int d- -> lo-2int }T
 
-( TODO m*/ not implemented ) 
 
-\ max-2int 71 73 m*/ 2constant dbl1 
-\ min-2int 73 79 m*/ 2constant dbl2
-\ : d>ascii ( d -- caddr u ) 
-   \ dup >r <# dabs #s r> sign #>    ( -- caddr1 u ) 
-   \ here swap 2dup 2>r chars dup allot move 2r> 
-\ ;
+max-2int 71 73 m*/ 2constant dbl1
+min-2int 73 79 m*/ 2constant dbl2
+: d>ascii ( d -- caddr u )
+   dup >r <# dabs #s r> sign #>    ( -- caddr1 u )
+   here swap 2dup 2>r chars dup allot move 2r>
+;
 
-\ dbl1 d>ascii 2constant "dbl1" 
-\ dbl2 d>ascii 2constant "dbl2"
+dbl1 d>ascii 2constant "dbl1"
+dbl2 d>ascii 2constant "dbl2"
 
-\ : doubleoutput 
-   \ cr ." you should see lines duplicated:" cr 
-   \ 5 spaces "dbl1" type cr 
-   \ 5 spaces dbl1 d. cr 
-   \ 8 spaces "dbl1" dup >r type cr 
-   \ 5 spaces dbl1 r> 3 + d.r cr 
-   \ 5 spaces "dbl2" type cr 
-   \ 5 spaces dbl2 d. cr 
-   \ 10 spaces "dbl2" dup >r type cr 
-   \ 5 spaces dbl2 r> 5 + d.r cr 
-\ ;
-
+: doubleoutput
+   cr ." you should see lines duplicated:" cr
+   5 spaces "dbl1" type cr
+   5 spaces dbl1 d. cr
+   8 spaces "dbl1" dup >r type cr
+   5 spaces dbl1 r> 3 + d.r cr
+   5 spaces "dbl2" type cr
+   5 spaces dbl2 d. cr
+   10 spaces "dbl2" dup >r type cr
+   5 spaces dbl2 r> 5 + d.r cr
+;
+doubleoutput
 \ T{ doubleoutput -> }T
 
 ( TODO D0< not implemented yet )
@@ -136,14 +135,14 @@ T{ min-2int  lo-2int d- -> lo-2int }T
 ( TODO D< not implemented yet )
 ( TODO D= not implemented yet )
 
-T{    1234  0 d>s ->  1234   }T 
-T{   -1234 -1 d>s -> -1234   }T 
-T{ max-int  0 d>s -> max-int }T 
+T{    1234  0 d>s ->  1234   }T
+T{   -1234 -1 d>s -> -1234   }T
+T{ max-int  0 d>s -> max-int }T
 T{ min-int -1 d>s -> min-int }T
 
-T{       1. dabs -> 1.       }T 
-T{      -1. dabs -> 1.       }T 
-T{ max-2int dabs -> max-2int }T 
+T{       1. dabs -> 1.       }T
+T{      -1. dabs -> 1.       }T
+T{ max-2int dabs -> max-2int }T
 T{ min-2int 1. d+ dabs -> max-2int }T
 
 ( TODO DMAX not implemented yet )
@@ -155,7 +154,10 @@ T{ -1. dnegate -> 1. }T
 T{ max-2int dnegate -> min-2int swap 1+ swap }T
 T{ min-2int swap 1+ swap dnegate -> max-2int }T
 
-( TODO M*/ not implemented yet )
+T{  5.  7  11 m*/ -> 3. }T
+T{ -5. -7  11 m*/ -> 3. }T
+T{ -5.  7 -11 m*/ -> 3. }T
+
 ( TODO M+ not implemented yet )
 ( TODO 2ROT not implemented yet )
 ( TODO 2VALUE not implemented yet )

--- a/tests/tali.fs
+++ b/tests/tali.fs
@@ -164,6 +164,11 @@ T{ ' four-b int>name wordsize ->  3 }T
 T{ latestnt wordsize          ->  3 }T
 T{ latestxt int>name wordsize ->  3 }T
 
+\ Test inline vs jsr+payload literals
+: five 6 [ 0 nc-limit ! ] 7 * ; 16 nc-limit !
+T{ ' five int>name wordsize -> 16 }t
+T{ five -> 42 }T
+
 \ Nothing is too trivial for testing!
 T{ 0 -> 0 }T
 T{ 1 -> 1 }T

--- a/words/core.asm
+++ b/words/core.asm
@@ -3825,14 +3825,10 @@ xt_number_sign:
                 jsr xt_zero             ; 0
                 jsr xt_r_fetch          ; r@
                 jsr xt_um_slash_mod     ; um/mod
-                jsr xt_rot              ; rot
-                jsr xt_rot              ; rot
+                jsr xt_not_rote         ; rot rot
                 jsr xt_r_from           ; r>
                 jsr xt_um_slash_mod     ; um/mod
-                jsr xt_rot              ; rot
-                ; end of UD/MOD ( rem ud )
-
-                jsr xt_rot              ; ( ud rem )
+                jsr xt_not_rote         ; rot ( rem ud ) rot ( ud rem )
 
                 ; Convert the number that is left over to an ASCII character. We
                 ; use a string lookup for speed. Use either abc_str_lower for

--- a/words/double.asm
+++ b/words/double.asm
@@ -142,7 +142,7 @@ z_dnegate:      rts
 
 
 ; ## D_DOT ( d -- ) "Print double"
-; ## "d."  tested  ANS double
+; ## "d."  auto  ANS double
         ; """http://forth-standard.org/standard/double/Dd"""
         ;
         ; From the Forth code:
@@ -166,7 +166,7 @@ z_d_dot:        rts
 
 
 ; ## D_DOT_R ( d u -- ) "Print double right-justified u wide"
-; ## "d.r"  tested  ANS double
+; ## "d.r"  auto  ANS double
         ; """http://forth-standard.org/standard/double/DDotR"""
         ; Based on the Forth code
         ;  : D.R >R TUCK DABS <# #S ROT SIGN #> R> OVER - SPACES TYPE ;
@@ -191,6 +191,60 @@ xt_d_dot_r:
 
 z_d_dot_r:      rts
 
+
+; ## M_STAR_SLASH ( d1 n1 n2 -- d2 ) "Multiply d1 by n1 and divide by n2.  Note n2 may be negative."
+; ## "m*/"  auto  ANS double
+        ; """https://forth-standard.org/standard/double/MTimesDiv"""
+        ; From All About FORTH, MVP-Forth, public domain,
+        ; from this forth code which is modified slightly for Tali2:
+        ; DDUP XOR SWAP ABS >R SWAP ABS >R OVER XOR ROT ROT DABS
+        ; SWAP R@ UM* ROT R> UM* ROT 0 D+ R@ UM/MOD ROT ROT R> UM/MOD
+        ; SWAP DROP SWAP ROT 0< if dnegate then
+xt_m_star_slash:
+                jsr underflow_4
+
+                ; DDUP XOR SWAP ABS >R SWAP ABS >R OVER XOR ROT ROT DABS
+                jsr xt_two_dup
+                jsr xt_xor
+                jsr xt_swap
+                jsr xt_abs
+                jsr xt_to_r
+                jsr xt_swap
+                jsr xt_abs
+                jsr xt_to_r
+                jsr xt_over
+                jsr xt_xor
+                jsr xt_not_rote         ; rot rot
+                jsr xt_dabs
+
+                ; SWAP R@ UM* ROT R> UM* ROT 0 D+ R@ UM/MOD ROT ROT R> UM/MOD
+                jsr xt_swap
+                jsr xt_r_fetch
+                jsr xt_um_star
+                jsr xt_rot
+                jsr xt_r_from
+                jsr xt_um_star
+                jsr xt_rot
+                jsr xt_zero
+                jsr xt_d_plus
+                jsr xt_r_fetch
+                jsr xt_um_slash_mod
+                jsr xt_not_rote         ; rot rot
+                jsr xt_r_from
+                jsr xt_um_slash_mod
+
+                ; SWAP DROP SWAP ROT 0< if dnegate then ;
+                jsr xt_swap
+                jsr xt_drop
+                jsr xt_swap
+                jsr xt_rot
+                inx                     ; drop TOS
+                inx
+                lda $fe,x               ; but keep MSB
+                bpl z_m_star_slash      ; ... 0< if ...
+                jsr xt_dnegate
+
+z_m_star_slash: rts
 
 
 ; ## TWO_CONSTANT (C: d "name" -- ) ( -- d) "Create a constant for a double word"


### PR DESCRIPTION
Knock a few items off #91 

I implemented your code for m*/ and took a few tests for m*/ from https://forth-standard.org/standard/double/MTimesDiv, and added one with negative n2.  Not sure if you want more there.   I guess if more double words are implemented we could make `double` an option for tali_optional_words?

Added a test to exercise the old style literals (jsr + payload).    