### PR TITLE
Compiling/strip-underflow honored even when compiling as JSR

### DIFF
--- a/tests/results.txt
+++ b/tests/results.txt
@@ -3353,12 +3353,12 @@ here 5       ' blank         cycle_test            CYCLES:    327 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  15436 ok
+             ' :             cycle_test wrd ;      CYCLES:  15441 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:    101 ok
-' aword      ' compile,      cycle_test            CYCLES:   1163 ok
+' aword      ' compile,      cycle_test            CYCLES:   1160 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
-5            ' constant      cycle_test mycnst     CYCLES:  15924 ok
+5            ' constant      cycle_test mycnst     CYCLES:  15929 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3407,7 +3407,7 @@ nc-limit !  ok
 5 5          ' =             cycle_test drop       CYCLES:     66 ok
 here 5       ' erase         cycle_test            CYCLES:    321 ok
 here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17170 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17175 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3427,7 +3427,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:   1020 ok
              ' ifloop        cycle_test            CYCLES:  18134 ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   2512 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   2476 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
@@ -3442,7 +3442,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:   1020 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    652 ok
-             ' marker        cycle_test marka      CYCLES:  17944 ok
+             ' marker        cycle_test marka      CYCLES:  17950 ok
              ' marka         cycle_test            CYCLES:    821 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
@@ -3508,7 +3508,7 @@ s" abc" 1    ' /string       cycle_test 2drop      CYCLES:     84 ok
 5 5          ' swap          cycle_test 2drop      CYCLES:     60 ok
              ' '             cycle_test aword drop CYCLES:   1993 ok
 \ postponing   to ( see value )  ok
-' aword      ' >body         cycle_test drop       CYCLES:   1508 ok
+' aword      ' >body         cycle_test drop       CYCLES:   1490 ok
              ' >in           cycle_test drop       CYCLES:     28 ok
 0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2432 ok
 \ skipping     >r  ok
@@ -3526,7 +3526,7 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  16663 ok
+             ' 2variable     cycle_test eword      CYCLES:  16669 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
 s" *"        ' type          cycle_test           *CYCLES:    123 ok
 5            ' u.            cycle_test          5 CYCLES:   3465 ok
@@ -3537,10 +3537,10 @@ s" *"        ' type          cycle_test           *CYCLES:    123 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    476 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  16914 ok
+5            ' value         cycle_test fword      CYCLES:  16920 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
 5            ' to            cycle_test fword      CYCLES:   1173 ok
-             ' variable      cycle_test gword      CYCLES:  16669 ok
+             ' variable      cycle_test gword      CYCLES:  16675 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    671 ok
 \ skipping     words  ok
@@ -3553,4 +3553,4 @@ char "       ' word          cycle_test "txt" drop CYCLES:    671 ok
 5            ' 0<            cycle_test drop       CYCLES:     47 ok
 5            ' 0<>           cycle_test drop       CYCLES:     48 ok
   ok
-bye c65: PC=f015 A=98 X=78 Y=01 S=f6 FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=147318240
+bye c65: PC=f015 A=98 X=78 Y=01 S=f6 FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=147282180

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -3353,7 +3353,7 @@ here 5       ' blank         cycle_test            CYCLES:    327 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  15441 ok
+             ' :             cycle_test wrd ;      CYCLES:  15440 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:    101 ok
 ' aword      ' compile,      cycle_test            CYCLES:   1160 ok
@@ -3407,7 +3407,7 @@ nc-limit !  ok
 5 5          ' =             cycle_test drop       CYCLES:     66 ok
 here 5       ' erase         cycle_test            CYCLES:    321 ok
 here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17175 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17174 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3442,7 +3442,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:   1020 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    652 ok
-             ' marker        cycle_test marka      CYCLES:  17950 ok
+             ' marker        cycle_test marka      CYCLES:  17949 ok
              ' marka         cycle_test            CYCLES:    821 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
@@ -3526,7 +3526,7 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  16669 ok
+             ' 2variable     cycle_test eword      CYCLES:  16673 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
 s" *"        ' type          cycle_test           *CYCLES:    123 ok
 5            ' u.            cycle_test          5 CYCLES:   3465 ok
@@ -3537,10 +3537,10 @@ s" *"        ' type          cycle_test           *CYCLES:    123 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    476 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  16920 ok
+5            ' value         cycle_test fword      CYCLES:  16919 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
 5            ' to            cycle_test fword      CYCLES:   1173 ok
-             ' variable      cycle_test gword      CYCLES:  16675 ok
+             ' variable      cycle_test gword      CYCLES:  16674 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    671 ok
 \ skipping     words  ok
@@ -3553,4 +3553,4 @@ char "       ' word          cycle_test "txt" drop CYCLES:    671 ok
 5            ' 0<            cycle_test drop       CYCLES:     47 ok
 5            ' 0<>           cycle_test drop       CYCLES:     48 ok
   ok
-bye c65: PC=f015 A=98 X=78 Y=01 S=f6 FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=147282180
+bye c65: PC=f015 A=98 X=78 Y=01 S=f6 FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=147249414

--- a/words/compile.asm
+++ b/words/compile.asm
@@ -157,8 +157,11 @@ cmpl_by_limit:
 cmpl_as_call:
         ; Compile xt as a subroutine call, return with C=0
         ; Stack is either ( xt xt nt ) or ( xt xt' u )
-                jsr xt_two_drop         ; either way 2drop leaves original xt
-                ; ( xt -- )
+        ; Use the xt or xt' (in the middle) as the jsr address
+        ; so that strip-underflow is respected.
+                jsr xt_drop
+                jsr xt_nip
+                ; ( jsr_address -- )
                 lda #OpJSR
                 jsr cmpl_a
                 jsr xt_comma

--- a/words/disasm.asm
+++ b/words/disasm.asm
@@ -411,7 +411,9 @@ disasm_jsr:
                 rts
 
 _no_nt:
-                jsr xt_two_drop
+                ; Drop the 0
+                inx
+                inx
                 clc
                 rts
 

--- a/words/disasm.asm
+++ b/words/disasm.asm
@@ -402,7 +402,41 @@ disasm_jsr:
                 ; int>name returns zero if we just don't know.
                 lda 0,x
                 ora 1,x
+                bne _found_nt
+
+                ; So we didn't find the JSR target in the dictionary.
+                ; Check again at address-3 in case this is a JSR that
+                ; skipped underflow checking during compiling by adding
+                ; 3 to the JSR address.
+                lda scratch+1
+                sec
+                sbc #3         ; Subtract 3 this time.
+                sta 0,x
+                lda scratch+2
+                sbc #0         ; Subtract the carry if needed.
+                sta 1,x
+                ; ( xt )
+                jsr xt_int_to_name    ; Try looking again
+                ; int>name returns zero if we just don't know.
+                lda 0,x
+                ora 1,x
                 beq _no_nt
+
+                ; We got an nt this time.  Double check that it has underflow
+                ; checking (that could be skipped).
+                ; Put the address of the status byte on the stack.
+                jsr xt_dup
+                jsr xt_one_plus
+                ; Grab the status into A
+                lda (0,x)
+                ; Get rid of the extra stack usage before doing the check
+                inx
+                inx
+                ;Check the UF flag
+                and #UF
+                beq _no_nt      ; The word doesn't have underflow checking
+
+_found_nt:
                 ; We now have a name token ( nt ) on the stack.
                 ; Change it into the name and print it.
                 jsr xt_name_to_string
@@ -411,7 +445,7 @@ disasm_jsr:
                 rts
 
 _no_nt:
-                ; Drop the 0
+                ; Drop the TOS as there is no usable nt
                 inx
                 inx
                 clc


### PR DESCRIPTION
This seems to work well.  It now honors the strip-underflow variable when compiling, and the disassembler recognizes +3 JSR targets (but it double checks to make sure the word DOES have the UF flag set before printing the name of the word).  I did some manual tests and it appears to be working as desired.

Also fixed #97 while in there (accidentally had 2drop when drop was correct).

I think this is independent from the w_ label work at the assembly level, so if you like it then I will go ahead and merge it.