### PR TITLE
Adds internal w_ labels, fixes some header flags and missing underflow checks

### DIFF
--- a/headers.asm
+++ b/headers.asm
@@ -620,12 +620,12 @@ nt_d_plus:
         .text "d+"
 
 nt_erase:
-        .byte 5, 0      ; underflow checked by FILL
+        .byte 5, UF
         .word nt_blank, xt_erase, z_erase
         .text "erase"
 
 nt_blank:
-        .byte 5, 0     ; underflow checked by FILL
+        .byte 5, UF
         .word nt_fill, xt_blank, z_blank
         .text "blank"
 
@@ -1176,27 +1176,27 @@ nt_if:
         .text "if"
 
 nt_then:
-        .byte 4, IM+CO+NN
+        .byte 4, UF+IM+CO+NN
         .word nt_else, xt_then, z_then
         .text "then"
 
 nt_else:
-        .byte 4, IM+CO+NN
+        .byte 4, UF+IM+CO+NN
         .word nt_repeat, xt_else, z_else
         .text "else"
 
 nt_repeat:
-        .byte 6, IM+CO+NN
+        .byte 6, UF+IM+CO+NN
         .word nt_until, xt_repeat, z_repeat
         .text "repeat"
 
 nt_until:
-        .byte 5, IM+CO+NN
+        .byte 5, UF+IM+CO+NN
         .word nt_while, xt_until, z_until
         .text "until"
 
 nt_while:
-        .byte 5, IM+CO+NN
+        .byte 5, UF+IM+CO+NN
         .word nt_case, xt_while, z_while
         .text "while"
 
@@ -1216,17 +1216,17 @@ nt_endof:
         .text "endof"
 
 nt_endcase:
-        .byte 7, IM+CO+NN
+        .byte 7, UF+IM+CO+NN
         .word nt_defer_fetch, xt_endcase, z_endcase
         .text "endcase"
 
 nt_defer_fetch:
-        .byte 6, 0
+        .byte 6, UF
         .word nt_defer_store, xt_defer_fetch, z_defer_fetch
         .text "defer@"
 
 nt_defer_store:
-        .byte 6, 0
+        .byte 6, UF
         .word nt_is, xt_defer_store, z_defer_store
         .text "defer!"
 
@@ -1277,22 +1277,22 @@ nt_blk:
         .text "blk"
 
 nt_block_write:
-        .byte 11, NN ; Deferred words need the HC (Code Field) flag.
+        .byte 11, NN
         .word nt_block_write_vector, xt_block_write, z_block_write
         .text "block-write"
 
 nt_block_write_vector:
-        .byte 18, NN ; Deferred words need the HC (Code Field) flag.
+        .byte 18, NN
         .word nt_block_read, xt_block_write_vector, z_block_write_vector
         .text "block-write-vector"
 
 nt_block_read:
-        .byte 10, HC+NN ; Deferred words need the HC (Code Field) flag.
+        .byte 10, NN
         .word nt_block_read_vector, xt_block_read, z_block_read
         .text "block-read"
 
 nt_block_read_vector:
-        .byte 17, HC+NN ; Deferred words need the HC (Code Field) flag.
+        .byte 17, NN
         .word nt_save_buffers, xt_block_read_vector, z_block_read_vector
         .text "block-read-vector"
 

--- a/taliforth.asm
+++ b/taliforth.asm
@@ -416,7 +416,7 @@ interpret:
                 ; delimiters per default and skips any leading spaces, which
                 ; PARSE doesn't
 _loop:
-                jsr xt_parse_name       ; ( "string" -- addr u )
+                jsr w_parse_name       ; ( "string" -- addr u )
 
                 ; If PARSE-NAME returns 0 (empty line), no characters were left
                 ; in the line and we need to go get a new line
@@ -427,8 +427,8 @@ _loop:
                 ; Go to FIND-NAME to see if this is a word we know. We have to
                 ; make a copy of the address in case it isn't a word we know and
                 ; we have to go see if it is a number
-                jsr xt_two_dup          ; ( addr u -- addr u addr u )
-                jsr xt_find_name        ; ( addr u addr u -- addr u nt|0 )
+                jsr w_two_dup          ; ( addr u -- addr u addr u )
+                jsr w_find_name        ; ( addr u addr u -- addr u nt|0 )
 
                 ; A zero signals that we didn't find a word in the Dictionary
                 lda 0,x
@@ -442,7 +442,7 @@ _loop:
 
                 ; If the number conversion doesn't work, NUMBER will do the
                 ; complaining for us
-                jsr xt_number           ; ( addr u -- u|d )
+                jsr w_number           ; ( addr u -- u|d )
 
                 ; Otherwise, if we're interpreting, we're done
                 lda state
@@ -455,13 +455,13 @@ _loop:
                 bit status
                 bne _double_number
 
-                jsr xt_literal
+                jsr w_literal
                 ; That was so much fun, let's do it again!
                 bra _loop
 
 _double_number:
                 ; It's a double cell number.
-                jsr xt_two_literal
+                jsr w_two_literal
                 bra _loop
 
 _got_name_token:
@@ -481,11 +481,11 @@ _got_name_token:
 
                 ; Whether interpreting or compiling we'll need to check the
                 ; status byte at nt+1 so let's save it now
-                jsr xt_one_plus
+                jsr w_one_plus
                 lda (0,x)
                 pha
-                jsr xt_one_minus
-                jsr xt_name_to_int      ; ( nt - xt )
+                jsr w_one_minus
+                jsr w_name_to_int      ; ( nt - xt )
 
                 ; See if we are in interpret or compile mode, 0 is interpret
                 lda state
@@ -507,7 +507,7 @@ _interpret:
                 ; skipping EXECUTE completely during RTS. If we were to execute
                 ; xt directly, we have to fool around with the Return Stack
                 ; instead, which is actually slightly slower
-                jsr xt_execute
+                jsr w_execute
 
                 ; That's quite enough for this word, let's get the next one
                 jmp _loop
@@ -522,7 +522,7 @@ _compile:
                 bne _interpret          ; IMMEDIATE word, execute right now
 
                 ; Compile the xt into the Dictionary with COMPILE,
-                jsr xt_compile_comma
+                jsr w_compile_comma
                 bra _loop
 
 _line_done:
@@ -609,7 +609,7 @@ error:
         ; """
                 pha                     ; save error
                 jsr print_error
-                jsr xt_cr
+                jsr w_cr
                 pla
                 cmp #err_underflow      ; should we display return stack?
                 bne _no_underflow
@@ -623,15 +623,15 @@ error:
 -
                 inx
                 beq +
-                jsr xt_space
+                jsr w_space
                 lda $100,x
                 jsr byte_to_ascii
                 bra -
 +
-                jsr xt_cr
+                jsr w_cr
 
 _no_underflow:
-                jmp xt_abort            ; no jsr, as we clobber return stack
+                jmp w_abort            ; no jsr, as we clobber return stack
 
 ; =====================================================================
 ; PRINTING ROUTINES
@@ -700,7 +700,7 @@ print_string:
         ; We do not check to see if the index is out of range. Uses tmp3.
         ; """
                 jsr print_string_no_lf
-                jmp xt_cr               ; JSR/RTS because never compiled
+                jmp w_cr               ; JSR/RTS because never compiled
 
 
 print_u:
@@ -709,11 +709,11 @@ print_u:
         ; basically u. without the space at the end. used for various
         ; outputs
         ; """
-                jsr xt_zero                     ; 0
-                jsr xt_less_number_sign         ; <#
-                jsr xt_number_sign_s            ; #S
-                jsr xt_number_sign_greater      ; #>
-                jmp xt_type                     ; JSR/RTS because never compiled
+                jsr w_zero                     ; 0
+                jsr w_less_number_sign         ; <#
+                jsr w_number_sign_s            ; #S
+                jsr w_number_sign_greater      ; #>
+                jmp w_type                     ; JSR/RTS because never compiled
 
 .weak
 kernel_kbhit .proc

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -3337,7 +3337,7 @@ drop \ accept test complete  ok
              ' beginwhile    cycle_test            CYCLES:   9306 ok
              ' bell          cycle_test            CYCLES:     36 ok
              ' bl            cycle_test drop       CYCLES:     26 ok
-here 5       ' blank         cycle_test            CYCLES:    327 ok
+here 5       ' blank         cycle_test            CYCLES:    332 ok
 5 5          ' bounds        cycle_test 2drop      CYCLES:     70 ok
 \ skipping     [char]  ok
 \ skipping     [']  ok
@@ -3348,17 +3348,17 @@ here 5       ' blank         cycle_test            CYCLES:    327 ok
 5 here       ' c!            cycle_test            CYCLES:     46 ok
 5            ' cell+         cycle_test drop       CYCLES:     46 ok
 5            ' cells         cycle_test drop       CYCLES:     40 ok
-             ' char          cycle_test w drop     CYCLES:    450 ok
+             ' char          cycle_test w drop     CYCLES:    449 ok
 5            ' char+         cycle_test drop       CYCLES:     37 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  15440 ok
+             ' :             cycle_test wrd ;      CYCLES:  15388 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:    101 ok
-' aword      ' compile,      cycle_test            CYCLES:   1160 ok
+' aword      ' compile,      cycle_test            CYCLES:    979 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
-5            ' constant      cycle_test mycnst     CYCLES:  15929 ok
+5            ' constant      cycle_test mycnst     CYCLES:  15857 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3369,7 +3369,7 @@ here         ' count         cycle_test 2drop      CYCLES:     59 ok
              ' decimal       cycle_test            CYCLES:     20 ok
 \ skipping     defer  ok
              ' depth         cycle_test drop       CYCLES:     36 ok
-char w       ' digit?        cycle_test 2drop      CYCLES:     86 ok
+char w       ' digit?        cycle_test 2drop      CYCLES:     87 ok
 \ skipping     disasm  ok
 5.           ' dnegate       cycle_test 2drop      CYCLES:     72 ok
 : do?word1 5 5 ?do loop ;  ok
@@ -3399,15 +3399,15 @@ nc-limit !  ok
 \ skipping     does  ok
 \ skipping     .  ok
 \ skipping     ."  ok
-             ' s"            cycle_test " 2drop    CYCLES:    541 ok
+             ' s"            cycle_test " 2drop    CYCLES:    476 ok
 5            ' drop          cycle_test            CYCLES:     32 ok
 \ skipping     dump  ok
 5            ' dup           cycle_test 2drop      CYCLES:     48 ok
 42           ' emit          cycle_test           *CYCLES:     46 ok
 5 5          ' =             cycle_test drop       CYCLES:     66 ok
-here 5       ' erase         cycle_test            CYCLES:    321 ok
-here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17174 ok
+here 5       ' erase         cycle_test            CYCLES:    330 ok
+here 5 5     ' fill          cycle_test            CYCLES:    314 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17011 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3415,9 +3415,9 @@ here         ' @             cycle_test drop       CYCLES:     59 ok
 \ making counted string for find  ok
 here 5 c, char a c, char w c, char o c,  ok
 char r c, char d c,  ok
-             ' find          cycle_test 2drop      CYCLES:   1354 ok
+             ' find          cycle_test 2drop      CYCLES:   1274 ok
 s" aword"    ' find-name     cycle_test drop       CYCLES:   1020 ok
-5. 5         ' fm/mod        cycle_test 2drop      CYCLES:   1313 ok
+5. 5         ' fm/mod        cycle_test 2drop      CYCLES:   1281 ok
 5 5          ' >             cycle_test drop       CYCLES:     81 ok
              ' here          cycle_test drop       CYCLES:     30 ok
              ' hex           cycle_test decimal    CYCLES:     14 ok
@@ -3427,12 +3427,12 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:   1020 ok
              ' ifloop        cycle_test            CYCLES:  18134 ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   2476 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   2439 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
              ' latestnt      cycle_test drop       CYCLES:     75 ok
-             ' latestxt      cycle_test drop       CYCLES:    158 ok
+             ' latestxt      cycle_test drop       CYCLES:    142 ok
 \ skipping     leave  ok
 \ skipping     [  ok
 \ skipping     <#  ok
@@ -3441,8 +3441,8 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:   1020 ok
 \ skipping     loop  ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
-5 5          ' m*            cycle_test 2drop      CYCLES:    652 ok
-             ' marker        cycle_test marka      CYCLES:  17949 ok
+5 5          ' m*            cycle_test 2drop      CYCLES:    588 ok
+             ' marker        cycle_test marka      CYCLES:  17895 ok
              ' marka         cycle_test            CYCLES:    821 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
@@ -3464,7 +3464,7 @@ decimal  ok
              ' nops          cycle_test            CYCLES:     29 ok
 5 5          ' <>            cycle_test drop       CYCLES:     70 ok
 5 5 5        ' -rot          cycle_test 2drop drop CYCLES:     76 ok
-s" 5"        ' number        cycle_test drop       CYCLES:   1650 ok
+s" 5"        ' number        cycle_test drop       CYCLES:   1537 ok
 \ skipping     #  ok
 \ skipping     #>  ok
 \ skipping     #s  ok
@@ -3476,41 +3476,41 @@ s" 5"        ' number        cycle_test drop       CYCLES:   1650 ok
 5 5          ' over          cycle_test 2drop drop CYCLES:     48 ok
              ' pad           cycle_test drop       CYCLES:     36 ok
 \ skipping     page  ok
-             ' parse-name    cycle_test a 2drop    CYCLES:    409 ok
+             ' parse-name    cycle_test a 2drop    CYCLES:    408 ok
 char "       ' parse         cycle_test " 2drop    CYCLES:    210 ok
 5 0          ' pick          cycle_test 2drop      CYCLES:     42 ok
 5 5          ' +             cycle_test drop       CYCLES:     58 ok
 5 here       ' +!            cycle_test            CYCLES:     86 ok
 \ skipping     postpone  ok
-myvar        ' ?             cycle_test          5 CYCLES:   3746 ok
+myvar        ' ?             cycle_test          5 CYCLES:   3460 ok
 5            ' ?dup          cycle_test 2drop      CYCLES:     58 ok
 \ skipping     r>  ok
 \ skipping     recurse  ok
-             ' refill        cycle_test            CYCLES:    335 ok
+             ' refill        cycle_test            CYCLES:    319 ok
 drop \ refill  ok
 \ skipping     ]  ok
 5 5 5        ' rot           cycle_test 2drop drop CYCLES:     76 ok
 5 5          ' rshift        cycle_test drop       CYCLES:    126 ok
-             ' s"            cycle_test " 2drop    CYCLES:    541 ok
+             ' s"            cycle_test " 2drop    CYCLES:    476 ok
 5            ' s>d           cycle_test 2drop      CYCLES:     47 ok
 \ skipping     ;  ok
 \ skipping     sign  ok
 s" abc" 1    ' /string       cycle_test 2drop      CYCLES:     84 ok
 \ skipping     sliteral  ok
-5. 5         ' sm/rem        cycle_test 2drop      CYCLES:   1400 ok
+5. 5         ' sm/rem        cycle_test 2drop      CYCLES:   1336 ok
              ' source        cycle_test 2drop      CYCLES:     48 ok
              ' source-id     cycle_test drop       CYCLES:     30 ok
              ' space         cycle_test            CYCLES:     36 ok
 1            ' spaces        cycle_test            CYCLES:     80 ok
-5 5          ' *             cycle_test drop       CYCLES:    508 ok
+5 5          ' *             cycle_test drop       CYCLES:    492 ok
              ' state         cycle_test drop       CYCLES:     28 ok
 5 here       ' !             cycle_test            CYCLES:     65 ok
 5 5          ' swap          cycle_test 2drop      CYCLES:     60 ok
-             ' '             cycle_test aword drop CYCLES:   1993 ok
+             ' '             cycle_test aword drop CYCLES:   1956 ok
 \ postponing   to ( see value )  ok
-' aword      ' >body         cycle_test drop       CYCLES:   1490 ok
+' aword      ' >body         cycle_test drop       CYCLES:   1438 ok
              ' >in           cycle_test drop       CYCLES:     28 ok
-0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2432 ok
+0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2335 ok
 \ skipping     >r  ok
              ' true          cycle_test drop       CYCLES:     26 ok
 5 5          ' tuck          cycle_test 2drop drop CYCLES:     72 ok
@@ -3526,23 +3526,23 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  16673 ok
+             ' 2variable     cycle_test eword      CYCLES:  16598 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
-s" *"        ' type          cycle_test           *CYCLES:    123 ok
-5            ' u.            cycle_test          5 CYCLES:   3465 ok
+s" *"        ' type          cycle_test           *CYCLES:    125 ok
+5            ' u.            cycle_test          5 CYCLES:   3275 ok
 5 5          ' u>            cycle_test drop       CYCLES:     60 ok
 5 5          ' u<            cycle_test drop       CYCLES:     60 ok
              ' strip-underflow   cycle_test drop   CYCLES:     40 ok
-5. 5         ' um/mod        cycle_test 2drop      CYCLES:   1262 ok
+5. 5         ' um/mod        cycle_test 2drop      CYCLES:   1246 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    476 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  16919 ok
+5            ' value         cycle_test fword      CYCLES:  16849 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
-5            ' to            cycle_test fword      CYCLES:   1173 ok
-             ' variable      cycle_test gword      CYCLES:  16674 ok
+5            ' to            cycle_test fword      CYCLES:   1136 ok
+             ' variable      cycle_test gword      CYCLES:  16619 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
-char "       ' word          cycle_test "txt" drop CYCLES:    671 ok
+char "       ' word          cycle_test "txt" drop CYCLES:    620 ok
 \ skipping     words  ok
 ' aword      ' wordsize      cycle_test drop       CYCLES:     84 ok
 5 5          ' xor           cycle_test drop       CYCLES:     56 ok
@@ -3553,4 +3553,4 @@ char "       ' word          cycle_test "txt" drop CYCLES:    671 ok
 5            ' 0<            cycle_test drop       CYCLES:     47 ok
 5            ' 0<>           cycle_test drop       CYCLES:     48 ok
   ok
-bye c65: PC=f015 A=98 X=78 Y=01 S=f6 FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=147249414
+bye c65: PC=f015 A=98 X=78 Y=01 S=f6 FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=144841872

--- a/words/all.asm
+++ b/words/all.asm
@@ -27,6 +27,7 @@
 ;       use the 65c02 reset for that. Flows into ABORT.
 ;       """
 xt_cold:
+w_cold:
                 cld
 
                 ; Set the OUTPUT vector to the default kernel_putc
@@ -74,7 +75,7 @@ _load_user_vars_loop:
                 ; Copy the 0th element.
                 lda cold_user_table
                 sta (up)
-                jsr xt_cr
+                jsr w_cr
 
                 ; Define high-level words in forth_words.asc via EVALUATE,
                 ; followed by any user-defined words from user_words.asc.
@@ -97,7 +98,7 @@ _load_user_vars_loop:
                 lda #>(user_words_end-forth_words_start)
                 sta 1,x
 
-                jsr xt_evaluate
+                jsr w_evaluate
 
 .if TALI_OPTION_HISTORY
                 ; Initialize all of the history buffers by putting a zero in
@@ -123,6 +124,7 @@ _load_user_vars_loop:
         ; actually delete the stuff on the Data Stack.
         ; """
 xt_abort:
+w_abort:
                 ldx #dsp0
 
                 ; fall through to QUIT
@@ -134,6 +136,7 @@ xt_abort:
         ; Rest the input and start command loop
         ; """
 xt_quit:
+w_quit:
                 ; Clear the Return Stack. This is a little screwed up
                 ; because the 65c02 can only set the Return Stack via X,
                 ; which is our Data Stack pointer. The ANS specification
@@ -178,7 +181,7 @@ _get_line:
 
                 ; Accept a line from the current import source. This is how
                 ; modern Forths do it.
-                jsr xt_refill           ; ( -- f )
+                jsr w_refill           ; ( -- f )
 
                 ; Test flag: LSB of TOS
                 lda 0,x

--- a/words/assembler.asm
+++ b/words/assembler.asm
@@ -1054,8 +1054,8 @@ z_asm_back_jump:
 xt_asm_back_branch:
                 ; We arrive here with ( addr-l ) of the label on the stack and
                 ; then subtract the current address
-                jsr xt_here             ; ( addr-l addr-h )
-                jsr xt_minus            ; ( offset )
+                jsr w_here             ; ( addr-l addr-h )
+                jsr w_minus            ; ( offset )
 
                 ; We subtract two more because of the branch instruction itself
                 dea

--- a/words/compile.asm
+++ b/words/compile.asm
@@ -60,12 +60,12 @@
         ; """
 xt_compile_comma:
                 jsr underflow_1
-
+w_compile_comma:
                 ; See if this is an Always Native (AN) word by checking the
                 ; AN flag. We need nt for this.
-                jsr xt_dup              ; keep an unadjusted copy of xt
-                jsr xt_dup              ; plus one to convert to nt
-                jsr xt_int_to_name
+                jsr w_dup              ; keep an unadjusted copy of xt
+                jsr w_dup              ; plus one to convert to nt
+                jsr w_int_to_name
                 ; ( xt xt nt )
 
                 ; Does this xt even have a valid (non-zero) nt?
@@ -74,8 +74,8 @@ xt_compile_comma:
                 beq cmpl_as_call        ; No nt so unknown size; must compile as a JSR
 
                 ; Otherwise investigate the nt
-                jsr xt_dup
-                jsr xt_one_plus         ; status is at nt+1
+                jsr w_dup
+                jsr w_one_plus         ; status is at nt+1
                 ; ( xt xt nt nt+1 )
                 lda (0,x)               ; get status byte
                 inx                     ; drop pointer
@@ -86,7 +86,7 @@ xt_compile_comma:
                 bne cmpl_as_call        ; never native
 
                 ; ( xt xt nt )             ; maybe native, let's check
-                jsr xt_wordsize
+                jsr w_wordsize
                 ; ( xt xt u )
 
                 ; --- SPECIAL CASE 1: PREVENT RETURN STACK THRASHING ---
@@ -159,27 +159,27 @@ cmpl_as_call:
         ; Stack is either ( xt xt nt ) or ( xt xt' u )
         ; Use the xt or xt' (in the middle) as the jsr address
         ; so that strip-underflow is respected.
-                jsr xt_drop
-                jsr xt_nip
+                jsr w_drop
+                jsr w_nip
                 ; ( jsr_address -- )
                 lda #OpJSR
                 jsr cmpl_a
-                jsr xt_comma
+                jsr w_comma
                 sec
                 rts
 
 cmpl_inline:
         ; compile inline, returning C=1
                 ; ( xt xt' u -- )
-                jsr xt_here
-                jsr xt_swap
+                jsr w_here
+                jsr w_swap
                 ; ( xt xt' cp u -- )
-                jsr xt_dup
-                jsr xt_allot            ; allocate space for the word
+                jsr w_dup
+                jsr w_allot            ; allocate space for the word
                 ; Enough of this, let's move those bytes already!
                 ; ( xt xt' cp u ) on the stack at this point
-                jsr xt_move
-                jsr xt_drop             ; drop original xt
+                jsr w_move
+                jsr w_drop             ; drop original xt
                 clc
                 rts
 
@@ -273,7 +273,7 @@ z_compile_comma:
 ; =====================================================================
 ; COMPILE WORDS, JUMPS and SUBROUTINE JUMPS INTO CODE
 
-; These routines compile instructions such as "jsr xt_words" into a word
+; These routines compile instructions such as "jsr w_words" into a word
 ; at compile time so they are available at run time. Words that use this
 ; routine may not be natively compiled. We use "cmpl" as not to confuse these
 ; routines with the COMPILE, word.  Always call this with a subroutine jump.
@@ -324,7 +324,7 @@ cmpl_jump_tos:
     ; compile a jump to the address at TOS, consuming it
                 lda #OpJMP
                 jsr cmpl_a
-                jmp xt_comma
+                jmp w_comma
 
 
 cmpl_jump_later:
@@ -332,7 +332,7 @@ cmpl_jump_later:
     ; MSB with Y, LSB indeterminate, leaving address of the JMP target TOS
                 lda #OpJMP
                 jsr cmpl_a
-                jsr xt_here
+                jsr w_here
                 bra cmpl_word
 
 
@@ -358,9 +358,9 @@ _done:
 cmpl_0branch_later:
         ; compile a 0BRANCH where we don't know the target yet
         ; leaves pointer to the target on TOS
-                jsr xt_zero             ; dummy placeholder, which forces long jmp in native version
+                jsr w_zero             ; dummy placeholder, which forces long jmp in native version
                 jsr cmpl_0branch_tos    ; generate native or subroutine branch code
-                jsr xt_here             ; either way the target address is two bytes before here
+                jsr w_here             ; either way the target address is two bytes before here
                 sec
                 lda 0,x
                 sbc #2
@@ -384,7 +384,7 @@ cmpl_0branch_tos:
                 lda #<zero_branch_runtime
                 jsr cmpl_subroutine             ; call the 0branch runtime
 
-                jmp xt_comma                    ; add the payload and return
+                jmp w_comma                    ; add the payload and return
 
 _inline:
                 ; inline the test code
@@ -405,8 +405,8 @@ _inline:
                 beq _long               ; always use the long form if target is 0
 
                 ; ( addr )
-                jsr xt_dup
-                jsr xt_here
+                jsr w_dup
+                jsr w_here
                 clc
                 lda #2
                 adc 0,x
@@ -414,7 +414,7 @@ _inline:
                 bcc +
                 inc 1,x
 +
-                jsr xt_minus
+                jsr w_minus
                 ; ( addr offset )
                 ; offset is a signed byte if LSB bit 7 is 0 and MSB is 0 or bit 7 is 1 and MSB is #ff
                 inx             ; pre-drop offset and use wraparound indexing to preserve flags

--- a/words/core.asm
+++ b/words/core.asm
@@ -14,8 +14,9 @@
         ; """
 
 xt_abort_quote:
+w_abort_quote:
                 ; save the string
-                jsr xt_s_quote          ; S"
+                jsr w_s_quote          ; S"
 
                 ; compile run-time part
                 ldy #>abort_quote_runtime
@@ -34,9 +35,9 @@ abort_quote_runtime:
 
                 ; We're true, so print string and ABORT. We follow Gforth
                 ; in going to a new line after the string
-                jsr xt_type
-                jsr xt_cr
-                jmp xt_abort    ; not JSR, so never come back
+                jsr w_type
+                jsr w_cr
+                jmp w_abort    ; not JSR, so never come back
 _done:
                 ; Drop three entries from the Data Stack
                 txa
@@ -54,7 +55,7 @@ _done:
         ; """
 xt_abs:
                 jsr underflow_1
-
+w_abs:
                 lda 1,x
                 bpl _done       ; positive number, easy money!
 
@@ -82,7 +83,7 @@ z_abs:          rts
         ; """
 xt_accept:
                 jsr underflow_2
-
+w_accept:
                 ; Abort if we were asked to receive 0 chars
                 lda 0,x
                 ora 1,x
@@ -165,7 +166,7 @@ accept_loop:
                 bra _buffer_full
 
 _eol:
-                jsr xt_space    ; print final space
+                jsr w_space    ; print final space
 
 _buffer_full:
                 ; REFILL updates ciblen and toin, we don't need to do it here
@@ -389,6 +390,7 @@ accept_total_recall:
 ; ## "action-of"  auto  ANS core ext
         ; """http://forth-standard.org/standard/core/ACTION-OF"""
 xt_action_of:
+w_action_of:
                 ; This is a state aware word with differet behavior
                 ; when used while compiling vs interpreting.
                 ; Check STATE
@@ -398,17 +400,17 @@ xt_action_of:
 
                 ; Run ['] to compile the xt of the next word
                 ; as a literal.
-                jsr xt_bracket_tick
+                jsr w_bracket_tick
 
                 ; Postpone DEFER@ by compiling a JSR to it.
-                ldy #>xt_defer_fetch
-                lda #<xt_defer_fetch
+                ldy #>w_defer_fetch
+                lda #<w_defer_fetch
                 jsr cmpl_subroutine
                 bra _done
 
 _interpreting:
-                jsr xt_tick
-                jsr xt_defer_fetch
+                jsr w_tick
+                jsr w_defer_fetch
 
 _done:
 z_action_of:           rts
@@ -419,7 +421,7 @@ z_action_of:           rts
         ; """https://forth-standard.org/standard/core/AGAIN"""
 xt_again:
                 jsr underflow_1
-
+w_again:
                 ; Compile a JMP back to TOS address.
                 jsr cmpl_jump_tos
 
@@ -441,6 +443,8 @@ z_again:        rts
         ; """https://forth-standard.org/standard/core/ALIGNED"""
 xt_align:
 xt_aligned:
+w_align:
+w_aligned:
 z_align:
 z_aligned:
                 rts             ; stripped out during native compile
@@ -458,7 +462,7 @@ z_aligned:
         ; """
 xt_allot:
                 jsr underflow_1
-
+w_allot:
                 ; Releasing memory is going to be a very rare operation,
                 ; so we check for it at the beginning and try to make
                 ; the most common case as fast as possible
@@ -518,7 +522,7 @@ _release:
                 lda cp+1
                 sta 1,x
 
-                jsr xt_plus                     ; new CP is now TOS
+                jsr w_plus                     ; new CP is now TOS
 
                 ; Second step, see if we've gone too far. We compare the new
                 ; CP on TOS (which, if we've really screwed up, might be
@@ -574,7 +578,7 @@ z_allot:
         ; """https://forth-standard.org/standard/core/AND"""
 xt_and:
                 jsr underflow_2
-
+w_and:
                 lda 0,x
                 and 2,x
                 sta 2,x
@@ -601,7 +605,7 @@ z_and:          rts
         ; """
 xt_at_xy:
                 jsr underflow_2
-
+w_at_xy:
                 ; Save the BASE and change to decimal as the ANSI escape code
                 ; values need to be in decimal.
                 lda base
@@ -613,11 +617,11 @@ xt_at_xy:
                 jsr emit_a
                 lda #'['
                 jsr emit_a
-                jsr xt_one_plus ; AT-XY is zero based, but ANSI is 1 based
+                jsr w_one_plus ; AT-XY is zero based, but ANSI is 1 based
                 jsr print_u
                 lda #';'
                 jsr emit_a
-                jsr xt_one_plus ; AT-XY is zero based, but ANSI is 1 based
+                jsr w_one_plus ; AT-XY is zero based, but ANSI is 1 based
                 jsr print_u
                 lda #'H'
                 jsr emit_a
@@ -634,6 +638,7 @@ z_at_xy:        rts
 ; ## "\"  auto  ANS block ext
         ; """https://forth-standard.org/standard/block/bs"""
 xt_backslash:
+w_backslash:
                 ; Check BLK to see if we are interpreting a block
                 ldy #blk_offset
                 lda (up),y
@@ -684,6 +689,7 @@ z_backslash:    rts
         ; ingore the MSB
         ; """
 xt_base:
+w_base:
                 dex
                 dex
                 lda #<base
@@ -709,6 +715,7 @@ z_base:         rts
 ; ## "bl"  auto  ANS core
         ; """https://forth-standard.org/standard/core/BL"""
 xt_bl:
+w_bl:
                 dex
                 dex
                 lda #AscSP
@@ -730,8 +737,9 @@ z_bl:           rts
         ; : [CHAR]  CHAR POSTPONE LITERAL ; IMMEDIATE
         ; """
 xt_bracket_char:
-                jsr xt_char
-                jsr xt_literal
+w_bracket_char:
+                jsr w_char
+                jsr w_literal
 z_bracket_char: rts
 
 
@@ -740,8 +748,9 @@ z_bracket_char: rts
 ; ## "[']"  auto  ANS core
         ; """https://forth-standard.org/standard/core/BracketTick"""
 xt_bracket_tick:
-                jsr xt_tick
-                jsr xt_literal
+w_bracket_tick:
+                jsr w_tick
+                jsr w_literal
 z_bracket_tick: rts
 
 
@@ -753,8 +762,9 @@ z_bracket_tick: rts
                 ; when its name is used.
                 ; """
 xt_buffer_colon:
-                jsr xt_create
-                jsr xt_allot
+w_buffer_colon:
+                jsr w_create
+                jsr w_allot
 z_buffer_colon: rts
 
 
@@ -764,7 +774,7 @@ z_buffer_colon: rts
         ; """https://forth-standard.org/standard/core/CComma"""
 xt_c_comma:
                 jsr underflow_1
-
+w_c_comma:
                 lda 0,x
                 jsr cmpl_a
 
@@ -780,7 +790,7 @@ z_c_comma:      rts
         ; """https://forth-standard.org/standard/core/CFetch"""
 xt_c_fetch:
                 jsr underflow_1
-
+w_c_fetch:
                 lda (0,x)
                 sta 0,x
                 stz 1,x         ; Ignore LSB
@@ -794,7 +804,7 @@ z_c_fetch:      rts
         ; """https://forth-standard.org/standard/core/CStore"""
 xt_c_store:
                 jsr underflow_2
-
+w_c_store:
                 lda 2,x
                 sta (0,x)
 
@@ -824,7 +834,7 @@ z_c_store:      rts
         ; """
 xt_cell_plus:
                 jsr underflow_1
-
+w_cell_plus:
                 inc 0,x
                 bne +
                 inc 1,x
@@ -851,8 +861,9 @@ z_cell_plus:    rts
 ; ## "char"  auto  ANS core
         ; """https://forth-standard.org/standard/core/CHAR"""
 xt_char:
+w_char:
                 ; get character from string, returns ( addr u )
-                jsr xt_parse_name
+                jsr w_parse_name
 
                 ; if we got back a zero, we have a problem
                 lda 0,x
@@ -895,7 +906,7 @@ xt_chars:
                 ; should be warned that there is something wrong with the
                 ; code if this occurs.
                 jsr underflow_1
-
+w_chars:
 z_chars:        rts
 
 
@@ -907,6 +918,7 @@ z_chars:        rts
         ; Use the CREATE routine and fill in the rest by hand.
         ; """
 xt_colon:
+w_colon:
                 ; If we're already in the compile state, complain
                 ; and quit
                 lda state
@@ -941,7 +953,7 @@ xt_colon:
                 lda #%10000000
                 tsb status
 
-                jsr xt_create
+                jsr w_create
 
                 ; Get the nt (not the xt!) of the new word as described above.
                 ; Only COLON, SEMICOLON and RECURSE get to access WORKWORD
@@ -977,6 +989,7 @@ z_colon:        rts
         ; Compile a word with no nt.  ";" will put its xt on the stack.
         ; """
 xt_colon_noname:
+w_colon_noname:
                 ; If we're already in the compile state, complain
                 ; and quit
                 lda state
@@ -1015,7 +1028,7 @@ z_colon_noname:        rts
         ; """
 xt_comma:
                 jsr underflow_1
-
+w_comma:
                 ldy #2
 _twice:         lda 0,x
                 jsr cmpl_a
@@ -1036,6 +1049,7 @@ z_comma:        rts
         ; ?COMPILE that makes sure  we're in compile mode
         ; """
 xt_compile_only:
+w_compile_only:
                 jsr current_to_dp
                 ldy #1          ; offset for status byte
                 lda (dp),y
@@ -1058,8 +1072,9 @@ z_compile_only: rts
 xt_value:
 xt_constant:
                 jsr underflow_1
-
-                jsr xt_create
+w_value:
+w_constant:
+                jsr w_create
 
             	; CREATE by default installs a subroutine jump to DOVAR,
                 ; but we want DOCONST for constants. Go back two bytes and
@@ -1079,14 +1094,14 @@ xt_constant:
                 sta (tmp1),y
 
                 ; Now we save the constant number itself in the next cell
-                jsr xt_comma            ; drop through to adjust_z
+                jsr w_comma            ; drop through to adjust_z
 
 adjust_z:
                 ; Now the length of the complete word (z_word) has increased by
                 ; two. We need to update that number or else words such as SEE
                 ; will ignore the PFA. We use this same routine for VARIABLE,
                 ; VALUE and DEFER
-                jsr xt_latestnt         ; gives us ( -- nt )
+                jsr w_latestnt         ; gives us ( -- nt )
 
                 ; z_word is six bytes further down
                 lda 0,x
@@ -1123,7 +1138,7 @@ z_constant:     rts
         ; """
 xt_count:
                 jsr underflow_1
-
+w_count:
                 lda (0,x)       ; Get number of characters (255 max)
                 tay
 
@@ -1147,7 +1162,7 @@ z_count:        rts
 ; ## "cr"  auto  ANS core
         ; """https://forth-standard.org/standard/core/CR"""
 xt_cr:
-
+w_cr:
 .if "cr" in TALI_OPTION_CR_EOL
                 lda #AscCR
                 jsr emit_a
@@ -1166,8 +1181,9 @@ z_cr:           rts
         ; See the drawing in headers.asm for details on the header
         ; """
 xt_create:
+w_create:
                 ; get string
-                jsr xt_parse_name       ; ( addr u )
+                jsr w_parse_name       ; ( addr u )
 
                 ; if we were given an empty string, we complain and quit
                 lda 0,x
@@ -1185,8 +1201,8 @@ _got_name:
                 stz 1,x
 
                 ; Check to see if this name already exists.
-                jsr xt_two_dup          ; ( addr u addr u )
-                jsr xt_find_name        ; ( addr u flag ) (non-zero nt as flag)
+                jsr w_two_dup          ; ( addr u addr u )
+                jsr w_find_name        ; ( addr u flag ) (non-zero nt as flag)
 
                 lda 0,x
                 ora 1,x
@@ -1214,9 +1230,9 @@ _redefined_name:
                 lda #str_redefined
                 jsr print_string_no_lf
 
-                jsr xt_two_dup           ; ( addr u addr u )
-                jsr xt_type
-                jsr xt_space
+                jsr w_two_dup           ; ( addr u addr u )
+                jsr w_type
+                jsr w_space
 
                 bra _process_name
 
@@ -1252,7 +1268,7 @@ _process_name:
                 ; We'll compile the CFA later
                 sta 0,x
                 stz 1,x         ; max header size is 255 chars
-                jsr xt_allot    ; ( addr )
+                jsr w_allot    ; ( addr )
 
                 ; Get the CURRENT dictionary pointer.
                 jsr current_to_dp
@@ -1384,6 +1400,7 @@ z_create:       rts
 ; ## "decimal"  auto  ANS core
         ; """https://forth-standard.org/standard/core/DECIMAL"""
 xt_decimal:
+w_decimal:
                 lda #10
                 sta base
                 stz base+1              ; paranoid
@@ -1401,7 +1418,8 @@ z_decimal:      rts
         ; But we use this routine as a low-level word so things go faster
 
 xt_defer:
-                jsr xt_create
+w_defer:
+                jsr w_create
 
                 ; CREATE by default installs a subroutine jump to DOVAR,
                 ; but we actually want DODEFER this time. Go back two
@@ -1450,9 +1468,10 @@ z_defer:        rts
         ; """http://forth-standard.org/standard/core/DEFERFetch"""
 
 xt_defer_fetch:
-                ; No underflow checking as >BODY does it.
-                jsr xt_to_body
-                jsr xt_fetch
+                jsr underflow_1
+w_defer_fetch:
+                jsr w_to_body
+                jsr w_fetch
 z_defer_fetch:  rts
 
 
@@ -1462,9 +1481,10 @@ z_defer_fetch:  rts
         ; """http://forth-standard.org/standard/core/DEFERStore"""
 
 xt_defer_store:
-                ; No underflow checking as >BODY and ! do it.
-                jsr xt_to_body
-                jsr xt_store
+                jsr underflow_2
+w_defer_store:
+                jsr w_to_body
+                jsr w_store
 z_defer_store:  rts
 
 
@@ -1473,6 +1493,7 @@ z_defer_store:  rts
 ; ## "depth"  auto  ANS core
         ; """https://forth-standard.org/standard/core/DEPTH"""
 xt_depth:
+w_depth:
                 lda #dsp0
                 stx tmpdsp
                 sec
@@ -1490,10 +1511,11 @@ z_depth:        rts
 
 
 
-; ## QUESTION_DO ( limit start -- ) "Conditional loop start"
+; ## QUESTION_DO (C: -- ) ( limit start -- ) "Conditional loop start"
 ; ## "?do"  auto  ANS core ext
         ; """https://forth-standard.org/standard/core/qDO"""
 xt_question_do:
+w_question_do:
                 ; ?DO shares most of its code with DO.
                 ; But first compile its runtime.
                 dex
@@ -1502,7 +1524,7 @@ xt_question_do:
                 sta 0,x
                 lda #>question_do_runtime
                 sta 1,x
-                jsr xt_dup              ; xt and xt' are the same
+                jsr w_dup              ; xt and xt' are the same
                 dex
                 dex
                 lda #question_do_runtime_size
@@ -1512,9 +1534,9 @@ xt_question_do:
                 bcc _native
 
                 ; for subroutine compile, write placeholder for jmp-target and save its address
-                jsr xt_here
-                jsr xt_zero
-                jsr xt_comma
+                jsr w_here
+                jsr w_zero
+                jsr w_comma
                 bra do_common
 
 _native:
@@ -1523,7 +1545,7 @@ _native:
                 bra do_common
 
 
-; ## DO ( limit start -- )  "Start a loop"
+; ## DO (C: -- ) ( limit start -- )  "Start a loop"
 ; ## "do"  auto  ANS core
         ; """https://forth-standard.org/standard/core/DO
         ;
@@ -1536,7 +1558,8 @@ _native:
         ; """
 
 xt_do:
-                jsr xt_zero             ; push 0 TOS
+w_do:
+                jsr w_zero             ; push 0 TOS
 
 do_common:
                 ; the stack is ( 0 | jmp-target ) depending
@@ -1574,7 +1597,7 @@ do_common:
                 ; to the Data Stack so LOOP/+LOOP knows where to repeat back
                 ; ( qdo-skip old-loopleave repeat-addr )
 
-                jmp xt_here
+                jmp w_here
 z_question_do:
 z_do:
 
@@ -1678,6 +1701,7 @@ do_runtime:
         ; """
 
 xt_does:
+w_does:
                 ; compile a subroutine jump to runtime of DOES>
                 ldy #>does_runtime
                 lda #<does_runtime
@@ -1755,17 +1779,17 @@ does_runtime:
 
 xt_dot:
                 jsr underflow_1
-
-                jsr xt_dup                      ; ( n n )
-                jsr xt_abs                      ; ( n u )
-                jsr xt_zero                     ; ( n u 0 )
-                jsr xt_less_number_sign         ; ( n u 0 )
-                jsr xt_number_sign_s            ; ( n ud )
-                jsr xt_rot                      ; ( ud n )
-                jsr xt_sign                     ; ( ud )
-                jsr xt_number_sign_greater      ; ( addr u )
-                jsr xt_type
-                jsr xt_space
+w_dot:
+                jsr w_dup                      ; ( n n )
+                jsr w_abs                      ; ( n u )
+                jsr w_zero                     ; ( n u 0 )
+                jsr w_less_number_sign         ; ( n u 0 )
+                jsr w_number_sign_s            ; ( n ud )
+                jsr w_rot                      ; ( ud n )
+                jsr w_sign                     ; ( ud )
+                jsr w_number_sign_greater      ; ( addr u )
+                jsr w_type
+                jsr w_space
 
 z_dot:          rts
 
@@ -1776,6 +1800,7 @@ z_dot:          rts
         ; """http://forth-standard.org/standard/core/Dotp"""
 
 xt_dot_paren:
+w_dot_paren:
                 ; Put a right paren on the stack.
                 dex
                 dex
@@ -1783,8 +1808,8 @@ xt_dot_paren:
                 sta 0,x
                 stz 1,x
 
-                jsr xt_parse
-                jsr xt_type
+                jsr w_parse
+                jsr w_type
 
 z_dot_paren:    rts
 
@@ -1800,14 +1825,15 @@ z_dot_paren:    rts
         ; """
 
 xt_dot_quote:
+w_dot_quote:
                 ; we let S" do the heavy lifting. Since we're in
                 ; compile mode, it will save the string and reproduce it
                 ; during runtime
-                jsr xt_s_quote
+                jsr w_s_quote
 
                 ; We then let TYPE do the actual printing
-                ldy #>xt_type
-                lda #<xt_type
+                ldy #>w_type
+                lda #<w_type
                 jsr cmpl_subroutine
 
 z_dot_quote:    rts
@@ -1824,21 +1850,21 @@ z_dot_quote:    rts
 
 xt_dot_r:
                 jsr underflow_2
-
-                jsr xt_to_r
-                jsr xt_dup
-                jsr xt_abs
-                jsr xt_zero
-                jsr xt_less_number_sign
-                jsr xt_number_sign_s
-                jsr xt_rot
-                jsr xt_sign
-                jsr xt_number_sign_greater
-                jsr xt_r_from
-                jsr xt_over
-                jsr xt_minus
-                jsr xt_spaces
-                jsr xt_type
+w_dot_r:
+                jsr w_to_r
+                jsr w_dup
+                jsr w_abs
+                jsr w_zero
+                jsr w_less_number_sign
+                jsr w_number_sign_s
+                jsr w_rot
+                jsr w_sign
+                jsr w_number_sign_greater
+                jsr w_r_from
+                jsr w_over
+                jsr w_minus
+                jsr w_spaces
+                jsr w_type
 
 z_dot_r:        rts
 
@@ -1849,7 +1875,7 @@ z_dot_r:        rts
         ; """https://forth-standard.org/standard/core/DROP"""
 xt_drop:
                 jsr underflow_1
-
+w_drop:
                 inx
                 inx
 
@@ -1862,7 +1888,7 @@ z_drop:         rts
         ; """https://forth-standard.org/standard/core/DUP"""
 xt_dup:
                 jsr underflow_1
-
+w_dup:
                 dex
                 dex
 
@@ -1884,16 +1910,20 @@ z_dup:          rts
 
 xt_else:
 xt_endof:
+                jsr underflow_1
+w_else:
+w_endof:
                 ; Add an unconditional branch with target filled in later
                 jsr cmpl_jump_later
 
                 ; stash the branch target for later
                 ; and then calculate the forward branch from orig
-                jsr xt_swap         ; ( target orig )
-
-                ; fall through to xt_then
+                jsr w_swap              ; ( target orig )
+                bra w_then              ; fall through to then
 
 xt_then:
+                jsr underflow_1
+w_then:
                 ; (C: orig -- ) ( -- )
 
                 ; This is a compile-time word that writes the target address
@@ -1907,9 +1937,9 @@ xt_then:
 
                 ; Just stuff HERE in for the branch address back
                 ; at the IF or ELSE (origination address is on stack).
-                jsr xt_here
-                jsr xt_swap
-                jsr xt_store
+                jsr w_here
+                jsr w_swap
+                jsr w_store
 
 z_else:
 z_endof:
@@ -1928,7 +1958,7 @@ z_then:         rts
 
 xt_emit:
                 jsr underflow_1
-
+w_emit:
                 lda 0,x
                 inx
                 inx
@@ -1949,10 +1979,12 @@ z_emit:         ; never reached
         ; """http://forth-standard.org/standard/core/ENDCASE"""
 
 xt_endcase:
+                jsr underflow_1
+w_endcase:
                 ; Postpone DROP to remove the item
                 ; being checked.
-                ldy #>xt_drop
-                lda #<xt_drop
+                ldy #>w_drop
+                lda #<w_drop
                 jsr cmpl_subroutine
 
                 ; There are a number of address (of branches that need their
@@ -1965,7 +1997,7 @@ _endcase_loop:
                 ora 1,x
                 beq _done
 
-                jsr xt_then
+                jsr w_then
                 bra _endcase_loop
 _done:
                 ; Remove the 0 from the stack.
@@ -2020,7 +2052,7 @@ z_endcase:      rts
         ; """
 xt_environment_q:
                 jsr underflow_1
-
+w_environment_q:
                 ; This code is table-driven: We walk through the list of
                 ; strings until we find one that matches, and then we take
                 ; the equivalent data from the results table. This is made
@@ -2038,7 +2070,7 @@ xt_environment_q:
 _table_loop:
                 ; We arrived here with the address of the string to be checked
                 ; on the stack. We make a copy. Index is in Y
-                jsr xt_two_dup          ; ( addr u addr u ) 2DUP does not use Y
+                jsr w_two_dup          ; ( addr u addr u ) 2DUP does not use Y
 
                 ; We do our work on the TOS to speed things up
                 dex
@@ -2060,8 +2092,8 @@ _table_loop:
                 ; old-style address format, that is, the first byte is the
                 ; length of the string
                 phy                     ; save Y, which is used by COUNT
-                jsr xt_count            ; ( addr u addr u addr-s u-s )
-                jsr xt_compare          ; ( addr u f )
+                jsr w_count            ; ( addr u addr u addr-s u-s )
+                jsr w_compare          ; ( addr u f )
                 ply
 
                 ; If we found a match (flag is zero -- COMPARE is weird
@@ -2170,7 +2202,7 @@ _no_match:
                 adc #10
                 tax                     ; ( addr ) - not ( 0 ) !
 
-                jsr xt_false
+                jsr w_false
 _done:
 z_environment_q:
                 rts
@@ -2216,7 +2248,7 @@ env_results_double:
 
 xt_equal:
                 jsr underflow_2
-
+w_equal:
                 lda 0,x                 ; LSB
                 cmp 2,x
                 bne _false
@@ -2244,15 +2276,14 @@ z_equal:        rts
 ; ## "blank"  auto  ANS string
         ; """https://forth-standard.org/standard/string/BLANK"""
 xt_blank:
-                ; We don't check for underflow here because
-                ; we deal with that in FILL
+                jsr underflow_2
+w_blank:
                 dex
                 dex
                 lda #AscSP
                 sta 0,x
                 stz 1,x
-
-                bra xt_fill     ; skip over code for ERASE
+                bra w_fill     ; skip over code for ERASE
 
 
 ; ## ERASE ( addr u -- ) "Fill memory region with zeros"
@@ -2263,14 +2294,15 @@ xt_blank:
         ; """
 
 xt_erase:
-                ; We don't check for underflow here because
-                ; we deal with that in FILL
+                jsr underflow_2
+w_erase:
                 dex
                 dex
                 stz 0,x
                 stz 1,x
 
                 ; fall through to FILL
+                bra w_fill
 
 ; ## FILL ( addr u char -- ) "Fill a memory region with a character"
 ; ## "fill"  auto  ANS core
@@ -2282,7 +2314,7 @@ xt_erase:
         ; """
 xt_fill:
                 jsr underflow_3
-
+w_fill:
                 ; We use tmp1 to hold the address
                 lda 4,x         ; LSB
                 sta tmp1
@@ -2353,7 +2385,7 @@ z_fill:         rts
         ; """https://forth-standard.org/standard/core/EXECUTE"""
 xt_execute:
                 jsr underflow_1
-
+w_execute:
                 jsr doexecute   ; do not combine to JMP (native coding)
 
 z_execute:      rts
@@ -2383,6 +2415,7 @@ doexecute:
         ; """
 
 xt_exit:
+w_exit:
                 rts             ; keep before z_exit
 z_exit:                         ; never reached
 
@@ -2400,7 +2433,7 @@ z_exit:                         ; never reached
         ; """https://forth-standard.org/standard/core/Fetch"""
 xt_fetch:
                 jsr underflow_1
-
+w_fetch:
                 lda (0,x)               ; LSB
                 tay
                 inc 0,x
@@ -2429,7 +2462,7 @@ z_fetch:        rts
 
 xt_find:
                 jsr underflow_1
-
+w_find:
                 ; Save address in case conversion fails. We use the
                 ; Return Stack instead of temporary variables like TMP1
                 ; because this is shorter and anybody still using FIND
@@ -2441,8 +2474,8 @@ xt_find:
 
                 ; Convert ancient-type counted string address to
                 ; modern format
-                jsr xt_count            ; ( caddr -- addr u )
-                jsr xt_find_name        ; ( addr u -- nt | 0 )
+                jsr w_count            ; ( caddr -- addr u )
+                jsr w_find_name        ; ( addr u -- nt | 0 )
 
                 lda 0,x
                 ora 1,x
@@ -2450,7 +2483,7 @@ xt_find:
 
                 ; No word found. Return address of the string and a false
                 ; flag
-                jsr xt_false            ; ( 0 0 )
+                jsr w_false            ; ( 0 0 )
 
                 ; The address needs to be restored.
                 pla                     ; LSB of address
@@ -2467,9 +2500,9 @@ _found_word:
 
                 ; We arrive here with ( nt ) on the TOS. Now we have to
                 ; convert the return values to FIND's format
-                jsr xt_dup              ; ( nt nt )
-                jsr xt_name_to_int      ; ( nt xt )
-                jsr xt_swap             ; ( xt nt )
+                jsr w_dup              ; ( nt nt )
+                jsr w_name_to_int      ; ( nt xt )
+                jsr w_swap             ; ( xt nt )
 
                 ldy #0                  ; Prepare flag
 
@@ -2511,17 +2544,17 @@ z_find:         rts
 
 xt_fm_slash_mod:
                 jsr underflow_3
-
+w_fm_slash_mod:
                 ; if sign of n1 is negative, negate both n1 and d
                 stz tmp2        ; default: n is positive
                 lda 1,x         ; MSB of n1
                 bpl _check_d
 
                 inc tmp2        ; set flag to negative for n1
-                jsr xt_negate   ; NEGATE
-                jsr xt_to_r     ; >R
-                jsr xt_dnegate  ; DNEGATE
-                jsr xt_r_from   ; R>
+                jsr w_negate   ; NEGATE
+                jsr w_to_r     ; >R
+                jsr w_dnegate  ; DNEGATE
+                jsr w_r_from   ; R>
 
 _check_d:
                 ; If d is negative, add n1 to high cell of d
@@ -2538,7 +2571,7 @@ _check_d:
                 sta 3,x
 
 _multiply:
-                jsr xt_um_slash_mod     ; ( d n1 -- rem n2 )
+                jsr w_um_slash_mod     ; ( d n1 -- rem n2 )
 
                 ; if n was negative, negate the result
                 lda tmp2
@@ -2546,7 +2579,7 @@ _multiply:
 
                 inx             ; pretend that we SWAP
                 inx
-                jsr xt_negate
+                jsr w_negate
                 dex
                 dex
 _done:
@@ -2576,7 +2609,7 @@ load_evaluate:
 
 xt_evaluate:
                 jsr underflow_2
-
+w_evaluate:
                 ; Clear the flag to zero BLK.  Only LOAD will set the flag,
                 ; and will set the block number.
                 stz tmp1
@@ -2617,7 +2650,7 @@ evaluate_got_work:
 
 _nozero:
                 ; Save the input state to the Return Stack
-                jsr xt_input_to_r
+                jsr w_input_to_r
 
                 ; set SOURCE-ID to -1
                 lda #$FF
@@ -2647,7 +2680,7 @@ _nozero:
                 jsr interpret   ; ( -- )
 
                 ; restore variables
-                jsr xt_r_to_input
+                jsr w_r_to_input
 
                 ; Restore BLK from the return stack.
                 ldy #blk_offset
@@ -2668,7 +2701,7 @@ z_evaluate:     rts
 
 xt_greater_than:
                 jsr underflow_2
-
+w_greater_than:
                 ldy #0          ; default false
                 jsr compare_16bit
 
@@ -2699,6 +2732,9 @@ z_greater_than: rts
 xt_here:
 xt_begin:
 xt_asm_arrow:
+w_here:
+w_begin:
+w_asm_arrow:
                 dex
                 dex
                 lda cp
@@ -2717,6 +2753,7 @@ z_asm_arrow:
 ; ## "hex"  auto  ANS core ext
         ; """https://forth-standard.org/standard/core/HEX"""
 xt_hex:
+w_hex:
                 lda #16
                 sta base
                 stz base+1              ; paranoid
@@ -2737,7 +2774,7 @@ z_hex:          rts
         ; """
 xt_hold:
                 jsr underflow_1
-
+w_hold:
                 lda tohold
                 bne +
                 dec tohold+1
@@ -2763,6 +2800,7 @@ z_hold:         rts
         ; """
 
 xt_i:
+w_i:
                 dex
                 dex
 
@@ -2787,6 +2825,7 @@ z_i:            rts
         ; """http://forth-standard.org/standard/core/IF"""
 
 xt_if:
+w_if:
                 jsr cmpl_0branch_later
 z_if:           rts
 
@@ -2801,6 +2840,7 @@ z_if:           rts
         ; error message.
         ; """
 xt_immediate:
+w_immediate:
                 jsr current_to_dp
                 ldy #1          ; offset for status byte
                 lda (dp),y
@@ -2816,7 +2856,7 @@ z_immediate:    rts
         ; """https://forth-standard.org/standard/core/INVERT"""
 xt_invert:
                 jsr underflow_1
-
+w_invert:
                 lda #$FF
                 eor 0,x         ; LSB
                 sta 0,x
@@ -2829,11 +2869,12 @@ z_invert:       rts
 
 
 
-; ## IS ( xt "name" -- ) "Set named word to execute xt"
+; ## IS ( xt "name" -- ) or (C: "name" ) "Set named word to execute xt"
 ; ## "is"  auto  ANS core ext
         ; """http://forth-standard.org/standard/core/IS"""
 
 xt_is:
+w_is:
                 ; This is a state aware word with differet behavior
                 ; when used while compiling vs interpreting.
                 ; Check STATE
@@ -2842,18 +2883,18 @@ xt_is:
                 beq _interpreting
 
                 ; Run ['] to compile the xt of the next word as a literal.
-                jsr xt_bracket_tick
+                jsr w_bracket_tick
 
                 ; Postpone DEFER! by compiling a JSR to it.
-                ldy #>xt_defer_store
-                lda #<xt_defer_store
+                ldy #>w_defer_store
+                lda #<w_defer_store
                 jsr cmpl_subroutine
 
                 bra _done
 
 _interpreting:
-                jsr xt_tick
-                jsr xt_defer_store
+                jsr w_tick
+                jsr w_defer_store
 _done:
 z_is:           rts
 
@@ -2870,6 +2911,7 @@ z_is:           rts
         ; """
 
 xt_j:
+w_j:
                 dex                 ; make space on the stack
                 dex
 
@@ -2892,6 +2934,7 @@ z_j:            rts
 ; ## KEY ( -- char ) "Get one character from the input"
 ; ## "key"  tested  ANS core
 xt_key:
+w_key:
         ; """https://forth-standard.org/standard/core/KEY
         ; Get a single character of input from the vectored
         ; input without echoing.
@@ -2917,6 +2960,7 @@ key_a:
 ; ## KEY? ( -- char ) "Return true if a character is available"
 ; ## "key?"  tested  ANS core
 xt_keyq:
+w_keyq:
         ; """https://forth-standard.org/standard/core/KEYq
         ; Check if a key is available from the vectored havekey.
         ; Use KEY to fetch it.
@@ -2950,6 +2994,7 @@ keyq_a:         jmp (havekey)
         ; """
 
 xt_leave:
+w_leave:
                 ; LEAVE will eventually jump forward to the unloop.
                 ; We don't know where that is at compile time
                 ; so we'll write a JMP to be patched later.
@@ -2982,6 +3027,7 @@ z_leave:
         ; This is an immediate and compile-only word
         ; """
 xt_left_bracket:
+w_left_bracket:
                 stz state
                 stz state+1
 
@@ -3007,7 +3053,8 @@ z_left_bracket: rts
         ; internal variable tohold instead of HLD.
         ; """
 xt_less_number_sign:
-                jsr xt_pad      ; ( addr )
+w_less_number_sign:
+                jsr w_pad      ; ( addr )
 
                 lda 0,x
                 sta tohold
@@ -3028,7 +3075,7 @@ z_less_number_sign:
 
 xt_less_than:
                 jsr underflow_2
-
+w_less_than:
                 ldy #0          ; default false
                 jsr compare_16bit
 
@@ -3061,7 +3108,7 @@ z_less_than:    rts
         ; """
 xt_literal:
                 jsr underflow_1
-
+w_literal:
                 lda #template_push_tos_size
                 jsr check_nc_limit
                 bcc _inline
@@ -3072,7 +3119,7 @@ xt_literal:
 
                 ; Compile the value that is to be pushed on the Stack during
                 ; runtime
-                jsr xt_comma
+                jsr w_comma
                 bra z_literal
 
 _inline:
@@ -3167,6 +3214,7 @@ literal_runtime:
         ;       IMMEDIATE ; COMPILE-ONLY
         ; """
 xt_loop:
+w_loop:
                 ; Compile LOOP-specific runtime
                 dex
                 dex
@@ -3181,7 +3229,7 @@ xt_loop:
                 stz 1,x
 
                 ; Now compile the runtime shared with +LOOP
-                bra xt_loop_common
+                bra loop_common
 
 
 
@@ -3199,6 +3247,7 @@ xt_loop:
         ; """
 
 xt_plus_loop:
+w_plus_loop:
                 ; Compile +LOOP-specific runtime
                 dex
                 dex
@@ -3214,9 +3263,9 @@ xt_plus_loop:
 
                 ; fall through to shared runtime
 
-xt_loop_common:
-                jsr xt_over
-                jsr xt_swap             ; xt and xt' are the same
+loop_common:
+                jsr w_over
+                jsr w_swap             ; xt and xt' are the same
                 ; ( xt xt u )
                 jsr cmpl_by_limit
 
@@ -3226,7 +3275,7 @@ xt_loop_common:
                 bcc _native
 
                 ; if non-native, just write repeat-addr as payload after the call
-                jsr xt_comma
+                jsr w_comma
                 bra +
 
 _native:
@@ -3268,11 +3317,11 @@ _noleave:
                 ; reuse TOS
 
                 ; Clean up the loop params by appending unloop
-                lda #<xt_unloop
+                lda #<w_unloop
                 sta 0,x
-                lda #>xt_unloop
+                lda #>w_unloop
                 sta 1,x
-                jsr xt_compile_comma
+                jsr w_compile_comma
 
                 ; Finally we're left with qdo-skip which either
                 ; points at ?DO's "skip the loop" jmp address,
@@ -3280,9 +3329,9 @@ _noleave:
                 ; or has MSB=0 from DO which we can just ignore
                 lda 1,x                 ; MSB=0 means DO so nothing to do
                 beq +
-                jsr xt_here
-                jsr xt_swap
-                jmp xt_store            ; write here as ?DO jmp target and return
+                jsr w_here
+                jsr w_swap
+                jmp w_store            ; write here as ?DO jmp target and return
 
 +               inx                     ; drop the ignored word for DO
                 inx
@@ -3370,7 +3419,7 @@ _done:          lda #1
 
 xt_lshift:
                 jsr underflow_2
-
+w_lshift:
                 ; max shift 16 times
                 lda 0,x
                 and #%00001111
@@ -3404,7 +3453,7 @@ z_lshift:       rts
 
 xt_m_star:
                 jsr underflow_2
-
+w_m_star:
                 ; figure out the sign
                 lda 1,x         ; MSB of n1
                 eor 3,x         ; MSB of n2
@@ -3416,17 +3465,17 @@ xt_m_star:
 
                 ; get the absolute value of both numbers so we can feed
                 ; them to UM*, which does the real work
-                jsr xt_abs
-                jsr xt_swap
-                jsr xt_abs
+                jsr w_abs
+                jsr w_swap
+                jsr w_abs
 
-                jsr xt_um_star          ; ( d )
+                jsr w_um_star          ; ( d )
 
                 ; handle the sign
                 pla
                 bpl _done
 
-                jsr xt_dnegate
+                jsr w_dnegate
 _done:
 z_m_star:       rts
 
@@ -3459,6 +3508,7 @@ z_m_star:       rts
         ; """
 
 xt_marker:
+w_marker:
                 ; Before we do anything, we need to save CP, which
                 ; after all is the whole point of this operation. CREATE
                 ; uses tmp1 and tmp2, so we take the speed hit and push stuff
@@ -3475,7 +3525,7 @@ xt_marker:
                 lda cp+1
                 pha
 
-                jsr xt_create
+                jsr w_create
 
                 ; By default, CREATE installs a subroutine jump to DOVAR, which
                 ; we have to replace by a jump to marker_runtime. We back up
@@ -3589,7 +3639,7 @@ marker_runtime:
 
 xt_max:
                 jsr underflow_2
-
+w_max:
                 ; Compare LSB. We do this first to set the carry flag
                 lda 0,x         ; LSB of TOS
                 cmp 2,x         ; LSB of NOS, this sets the carry
@@ -3629,7 +3679,7 @@ z_max:          rts
 
 xt_min:
                 jsr underflow_2
-
+w_min:
                 ; compare LSB. We do this first to set the carry flag
                 lda 0,x         ; LSB of TOS
                 cmp 2,x         ; LSB of NOS, this sets carry
@@ -3664,7 +3714,7 @@ z_min:          rts
         ; """https://forth-standard.org/standard/core/Minus"""
 xt_minus:
                 jsr underflow_2
-
+w_minus:
                 sec
                 lda 2,x         ; LSB
                 sbc 0,x
@@ -3690,8 +3740,8 @@ z_minus:        rts
         ; """
 xt_mod:
                 jsr underflow_2
-
-                jsr xt_slash_mod
+w_mod:
+                jsr w_slash_mod
 
                 inx             ; DROP
                 inx
@@ -3712,16 +3762,15 @@ z_mod:
         ; """
 
 xt_move:
-                ; We let CMOVE and CMOVE> check if there is underflow or
-                ; we've been told to copy zero bytes
-
+                jsr underflow_3
+w_move:
                 ; compare MSB first
                 lda 3,x                 ; MSB of addr2
                 cmp 5,x                 ; MSB of addr1
                 beq _lsb                ; wasn't helpful, move to LSB
                 bcs _to_move_up         ; we want CMOVE>
 
-                jmp xt_cmove            ; JSR/RTS
+                jmp w_cmove            ; JSR/RTS
 
 _lsb:
                 ; MSB were equal, so do the whole thing over with LSB
@@ -3730,10 +3779,10 @@ _lsb:
                 beq _equal              ; LSB is equal as well
                 bcs _to_move_up         ; we want CMOVE>
 
-                jmp xt_cmove            ; JSR/RTS
+                jmp w_cmove            ; JSR/RTS
 
 _to_move_up:
-                jmp xt_cmove_up         ; JSR/RTS
+                jmp w_cmove_up         ; JSR/RTS
 _equal:
                 ; drop three entries from Data Stack
                 txa
@@ -3750,7 +3799,7 @@ z_move:         rts
         ; """https://forth-standard.org/standard/core/NEGATE"""
 xt_negate:
                 jsr underflow_1
-
+w_negate:
         	lda #0
                 sec
                 sbc 0,x         ; LSB
@@ -3769,7 +3818,7 @@ z_negate:       rts
         ; """https://forth-standard.org/standard/core/NIP"""
 xt_nip:
                 jsr underflow_2
-
+w_nip:
                 lda 0,x         ; LSB
                 sta 2,x
                 lda 1,x         ; MSB
@@ -3792,7 +3841,7 @@ z_nip:          rts
 
 xt_not_equals:
                 jsr underflow_2
-
+w_not_equals:
                 ldy #0                  ; default is true
 
                 lda 0,x                 ; LSB
@@ -3832,9 +3881,9 @@ z_not_equals:   rts
         ; """
 xt_number_sign:
                 jsr underflow_2         ; double number
-
-                jsr xt_base
-                jsr xt_fetch            ; ( ud1 base )
+w_number_sign:
+                jsr w_base
+                jsr w_fetch            ; ( ud1 base )
 
                 ; The following code is the ancient Forth word UD/MOD, which in
                 ; various Forths (including Gforth) lives on under the hood,
@@ -3842,14 +3891,14 @@ xt_number_sign:
                 ; in the docs, it's only used here, and there are no tests for
                 ; it. This is why we got rid of it. We'll be converting this
                 ; mess to something more sane in the long run.
-                jsr xt_to_r             ; >r
-                jsr xt_zero             ; 0
-                jsr xt_r_fetch          ; r@
-                jsr xt_um_slash_mod     ; um/mod
-                jsr xt_not_rote         ; rot rot
-                jsr xt_r_from           ; r>
-                jsr xt_um_slash_mod     ; um/mod
-                jsr xt_not_rote         ; rot ( rem ud ) rot ( ud rem )
+                jsr w_to_r             ; >r
+                jsr w_zero             ; 0
+                jsr w_r_fetch          ; r@
+                jsr w_um_slash_mod     ; um/mod
+                jsr w_not_rote         ; rot rot
+                jsr w_r_from           ; r>
+                jsr w_um_slash_mod     ; um/mod
+                jsr w_not_rote         ; rot ( rem ud ) rot ( ud rem )
 
                 ; Convert the number that is left over to an ASCII character. We
                 ; use a string lookup for speed. Use either abc_str_lower for
@@ -3860,7 +3909,7 @@ xt_number_sign:
                 sta 0,x
                 stz 1,x                 ; paranoid; now ( ud char )
 
-                jsr xt_hold
+                jsr w_hold
 
 z_number_sign:
                 rts
@@ -3878,9 +3927,8 @@ z_number_sign:
         ; https://github.com/philburk/pforth/blob/master/fth/numberio.fth
         ; """
 xt_number_sign_greater:
-
                 jsr underflow_2         ; double number
-
+w_number_sign_greater:
                 ; The start address lives in tohold
                 lda tohold
                 sta 0,x         ; LSB of tohold
@@ -3890,7 +3938,7 @@ xt_number_sign_greater:
                 sta 3,x         ; ( addr addr )
 
                 ; The length of the string is pad - addr
-                jsr xt_pad      ; ( addr addr pad )
+                jsr w_pad      ; ( addr addr pad )
 
                 sec
                 lda 0,x         ; LSB of pad address
@@ -3921,9 +3969,10 @@ z_number_sign_greater:
 
 xt_number_sign_s:
                 jsr underflow_2
+w_number_sign_s:
 _loop:
                 ; convert a single number ("#")
-                jsr xt_number_sign
+                jsr w_number_sign
 
                 ; stop when double-celled number in TOS is zero:
                 lda 0,x
@@ -3942,23 +3991,24 @@ z_number_sign_s:
         ; """http://forth-standard.org/standard/core/OF"""
 
 xt_of:
+w_of:
                 ; Check if value is equal to this case.
                 ; Postpone over (eg. compile a jsr to it)
-                ldy #>xt_over
-                lda #<xt_over
+                ldy #>w_over
+                lda #<w_over
                 jsr cmpl_subroutine
 
                 ; Postpone = (EQUAL), that is, compile a jsr to it
-                ldy #>xt_equal
-                lda #<xt_equal
+                ldy #>w_equal
+                lda #<w_equal
                 jsr cmpl_subroutine
 
-                jsr xt_if
+                jsr w_if
 
                 ; If it's true, consume the original value.
                 ; Postpone DROP (eg. compile a jsr to it)
-                ldy #>xt_drop
-                lda #<xt_drop
+                ldy #>w_drop
+                lda #<w_drop
                 jsr cmpl_subroutine
 
 z_of:           rts
@@ -3971,7 +4021,7 @@ z_of:           rts
 
 xt_one_minus:
                 jsr underflow_1
-
+w_one_minus:
                 lda 0,x
                 bne +
                 dec 1,x
@@ -3992,7 +4042,8 @@ z_one_minus:    rts
 xt_char_plus:
 xt_one_plus:
                 jsr underflow_1
-
+w_char_plus:
+w_one_plus:
                 inc 0,x
                 bne _done
                 inc 1,x
@@ -4008,7 +4059,7 @@ z_one_plus:     rts
         ; """https://forth-standard.org/standard/core/OR"
 xt_or:
                 jsr underflow_2
-
+w_or:
                 lda 0,x
                 ora 2,x
                 sta 2,x
@@ -4029,7 +4080,7 @@ z_or:           rts
         ; """https://forth-standard.org/standard/core/OVER"""
 xt_over:
                 jsr underflow_2
-
+w_over:
                 dex
                 dex
 
@@ -4051,6 +4102,7 @@ z_over:         rts
         ; This area is reserved for the user and not used by the system
         ; """
 xt_pad:
+w_pad:
                 dex
                 dex
 
@@ -4075,6 +4127,7 @@ z_pad:          rts
         ; left of the screen
         ; """
 xt_page:
+w_page:
                 lda #AscESC
                 jsr emit_a
                 lda #'['
@@ -4085,9 +4138,9 @@ xt_page:
                 jsr emit_a
 
                 ; move cursor to top left of screen
-                jsr xt_zero
-                jsr xt_zero
-                jsr xt_at_xy
+                jsr w_zero
+                jsr w_zero
+                jsr w_at_xy
 
 z_page:         rts
 
@@ -4098,6 +4151,7 @@ z_page:         rts
         ; """http://forth-standard.org/standard/core/p"""
 
 xt_paren:
+w_paren:
                 ; Put a right paren on the stack.
                 dex
                 dex
@@ -4106,7 +4160,7 @@ xt_paren:
                 stz 1,x
 
                 ; Call parse.
-                jsr xt_parse
+                jsr w_parse
 
                 ; Throw away the result.
                 inx
@@ -4135,6 +4189,7 @@ z_paren:        rts
         ; """
 
 xt_parse_name:
+w_parse_name:
                 ; To enable the compilation of the high-level Forth words
                 ; in forth-words.asm and user-words.asm at boot time,
                 ; PARSE-NAME and PARSE must be able to deal with 16-bit string
@@ -4252,7 +4307,7 @@ _char_found:
 
 xt_parse:
                 jsr underflow_1
-
+w_parse:
                 ; If the input buffer is empty, we just return
                 lda ciblen
                 ora ciblen+1
@@ -4413,6 +4468,7 @@ z_parse:        rts
         ; """
 
 xt_pick:
+w_pick:
                 ; Checking for underflow is difficult because it depends on
                 ; which element we want to grab. We could probably figure
                 ; something out, but it wouldn't work with underflow stripping
@@ -4437,7 +4493,7 @@ z_pick:         rts
         ; """https://forth-standard.org/standard/core/Plus"""
 xt_plus:
                 jsr underflow_2
-
+w_plus:
                 clc
                 lda 0,x         ; LSB
                 adc 2,x
@@ -4459,7 +4515,7 @@ z_plus:         rts
         ; """https://forth-standard.org/standard/core/PlusStore"""
 xt_plus_store:
                 jsr underflow_2
-
+w_plus_store:
                 ; move address to tmp1 so we can work with it
                 lda 0,x
                 sta tmp1
@@ -4496,11 +4552,12 @@ z_plus_store:   rts
         ;
         ; Because POSTPONE expects a word (not an xt) in the input stream (not
         ; on the Data Stack). This means we cannot build words with
-        ; "jsr xt_postpone, jsr <word>" directly.
+        ; "jsr w_postpone, jsr <word>" directly.
         ; """
 
 xt_postpone:
-                jsr xt_parse_name               ; ( -- addr n )
+w_postpone:
+                jsr w_parse_name               ; ( -- addr n )
 
                 ; if there was no word provided, complain and quit
                 lda 0,x
@@ -4510,7 +4567,7 @@ xt_postpone:
                 lda #err_noname
                 jmp error
 +
-                jsr xt_find_name                ; ( -- nt | 0 )
+                jsr w_find_name                ; ( -- nt | 0 )
 
                 ; if word not in Dictionary, complain and quit
                 bne +
@@ -4525,7 +4582,7 @@ xt_postpone:
                 sta tmp1+1
 
                 ; We need the xt instead of the nt
-                jsr xt_name_to_int              ; ( nt -- xt )
+                jsr w_name_to_int              ; ( nt -- xt )
 
                 ; See if this is an immediate word. This is easier
                 ; with nt than with xt. The status byte of the word
@@ -4541,7 +4598,7 @@ xt_postpone:
                 ; We're immediate, so instead of executing it right now, we
                 ; compile it. xt is TOS, so this is easy. The RTS at the end
                 ; takes us back to the original caller
-                jsr xt_compile_comma
+                jsr w_compile_comma
                 bra _done
 
 _not_immediate:
@@ -4549,11 +4606,11 @@ _not_immediate:
                 ; compilation" by including ' <NAME> COMPILE, which we do by
                 ; compiling the run-time routine of LITERAL, the xt itself, and
                 ; a subroutine jump to COMPILE,
-                jsr xt_literal
+                jsr w_literal
 
                 ; Last, compile COMPILE,
-                ldy #>xt_compile_comma
-                lda #<xt_compile_comma
+                ldy #>w_compile_comma
+                lda #<w_compile_comma
                 jsr cmpl_subroutine
 _done:
 z_postpone:     rts
@@ -4566,7 +4623,7 @@ z_postpone:     rts
 
 xt_question_dup:
                 jsr underflow_1
-
+w_question_dup:
                 ; Check if TOS is zero
                 lda 0,x
                 ora 1,x
@@ -4595,6 +4652,7 @@ z_question_dup: rts
         ; does, these versions should be compared at some point.
         ; """
 xt_r_fetch:
+w_r_fetch:
                 ; get the return address
                 ply             ; LSB
                 sty tmp1
@@ -4639,6 +4697,7 @@ z_r_fetch:      rts
         ; """
 
 xt_r_from:
+w_r_from:
                 ; Rescue the address of the return jump that is currently
                 ; on top of the Return Stack. If this word is natively
                 ; compiled, this is a total waste of time
@@ -4677,6 +4736,7 @@ z_r_from:       rts
         ; """
 
 xt_recurse:
+w_recurse:
                 ; The whole routine amounts to compiling a reference to
                 ; the word that is being compiled. First, we save the JSR
                 ; instruction
@@ -4756,6 +4816,7 @@ z_recurse:      rts
         ; """"
 
 xt_refill:
+w_refill:
                 ; Get input source from SOURCE-ID. This is an
                 ; optimized version of a subroutine jump to SOURCE-ID
                 lda insrc               ; cheat: We only check LSB
@@ -4781,7 +4842,7 @@ xt_refill:
                 sta 0,x
                 stz 1,x                 ; cheat: We only accept max 255
 
-                jsr xt_accept           ; ( addr n1 -- n2)
+                jsr w_accept           ; ( addr n1 -- n2)
 
                 ; ACCEPT returns the number of characters accepted, which
                 ; belong in CIBLEN
@@ -4831,12 +4892,14 @@ z_refill:       rts
         ; """http://forth-standard.org/standard/core/REPEAT"""
 
 xt_repeat:
+                jsr underflow_2
+w_repeat:
                 ; Code the jump back to begin
-                jsr xt_again
+                jsr w_again
 
                 ; Stuff HERE in for the branch address left by WHILE
                 ; to get out of the loop
-                jmp xt_then
+                jmp w_then
 z_repeat:
 
 
@@ -4847,6 +4910,7 @@ z_repeat:
         ; This is an immediate word.
         ; """
 xt_right_bracket:
+w_right_bracket:
                 lda #$FF
                 sta state
                 sta state+1
@@ -4864,7 +4928,7 @@ z_right_bracket:
 
 xt_rot:
                 jsr underflow_3
-
+w_rot:
                 ldy 5,x         ; MSB first
                 lda 3,x
                 sta 5,x
@@ -4888,7 +4952,7 @@ z_rot:          rts
         ; """https://forth-standard.org/standard/core/RSHIFT"""
 xt_rshift:
                 jsr underflow_2
-
+w_rshift:
                 ; We shift maximal by 16 bits, mask everything else
                 lda 0,x
                 and #%00001111
@@ -4918,6 +4982,7 @@ z_rshift:       rts
         ; """
 
 xt_s_backslash_quote:
+w_s_backslash_quote:
                 ; tmp2 will be used to determine if we are handling
                 ; escaped characters or not. In this case, we are,
                 ; so set it to $FF (the upper byte will be used to
@@ -4971,6 +5036,7 @@ _done:
         ; """
 
 xt_s_quote:
+w_s_quote:
                 ; tmp2 will be used to determine if we are handling
                 ; escaped characters or not.  In this case, we are
                 ; not, so set it to zero.  (cf S_BACKSLASH_QUOTE)
@@ -4980,7 +5046,7 @@ xt_s_quote:
 s_quote_start:
                 ; Put a jmp past the string data to be filled in later.
                 jsr cmpl_jump_later
-                jsr xt_here             ; the start of the string
+                jsr w_here             ; the start of the string
                 ; ( jmp-target addr )
 
 _savechars_loop:
@@ -5004,7 +5070,7 @@ _savechars_loop:
                 lda tmp3    ; Only tmp3 used, so don't bother with tmp3+1
                 pha
 
-                jsr xt_refill           ; ( -- f )
+                jsr w_refill           ; ( -- f )
 
                 pla
                 sta tmp3
@@ -5098,38 +5164,7 @@ _esc_x_second_digit:
                 jsr convert_hex_value
                 ora tmp3
 
-                jmp _save_character
-
-_esc_tr_table:
-    ; 26 character translation for simple escapes
-    ; 0 indicates no translation, hi bit indicates special
-    .byte   7               ; a -> BEL (ASCII value 7)
-    .byte   8               ; b -> Backspace (ASCII value 8)
-    .byte   0,0             ; c, d no escape
-    .byte   27              ; e -> ESC (ASCII value 27)
-    .byte   12              ; f -> FF (ASCII value 12)
-    .byte   0,0,0,0,0       ; g,h,i,j,k
-    .byte   10              ; l -> LF (ASCII value 10)
-    .byte   13+128          ; m -> CR/LF pair (ASCII values 13, 10)
-    ; n has configurable behavior which we hard-code in the table
-.if "cr" in TALI_OPTION_CR_EOL
-.if "lf" in TALI_OPTION_CR_EOL
-    .byte   13+128          ; n behaves like m --> cr/lf
-.else
-    .byte   13              ; n behaves like r --> cr
-.endif
-.else
-    .byte   10              ; n behaves like l --> lf
-.endif
-    .byte   0,0             ; o,p
-    .byte   34              ; q -> Double quote (ASCII value 34)
-    .byte   13              ; r ->  CR (ASCII value 13)
-    .byte   0               ; s
-    .byte   9               ; t -> Horizontal TAB (ASCII value 9)
-    .byte   0               ; u
-    .byte   11              ; v -> Vertical TAB (ASCII value 11)
-    .byte   0,0,0           ; w,x,y   (x is a special case later)
-    .byte   0+128           ; z -> NULL (ASCII value 0)
+                bra _save_character
 
 _check_esc_chars:
                 ; Clear the escaped character flag (because we are
@@ -5143,7 +5178,7 @@ _check_esc_chars:
                 bpl _check_esc_quote
                 ; check translation table
                 tay
-                lda _esc_tr_table - 'a',y   ; fake base address to index with a-z directly
+                lda escape_tr_table - 'a',y   ; fake base address to index with a-z directly
                 bne _esc_replace
                 tya                     ; revert if no translation
                 bra _check_esc_quote
@@ -5220,13 +5255,13 @@ _found_string_end:
                 ; We need to calculate the length of string
                 ; and update the jump target.
 
-                jsr xt_here
-                jsr xt_rot
-                jsr xt_store    ; Update the jmp target
+                jsr w_here
+                jsr w_rot
+                jsr w_store    ; Update the jmp target
 
-                jsr xt_here
-                jsr xt_over
-                jsr xt_minus    ; HERE - addr gives string length
+                jsr w_here
+                jsr w_over
+                jsr w_minus    ; HERE - addr gives string length
 
                 ; What happens next depends on the state (which is bad, but
                 ; that's the way it works at the moment). If we are
@@ -5248,13 +5283,46 @@ z_s_quote:      rts
 
 
 
+escape_tr_table:
+    ; 26 character translation for simple escapes
+    ; 0 indicates no translation, hi bit indicates special
+    .byte   7               ; a -> BEL (ASCII value 7)
+    .byte   8               ; b -> Backspace (ASCII value 8)
+    .byte   0,0             ; c, d no escape
+    .byte   27              ; e -> ESC (ASCII value 27)
+    .byte   12              ; f -> FF (ASCII value 12)
+    .byte   0,0,0,0,0       ; g,h,i,j,k
+    .byte   10              ; l -> LF (ASCII value 10)
+    .byte   13+128          ; m -> CR/LF pair (ASCII values 13, 10)
+    ; n has configurable behavior which we hard-code in the table
+.if "cr" in TALI_OPTION_CR_EOL
+.if "lf" in TALI_OPTION_CR_EOL
+    .byte   13+128          ; n behaves like m --> cr/lf
+.else
+    .byte   13              ; n behaves like r --> cr
+.endif
+.else
+    .byte   10              ; n behaves like l --> lf
+.endif
+    .byte   0,0             ; o,p
+    .byte   34              ; q -> Double quote (ASCII value 34)
+    .byte   13              ; r ->  CR (ASCII value 13)
+    .byte   0               ; s
+    .byte   9               ; t -> Horizontal TAB (ASCII value 9)
+    .byte   0               ; u
+    .byte   11              ; v -> Vertical TAB (ASCII value 11)
+    .byte   0,0,0           ; w,x,y   (x is a special case later)
+    .byte   0+128           ; z -> NULL (ASCII value 0)
+
+
+
 ; ## S_TO_D ( u -- d ) "Convert single cell number to double cell"
 ; ## "s>d"  auto  ANS core
         ; """https://forth-standard.org/standard/core/StoD"""
 
 xt_s_to_d:
                 jsr underflow_1
-
+w_s_to_d:
                 dex
                 dex
                 stz 0,x
@@ -5285,6 +5353,7 @@ z_s_to_d:       rts
         ; """
 
 xt_semicolon:
+w_semicolon:
                 ; Check if this is a : word or a :NONAME word.
                 bit status
                 bvs _colonword
@@ -5359,8 +5428,8 @@ _colonword:
                 jsr print_string_no_lf
 
                 ; Now we print the offending word.
-                jsr xt_type
-                jsr xt_space
+                jsr w_type
+                jsr w_space
 
                 ; Clear bit 7 of status (so future words will print message
                 ; by defaut)
@@ -5397,7 +5466,7 @@ z_semicolon:    rts
 
 xt_sign:
                 jsr underflow_1
-
+w_sign:
                 lda 1,x         ; check MSB of TOS
                 bmi _minus
 
@@ -5409,7 +5478,7 @@ _minus:
                 sta 0,x         ; overwrite TOS
                 stz 1,x         ; paranoid
 
-                jsr xt_hold
+                jsr w_hold
 _done:
 z_sign:         rts
 
@@ -5426,24 +5495,27 @@ z_sign:         rts
         ; """
 
 xt_slash:
+                jsr underflow_2
+w_slash:
                 ; With all the multiplication going on, it would be hard to
                 ; make sure that one of our temporary variables is not
                 ; overwritten. We make sure that doesn't happen by taking the
                 ; hit of pushing the flag to the 65c02's stack
                 lda #0
-                pha
                 bra slashmod_common
 
 xt_slash_mod:
+                jsr underflow_2
+w_slash_mod:
                 ; Note that /MOD accesses this code
-                lda #$FF
-                pha             ; falls through to _common
+                lda #$FF                ; falls through to _common
 
 slashmod_common:
-                jsr xt_to_r             ; >R
-                jsr xt_s_to_d           ; S>D
-                jsr xt_r_from           ; R>
-                jsr xt_sm_slash_rem     ; SM/REM
+                pha
+                jsr w_to_r             ; >R
+                jsr w_s_to_d           ; S>D
+                jsr w_r_from           ; R>
+                jsr w_sm_slash_rem     ; SM/REM
 
                 ; Get the flag back from the 65c02's stack. Zero is SLASH,
                 ; $FF is SLASH MOD
@@ -5451,7 +5523,7 @@ slashmod_common:
                 bne _done
 
                 ; The following code is for SLASH only
-                jsr xt_swap
+                jsr w_swap
                 inx             ; DROP
                 inx
 _done:
@@ -5481,7 +5553,7 @@ z_slash:        rts
 
 xt_sm_slash_rem:
                 jsr underflow_3 ; contains double number
-
+w_sm_slash_rem:
                 ; push MSB of high cell of d to Data Stack so we can check
                 ; its sign later
                 lda 3,x
@@ -5494,21 +5566,21 @@ xt_sm_slash_rem:
                 pha
 
                 ; Prepare division by getting absolute of n1 and d
-                jsr xt_abs
+                jsr w_abs
                 inx             ; pretend we pushed n1 to R
                 inx
 
-                jsr xt_dabs
+                jsr w_dabs
                 dex
                 dex
 
-                jsr xt_um_slash_mod     ; UM/MOD
+                jsr w_um_slash_mod     ; UM/MOD
 
                 ; if the XOR compiled above is negative, negate the
                 ; quotient (n3)
                 pla
                 bpl +
-                jsr xt_negate
+                jsr w_negate
 +
                 ; if d was negative, negate the remainder (n2)
                 pla
@@ -5516,7 +5588,7 @@ xt_sm_slash_rem:
 
                 inx             ; pretend we pushed quotient to R
                 inx
-                jsr xt_negate
+                jsr w_negate
                 dex
                 dex
 
@@ -5529,6 +5601,7 @@ z_sm_slash_rem: rts
 ; ## "source"  auto  ANS core
         ; """https://forth-standard.org/standard/core/SOURCE"""
 xt_source:
+w_source:
                 ; add address
                 dex
                 dex
@@ -5557,6 +5630,7 @@ z_source:       rts
         ; string, and a text file gives the fileid.
         ; """
 xt_source_id:
+w_source_id:
                 dex
                 dex
 
@@ -5573,6 +5647,7 @@ z_source_id:    rts
 ; ## "space"  auto  ANS core
         ; """https://forth-standard.org/standard/core/SPACE"""
 xt_space:
+w_space:
                 lda #AscSP
                 jsr emit_a
 
@@ -5586,7 +5661,7 @@ z_space:        rts
 
 xt_spaces:
                 jsr underflow_1
-
+w_spaces:
                 lda 1,x         ; ANS says this word takes a signed value
                 bmi _done       ; but prints no spaces for negative values.
 
@@ -5616,8 +5691,8 @@ z_spaces:       rts
 
 xt_star:
                 jsr underflow_2
-
-                jsr xt_um_star
+w_star:
+                jsr w_um_star
                 inx
                 inx
 
@@ -5636,9 +5711,10 @@ z_star:         rts
         ; pretty much what we do here
         ; """
 xt_star_slash:
-                ; We let */MOD check for underflow
-                jsr xt_star_slash_mod
-                jsr xt_swap
+                jsr underflow_3
+w_star_slash:
+                jsr w_star_slash_mod
+                jsr w_swap
                 inx
                 inx
 z_star_slash:
@@ -5657,11 +5733,11 @@ z_star_slash:
         ; """
 xt_star_slash_mod:
                 jsr underflow_3
-
-                jsr xt_to_r
-                jsr xt_m_star
-                jsr xt_r_from
-                jsr xt_sm_slash_rem
+w_star_slash_mod:
+                jsr w_to_r
+                jsr w_m_star
+                jsr w_r_from
+                jsr w_sm_slash_rem
 
 z_star_slash_mod:
                 rts
@@ -5677,6 +5753,7 @@ z_star_slash_mod:
         ; http://forth.sourceforge.net/standard/dpans/dpans6.htm#6.1.2250
         ; """
 xt_state:
+w_state:
                 dex
                 dex
                 lda #<state
@@ -5693,7 +5770,7 @@ z_state:        rts
         ; """https://forth-standard.org/standard/core/Store"""
 xt_store:
                 jsr underflow_2
-
+w_store:
                 lda 2,x         ; LSB
                 sta (0,x)
 
@@ -5718,7 +5795,7 @@ z_store:        rts
         ; """https://forth-standard.org/standard/core/SWAP"""
 xt_swap:
                 jsr underflow_2
-
+w_swap:
                 lda 0,x         ; LSB
                 ldy 2,x
                 sta 2,x
@@ -5746,7 +5823,8 @@ z_swap:         rts
         ; """https://forth-standard.org/standard/core/Tick"""
 
 xt_tick:
-                jsr xt_parse_name       ; ( -- addr u )
+w_tick:
+                jsr w_parse_name       ; ( -- addr u )
 
                 ; if we got a zero, there was a problem getting the
                 ; name of the word
@@ -5757,7 +5835,7 @@ xt_tick:
                 lda #err_noname
                 jmp error
 +
-                jsr xt_find_name        ; ( addr u -- nt )
+                jsr w_find_name        ; ( addr u -- nt )
 
                 ; If we didn't find the word in the Dictionary, abort
                 lda 0,x
@@ -5767,13 +5845,13 @@ xt_tick:
                 lda #err_syntax
                 jmp error
 +
-                jsr xt_name_to_int      ; ( nt -- xt )
+                jsr w_name_to_int      ; ( nt -- xt )
 
 z_tick:         rts
 
 
 
-; ## TO ( n "name" -- ) or ( "name") "Change a value"
+; ## TO ( n "name" -- ) or ( "name" ) "Change a value"
 ; ## "to"  auto  ANS core ext
         ; """https://forth-standard.org/standard/core/TO
         ; Gives a new value to a, uh, VALUE.
@@ -5793,11 +5871,12 @@ z_tick:         rts
         ; """
 
 xt_to:
+w_to:
                 ; One way or the other, we need the xt of the word after this
                 ; one. At this point, we don't know if we are interpreted or
                 ; compile, so we don't know if there is a value n on the stack,
                 ; so we can't do an underflow check yet
-                jsr xt_tick             ; ( [n] xt )
+                jsr w_tick             ; ( [n] xt )
 
                 ; The PFA (DFA in this case) is three bytes down,
                 ; after the jump to DOCONST
@@ -5824,10 +5903,10 @@ xt_to:
                 lda tmp1+1
                 sta 1,x
 
-                jsr xt_literal      ; generate the runtime for LITERAL tmp1
+                jsr w_literal      ; generate the runtime for LITERAL tmp1
 
-                ldy #>xt_store      ; write the runtime for !
-                lda #<xt_store
+                ldy #>w_store      ; write the runtime for !
+                lda #<w_store
                 jsr cmpl_subroutine
 
                 bra _done
@@ -5875,11 +5954,11 @@ z_to:           rts
 
 xt_to_body:
                 jsr underflow_1
-
+w_to_body:
                 ; Ideally, xt already points to the CFA. We just need to check
                 ; the HC flag for special cases
-                jsr xt_dup              ; ( xt xt )
-                jsr xt_int_to_name      ; ( xt nt )
+                jsr w_dup              ; ( xt xt )
+                jsr w_int_to_name      ; ( xt nt )
 
                 ; The status byte is nt+1
                 inc 0,x
@@ -5908,6 +5987,7 @@ z_to_body:      rts
 ; ## TO_IN ( -- addr ) "Return address of the input pointer"
 ; ## ">in"  auto  ANS core
 xt_to_in:
+w_to_in:
                 dex
                 dex
 
@@ -5958,7 +6038,7 @@ z_to_in:        rts
 
 xt_to_number:
                 jsr underflow_4
-
+w_to_number:
                 ; Fill the scratchpad. We arrive with ( ud-lo ud-hi addr u ).
                 ; After this step, the original ud-lo and ud-hi will still be on
                 ; the Data Stack, but will be ignored and later overwritten
@@ -5984,7 +6064,7 @@ _loop:
                 sta 0,x                 ; ( ud-lo ud-hi addr u char )
                 stz 1,x                 ; paranoid
 
-                jsr xt_digit_question   ; ( char -- n -1 | char 0 )
+                jsr w_digit_question   ; ( char -- n -1 | char 0 )
 
                 ; This gives us ( ud-lo ud-hi addr u char f | n f ), so we
                 ; check the flag. If it is zero, we return what we have and
@@ -6021,7 +6101,7 @@ _digit_ok:
                 stz 1,x         ; now ( ud-lo ud-hi addr u ud-hi base)
 
                 ; UM* returns a double-celled number
-                jsr xt_um_star  ; ( ud-lo ud-hi addr u ud-hi-lo ud-hi-hi )
+                jsr w_um_star  ; ( ud-lo ud-hi addr u ud-hi-lo ud-hi-hi )
 
                 ; Move ud-hi-lo to safety
                 lda 2,x         ; ud-hi-lo
@@ -6039,7 +6119,7 @@ _digit_ok:
                 sta 0,x
                 stz 1,x         ; ( ud-lo ud-hi addr u ud-lo base )
 
-                jsr xt_um_star  ; ( ud-lo ud-hi addr u ud-lo-lo ud-lo-hi )
+                jsr w_um_star  ; ( ud-lo ud-hi addr u ud-lo-lo ud-lo-hi )
 
                 lda 0,x
                 sta scratch+2
@@ -6113,6 +6193,7 @@ z_to_number:    rts
         ; word.
         ; """
 xt_to_r:
+w_to_r:
                 ; Save the return address. If this word is natively
                 ; coded, this is a complete waste of cycles, but
                 ; required for subroutine coding
@@ -6150,6 +6231,7 @@ z_to_r:         rts
 ; ## "true"  auto  ANS core ext
         ; """https://forth-standard.org/standard/core/TRUE"""
 xt_true:
+w_true:
                 dex
                 dex
                 lda #$FF
@@ -6164,7 +6246,7 @@ z_true:         rts
         ; """https://forth-standard.org/standard/core/TUCK"""
 xt_tuck:
                 jsr underflow_2
-
+w_tuck:
                 dex
                 dex
 
@@ -6189,7 +6271,7 @@ z_tuck:         rts
         ; """https://forth-standard.org/standard/core/TwoDROP"""
 xt_two_drop:
                 jsr underflow_2
-
+w_two_drop:
                 inx
                 inx
                 inx
@@ -6204,7 +6286,7 @@ z_two_drop:     rts
         ; """https://forth-standard.org/standard/core/TwoDUP"""
 xt_two_dup:
                 jsr underflow_2
-
+w_two_dup:
                 dex
                 dex
                 dex
@@ -6232,7 +6314,7 @@ z_two_dup:      rts
         ; """
 xt_two_fetch:
                 jsr underflow_1
-
+w_two_fetch:
                 lda 0,x
                 sta tmp1
                 ldy 1,x
@@ -6262,7 +6344,7 @@ z_two_fetch:    rts
         ; """https://forth-standard.org/standard/core/TwoOVER"""
 xt_two_over:
                 jsr underflow_4
-
+w_two_over:
                 dex
                 dex
                 dex
@@ -6296,6 +6378,7 @@ z_two_over:     rts
         ; see if an Always Native version would be better
         ; """
 xt_two_r_fetch:
+w_two_r_fetch:
 		; make room on the Data Stack
                 dex
                 dex
@@ -6339,6 +6422,7 @@ z_two_r_fetch:  rts
         ; Native compile needs to be handled as a special case.
         ; """
 xt_two_r_from:
+w_two_r_from:
                 ; save the return address
                 pla                     ; LSB
                 sta tmp1
@@ -6384,7 +6468,7 @@ z_two_r_from:   rts
         ; """https://forth-standard.org/standard/core/TwoDiv"""
 xt_two_slash:
                 jsr underflow_1
-
+w_two_slash:
                 ; We can't just LSR the LSB and ROR the MSB because that
                 ; would do bad things to the sign
                 lda 1,x
@@ -6405,7 +6489,8 @@ z_two_slash:    rts
 xt_two_star:
 xt_cells:
                 jsr underflow_1
-
+w_two_star:
+w_cells:
                 asl 0,x
                 rol 1,x
 z_cells:
@@ -6421,7 +6506,7 @@ z_two_star:     rts
         ; """
 xt_two_store:
                 jsr underflow_3
-
+w_two_store:
                 lda 0,x
                 sta tmp1
                 ldy 1,x
@@ -6456,7 +6541,7 @@ z_two_store:    rts
         ; """https://forth-standard.org/standard/core/TwoSWAP"""
 xt_two_swap:
                 jsr underflow_4
-
+w_two_swap:
                 ; 0 <-> 4
                 lda 0,x
                 ldy 4,x
@@ -6496,6 +6581,7 @@ z_two_swap:     rts
         ; special routines.
         ; """
 xt_two_to_r:
+w_two_to_r:
                 ; save the return address
                 pla             ; LSB
                 sta tmp1
@@ -6543,7 +6629,7 @@ z_two_to_r:     rts
 
 xt_type:
                 jsr underflow_2
-
+w_type:
                 ; Save the starting address into tmp1
                 lda 2,x
                 sta tmp1
@@ -6592,7 +6678,7 @@ z_type:         rts
         ; """
 xt_u_dot:
                 jsr underflow_1
-
+w_u_dot:
                 jsr print_u
                 lda #AscSP
                 jsr emit_a
@@ -6605,17 +6691,17 @@ z_u_dot:        rts
         ; """https://forth-standard.org/standard/core/UDotR"""
 xt_u_dot_r:
                 jsr underflow_2
-
-                jsr xt_to_r
-                jsr xt_zero
-                jsr xt_less_number_sign
-                jsr xt_number_sign_s
-                jsr xt_number_sign_greater
-                jsr xt_r_from
-                jsr xt_over
-                jsr xt_minus
-                jsr xt_spaces
-                jsr xt_type
+w_u_dot_r:
+                jsr w_to_r
+                jsr w_zero
+                jsr w_less_number_sign
+                jsr w_number_sign_s
+                jsr w_number_sign_greater
+                jsr w_r_from
+                jsr w_over
+                jsr w_minus
+                jsr w_spaces
+                jsr w_type
 
 z_u_dot_r:      rts
 
@@ -6625,7 +6711,7 @@ z_u_dot_r:      rts
         ; """https://forth-standard.org/standard/core/Umore"""
 xt_u_greater_than:
                 jsr underflow_2
-
+w_u_greater_than:
                 lda 0,x
                 cmp 2,x
                 lda 1,x
@@ -6646,7 +6732,7 @@ z_u_greater_than:    rts
         ; """https://forth-standard.org/standard/core/Uless"""
 xt_u_less_than:
                 jsr underflow_2
-
+w_u_less_than:
                 lda 2,x
                 cmp 0,x
                 lda 3,x
@@ -6676,7 +6762,7 @@ z_u_less_than:    rts
 
 xt_um_slash_mod:
                 jsr underflow_3
-
+w_um_slash_mod:
                 ; catch division by zero
                 lda 0,x
                 ora 1,x
@@ -6729,7 +6815,7 @@ _done:
                 inx
                 inx
 
-                jsr xt_swap
+                jsr w_swap
 
 z_um_slash_mod: rts
 
@@ -6758,7 +6844,7 @@ z_um_slash_mod: rts
 
 xt_um_star:
                 jsr underflow_2
-
+w_um_star:
                 ; to eliminate clc inside the loop, the value at
                 ; tmp1 is reduced by 1 in advance
                 clc
@@ -6820,6 +6906,7 @@ z_um_star:      rts
 ; ## "unloop"  auto  ANS core
         ; """https://forth-standard.org/standard/core/UNLOOP"""
 xt_unloop:
+w_unloop:
                 ; This is used as an epliogue to each LOOP/+LOOP
                 ; as well as prior to EXIT'ng a loop
                 ; We need to drop the current loop control block
@@ -6843,6 +6930,8 @@ z_unloop:       rts
 ; ## "until"  auto  ANS core
         ; """http://forth-standard.org/standard/core/UNTIL"""
 xt_until:
+                jsr underflow_1
+w_until:
                 ; The address to loop back to is on the stack.
                 jsr cmpl_0branch_tos
 
@@ -6857,6 +6946,7 @@ z_until:        rts
         ; defaults to $400
         ; """
 xt_unused:
+w_unused:
                 dex
                 dex
 
@@ -6890,8 +6980,9 @@ z_unused:       rts
         ; second one so the variable is initialized to zero
         ; """
 xt_variable:
+w_variable:
                 ; we let CREATE do the heavy lifting
-                jsr xt_create
+                jsr w_create
 
                 ; there is no "STZ (CP)" so we have to do this the hard
                 ; way
@@ -6917,9 +7008,11 @@ z_variable:     rts
 ; ## "while"  auto  ANS core
         ; """http://forth-standard.org/standard/core/WHILE"""
 xt_while:
+                jsr underflow_1
+w_while:
                 jsr cmpl_0branch_later          ; branch to location we'll determine later
                 ; tuck the address of the branch placeholder under the repeat address left by begin
-                jsr xt_swap
+                jsr w_swap
                 ; ( branch-target repeat-target )
 
 z_while:        rts
@@ -6936,13 +7029,13 @@ z_while:        rts
         ; """"
 xt_within:
                 jsr underflow_3
-
-                jsr xt_over
-                jsr xt_minus
-                jsr xt_to_r
-                jsr xt_minus
-                jsr xt_r_from
-                jsr xt_u_less_than
+w_within:
+                jsr w_over
+                jsr w_minus
+                jsr w_to_r
+                jsr w_minus
+                jsr w_r_from
+                jsr w_u_less_than
 
 z_within:       rts
 
@@ -6966,7 +7059,7 @@ z_within:       rts
 
 xt_word:
                 jsr underflow_1
-
+w_word:
                 ; Skip over leading delimiters - this is like PARSE-NAME,
                 ; but unlike PARSE
                 ldy toin                ; >IN
@@ -6984,7 +7077,7 @@ _found_char:
                 sty toin
 
                 ; The real work is done by parse
-                jsr xt_parse            ; Returns ( addr u )
+                jsr w_parse            ; Returns ( addr u )
 
                 ; Convert the modern ( addr u ) string format to obsolete
                 ; ( caddr ) format. We just do this in the Dictionary
@@ -6992,7 +7085,7 @@ _found_char:
                 sta (cp)                ; Save length of string
                 pha                     ; Keep copy of length for later
 
-                jsr xt_dup              ; ( addr u u )
+                jsr w_dup              ; ( addr u u )
                 lda cp
                 clc
                 adc #1
@@ -7001,7 +7094,7 @@ _found_char:
                 adc #0
                 sta 3,x                 ; ( addr cp+1 u )
 
-                jsr xt_move
+                jsr w_move
 
                 ; Return caddr
                 dex
@@ -7027,7 +7120,7 @@ z_word:         rts
         ; """https://forth-standard.org/standard/core/XOR"""
 xt_xor:
                 jsr underflow_2
-
+w_xor:
                 lda 0,x
                 eor 2,x
                 sta 2,x
@@ -7049,7 +7142,7 @@ z_xor:          rts
 
 xt_zero_equal:
                 jsr underflow_1
-
+w_zero_equal:
                 lda 0,x
                 ora 1,x
                 beq _zero       ; if 0, A is inverse of the TRUE (-1) we want
@@ -7069,7 +7162,7 @@ z_zero_equal:   rts
 
 xt_zero_greater:
                 jsr underflow_1
-
+w_zero_greater:
                 ldy #0          ; Default is FALSE (TOS is negative)
 
                 lda 1,x         ; MSB
@@ -7093,7 +7186,7 @@ z_zero_greater: rts
 
 xt_zero_less:
                 jsr underflow_1
-
+w_zero_less:
                 ldy #0          ; Default is FALSE (TOS positive)
 
                 lda 1,x         ; MSB
@@ -7115,7 +7208,7 @@ z_zero_less:    rts
 
 xt_zero_unequal:
                 jsr underflow_1
-
+w_zero_unequal:
                 lda 0,x
                 ora 1,x
                 beq _zero

--- a/words/disasm.asm
+++ b/words/disasm.asm
@@ -32,7 +32,7 @@
         ; """
 xt_disasm:
                 jsr underflow_2
-
+w_disasm:
                 jsr disassembler
 
 z_disasm:       rts
@@ -41,13 +41,13 @@ z_disasm:       rts
 
 disassembler:
                 stz scratch+5   ; flag indicating whether we're arriving at sliteral (vs 2literal)
-                jsr xt_cr       ; ( addr u )
+                jsr w_cr       ; ( addr u )
 _byte_loop:
                 ; Print address at start of the line. Note we use whatever
                 ; number base the user has
-                jsr xt_over     ; ( addr u addr )
-                jsr xt_u_dot    ; ( addr u )
-                jsr xt_space
+                jsr w_over     ; ( addr u addr )
+                jsr w_u_dot    ; ( addr u )
+                jsr w_space
 
                 ; We use the opcode value as the offset in the oc_index_table.
                 ; We have 256 entries, each two bytes long, so we can't just
@@ -105,7 +105,7 @@ _byte_loop:
                 bpl _no_operand         ; bit 7 clear, single-byte instruction
 
                 ; We have an operand. Prepare the Data Stack
-                jsr xt_zero             ; ( addr u 0 ) ZERO does not use Y
+                jsr w_zero             ; ( addr u 0 ) ZERO does not use Y
 
                 ; Because of the glory of a little endian CPU, we can start
                 ; with the next byte regardless if this is a one or two byte
@@ -164,7 +164,7 @@ _print_operand:
                 sta 0,x
                 stz 1,x                 ; ( addr+n u-n opr 5 )
 
-                jsr xt_u_dot_r          ; U.R ( addr+n u-n )
+                jsr w_u_dot_r          ; U.R ( addr+n u-n )
 
                 bra _print_mnemonic
 
@@ -179,14 +179,14 @@ _no_operand:
                 sta 0,x
                 stz 1,x                 ; ( addr u 5 )
 
-                jsr xt_spaces           ; ( addr u )
+                jsr w_spaces           ; ( addr u )
 
                 ; fall through to _print_mnemonic
 
 _print_mnemonic:
                 ; We arrive here with the opcode table address on the stack and
                 ; ( addr u | addr+n u-n ). Time to print the mnemonic.
-                jsr xt_space
+                jsr w_space
 
                 dex
                 dex                     ; ( addr u ? )
@@ -195,7 +195,7 @@ _print_mnemonic:
                 pla                     ; LSB
                 sta 0,x                 ; ( addr u addr-o )
 
-                jsr xt_count            ; ( addr u addr-o u-o )
+                jsr w_count            ; ( addr u addr-o u-o )
 
                 ; The length of the mnemnonic string is in bits 2 to 0
                 stz 1,x                 ; paranoid
@@ -203,7 +203,7 @@ _print_mnemonic:
                 and #%00000111          ; ( addr u addr-o u-o )
                 sta 0,x
 
-                jsr xt_type             ; ( addr u )
+                jsr w_type             ; ( addr u )
 
                 ; Handle JSR by printing name of function, if available.
                 ; scratch has opcode ($20 for JSR)
@@ -218,7 +218,7 @@ _print_mnemonic:
                 lda #5
                 sta 0,x
                 stz 1,x
-                jsr xt_spaces
+                jsr w_spaces
 
                 jsr disasm_special
                 bcs _printing_done
@@ -311,7 +311,7 @@ _is_rel:
                 lda #9
                 sta 0,x
                 stz 1,x
-                jsr xt_u_dot_r      ; print the destination with 5 leading spaces
+                jsr w_u_dot_r      ; print the destination with 5 leading spaces
 
                 lda #AscSP          ; print space and branch direction indicator
                 jsr emit_a
@@ -319,14 +319,14 @@ _is_rel:
                 jsr emit_a
 
 _printing_done:
-                jsr xt_cr
+                jsr w_cr
 
                 ; Housekeeping: Next byte
                 inc 2,x
                 bne +
                 inc 3,x                 ; ( addr+1 u )
 +
-                jsr xt_one_minus        ; ( addr+1 u-1 )
+                jsr w_one_minus        ; ( addr+1 u-1 )
 
                 lda 0,x                 ; All done?
                 ora 1,x
@@ -338,7 +338,7 @@ _printing_done:
                 jmp _byte_loop          ; out of range for BRA
 _done:
                 ; Clean up and leave
-                jmp xt_two_drop         ; JSR/RTS
+                jmp w_two_drop         ; JSR/RTS
 
 
 ; Handlers for various special disassembled instructions:
@@ -358,19 +358,19 @@ disasm_sliteral_jump:
 
                 ; Determine the distance of the jump so we end on the byte
                 ; just before the JSR (sets us up for SLITERAL on next loop)
-                jsr xt_swap
+                jsr w_swap
                 dex
                 dex
                 lda scratch+1
                 sta 0,x
                 lda scratch+2
                 sta 1,x
-                jsr xt_swap
-                jsr xt_minus
-                jsr xt_one_minus
+                jsr w_swap
+                jsr w_minus
+                jsr w_one_minus
                 ; ( n jump_distance )
                 ; Subtract the jump distance from the bytes left.
-                jsr xt_minus
+                jsr w_minus
                 ; ( new_n )
                 ; Move to one byte before the target address
                 dex
@@ -379,8 +379,8 @@ disasm_sliteral_jump:
                 sta 0,x
                 lda scratch+2
                 sta 1,x
-                jsr xt_one_minus
-                jsr xt_swap ; ( new_addr new_n )
+                jsr w_one_minus
+                jsr w_swap ; ( new_addr new_n )
                 rts
 
 
@@ -398,7 +398,7 @@ disasm_jsr:
                 lda scratch+2
                 sta 1,x
                 ; ( xt )
-                jsr xt_int_to_name
+                jsr w_int_to_name
                 ; int>name returns zero if we just don't know.
                 lda 0,x
                 ora 1,x
@@ -416,7 +416,7 @@ disasm_jsr:
                 sbc #0         ; Subtract the carry if needed.
                 sta 1,x
                 ; ( xt )
-                jsr xt_int_to_name    ; Try looking again
+                jsr w_int_to_name    ; Try looking again
                 ; int>name returns zero if we just don't know.
                 lda 0,x
                 ora 1,x
@@ -425,8 +425,8 @@ disasm_jsr:
                 ; We got an nt this time.  Double check that it has underflow
                 ; checking (that could be skipped).
                 ; Put the address of the status byte on the stack.
-                jsr xt_dup
-                jsr xt_one_plus
+                jsr w_dup
+                jsr w_one_plus
                 ; Grab the status into A
                 lda (0,x)
                 ; Get rid of the extra stack usage before doing the check
@@ -439,8 +439,8 @@ disasm_jsr:
 _found_nt:
                 ; We now have a name token ( nt ) on the stack.
                 ; Change it into the name and print it.
-                jsr xt_name_to_string
-                jsr xt_type
+                jsr w_name_to_string
+                jsr w_type
                 sec
                 rts
 
@@ -506,24 +506,24 @@ _done:          sec
 _print_literal:
                 ; ( addr u ) address of last byte of JSR and bytes left on the stack.
                 ; We need to print the value just after the address and move along two bytes.
-                jsr xt_swap ; switch to (u addr)
-                jsr xt_one_plus
+                jsr w_swap ; switch to (u addr)
+                jsr w_one_plus
 
-                jsr xt_dup
-                jsr xt_question ; Print the value at the address
+                jsr w_dup
+                jsr w_question ; Print the value at the address
                 ; Advance one more byte to skip over the constant
-                jsr xt_one_plus
-                jsr xt_swap ; (addr+2 u)
-                jsr xt_one_minus
-                jmp xt_one_minus ; (addr+2 u-2)
+                jsr w_one_plus
+                jsr w_swap ; (addr+2 u)
+                jsr w_one_minus
+                jmp w_one_minus ; (addr+2 u-2)
 
 _print_2literal:
-                jsr xt_swap
-                jsr xt_one_plus
-                jsr xt_dup
-                jsr xt_two_fetch
-                jsr xt_swap             ; 2! / 2@ put MSW first; but 2literal writes LSW first
-                jsr xt_d_dot
+                jsr w_swap
+                jsr w_one_plus
+                jsr w_dup
+                jsr w_two_fetch
+                jsr w_swap             ; 2! / 2@ put MSW first; but 2literal writes LSW first
+                jsr w_d_dot
                 clc
                 lda 0,x
                 adc #3
@@ -531,7 +531,7 @@ _print_2literal:
                 bcc +
                 inc 1,x
 +
-                jsr xt_swap ; ( addr+4 u )
+                jsr w_swap ; ( addr+4 u )
                 sec
                 lda 0,x
                 sbc #4

--- a/words/double.asm
+++ b/words/double.asm
@@ -3,7 +3,7 @@
         ; """https://forth-standard.org/standard/double/DMinus"""
 xt_d_minus:
                 jsr underflow_4 ; two double numbers
-
+w_d_minus:
                 sec
 
                 lda 6,x         ; LSB of lower word
@@ -35,7 +35,7 @@ z_d_minus:      rts
         ; """https://forth-standard.org/standard/double/DPlus"""
 xt_d_plus:
                 jsr underflow_4 ; two double numbers
-
+w_d_plus:
                 clc
                 lda 2,x         ; LSB of lower word
                 adc 6,x
@@ -70,7 +70,7 @@ z_d_plus:       rts
 
 xt_d_to_s:
                 jsr underflow_2
-
+w_d_to_s:
                 inx
                 inx
 
@@ -84,7 +84,7 @@ z_d_to_s:       rts
 
 xt_dabs:
                 jsr underflow_2 ; double number
-
+w_dabs:
                 lda 1,x         ; MSB of high cell
                 bpl _done       ; positive, we get off light
 
@@ -117,7 +117,7 @@ z_dabs:         rts
         ; """https://forth-standard.org/standard/double/DNEGATE"""
 xt_dnegate:
                 jsr underflow_2 ; double number
-
+w_dnegate:
      		ldy #0
                 sec
 
@@ -151,16 +151,16 @@ z_dnegate:      rts
 
 xt_d_dot:
                 jsr underflow_2
-
-                jsr xt_tuck
-                jsr xt_dabs
-                jsr xt_less_number_sign
-                jsr xt_number_sign_s
-                jsr xt_rot
-                jsr xt_sign
-                jsr xt_number_sign_greater
-                jsr xt_type
-                jsr xt_space
+w_d_dot:
+                jsr w_tuck
+                jsr w_dabs
+                jsr w_less_number_sign
+                jsr w_number_sign_s
+                jsr w_rot
+                jsr w_sign
+                jsr w_number_sign_greater
+                jsr w_type
+                jsr w_space
 
 z_d_dot:        rts
 
@@ -174,20 +174,21 @@ z_d_dot:        rts
 
 xt_d_dot_r:
                 jsr underflow_3
+w_d_dot_r:
                 ; From the forth code:
-                jsr xt_to_r
-                jsr xt_tuck
-                jsr xt_dabs
-                jsr xt_less_number_sign
-                jsr xt_number_sign_s
-                jsr xt_rot
-                jsr xt_sign
-                jsr xt_number_sign_greater
-                jsr xt_r_from
-                jsr xt_over
-                jsr xt_minus
-                jsr xt_spaces
-                jsr xt_type
+                jsr w_to_r
+                jsr w_tuck
+                jsr w_dabs
+                jsr w_less_number_sign
+                jsr w_number_sign_s
+                jsr w_rot
+                jsr w_sign
+                jsr w_number_sign_greater
+                jsr w_r_from
+                jsr w_over
+                jsr w_minus
+                jsr w_spaces
+                jsr w_type
 
 z_d_dot_r:      rts
 
@@ -202,47 +203,47 @@ z_d_dot_r:      rts
         ; SWAP DROP SWAP ROT 0< if dnegate then
 xt_m_star_slash:
                 jsr underflow_4
-
+w_m_star_slash:
                 ; DDUP XOR SWAP ABS >R SWAP ABS >R OVER XOR ROT ROT DABS
-                jsr xt_two_dup
-                jsr xt_xor
-                jsr xt_swap
-                jsr xt_abs
-                jsr xt_to_r
-                jsr xt_swap
-                jsr xt_abs
-                jsr xt_to_r
-                jsr xt_over
-                jsr xt_xor
-                jsr xt_not_rote         ; rot rot
-                jsr xt_dabs
+                jsr w_two_dup
+                jsr w_xor
+                jsr w_swap
+                jsr w_abs
+                jsr w_to_r
+                jsr w_swap
+                jsr w_abs
+                jsr w_to_r
+                jsr w_over
+                jsr w_xor
+                jsr w_not_rote         ; rot rot
+                jsr w_dabs
 
                 ; SWAP R@ UM* ROT R> UM* ROT 0 D+ R@ UM/MOD ROT ROT R> UM/MOD
-                jsr xt_swap
-                jsr xt_r_fetch
-                jsr xt_um_star
-                jsr xt_rot
-                jsr xt_r_from
-                jsr xt_um_star
-                jsr xt_rot
-                jsr xt_zero
-                jsr xt_d_plus
-                jsr xt_r_fetch
-                jsr xt_um_slash_mod
-                jsr xt_not_rote         ; rot rot
-                jsr xt_r_from
-                jsr xt_um_slash_mod
+                jsr w_swap
+                jsr w_r_fetch
+                jsr w_um_star
+                jsr w_rot
+                jsr w_r_from
+                jsr w_um_star
+                jsr w_rot
+                jsr w_zero
+                jsr w_d_plus
+                jsr w_r_fetch
+                jsr w_um_slash_mod
+                jsr w_not_rote         ; rot rot
+                jsr w_r_from
+                jsr w_um_slash_mod
 
                 ; SWAP DROP SWAP ROT 0< if dnegate then ;
-                jsr xt_swap
-                jsr xt_drop
-                jsr xt_swap
-                jsr xt_rot
+                jsr w_swap
+                jsr w_drop
+                jsr w_swap
+                jsr w_rot
                 inx                     ; drop TOS
                 inx
                 lda $fe,x               ; but keep MSB
                 bpl z_m_star_slash      ; ... 0< if ...
-                jsr xt_dnegate
+                jsr w_dnegate
 
 z_m_star_slash: rts
 
@@ -256,20 +257,20 @@ z_m_star_slash: rts
         ; """
 xt_two_constant:
                 jsr underflow_2
-
-                jsr xt_create
-                jsr xt_swap
-                jsr xt_comma
-                jsr xt_comma
+w_two_constant:
+                jsr w_create
+                jsr w_swap
+                jsr w_comma
+                jsr w_comma
 
                 jsr does_runtime    ; does> turns into these two routines.
                 jsr dodoes
 
-                jsr xt_dup
-                jsr xt_fetch
-                jsr xt_swap
-                jsr xt_cell_plus
-                jsr xt_fetch
+                jsr w_dup
+                jsr w_fetch
+                jsr w_swap
+                jsr w_cell_plus
+                jsr w_fetch
 
 z_two_constant: rts
 
@@ -281,15 +282,15 @@ z_two_constant: rts
         ; """
 xt_two_literal:
                 jsr underflow_2 ; double number
-
+w_two_literal:
                 lda #template_push_tos_size
                 asl
                 jsr check_nc_limit
                 bcs _no_inline
 
-                jsr xt_swap
-                jsr xt_literal
-                jmp xt_literal
+                jsr w_swap
+                jsr w_literal
+                jmp w_literal
 
 _no_inline:
                 jsr cmpl_two_literal
@@ -307,8 +308,9 @@ z_two_literal:  rts
         ; CREATE 2 CELLS ALLOT  or just  CREATE 0 , 0 ,
         ; """
 xt_two_variable:
+w_two_variable:
                 ; We just let CRATE and ALLOT do the heavy lifting
-                jsr xt_create
+                jsr w_create
 
                 dex
                 dex
@@ -316,7 +318,7 @@ xt_two_variable:
                 sta 0,x
                 stz 1,x
 
-                jsr xt_allot
+                jsr w_allot
 
 z_two_variable: rts
 
@@ -329,12 +331,12 @@ z_two_variable: rts
         ; """
 xt_ud_dot:
                 jsr underflow_2 ; double number
-
-                jsr xt_less_number_sign
-                jsr xt_number_sign_s
-                jsr xt_number_sign_greater
-                jsr xt_type
-                jsr xt_space
+w_ud_dot:
+                jsr w_less_number_sign
+                jsr w_number_sign_s
+                jsr w_number_sign_greater
+                jsr w_type
+                jsr w_space
 
 z_ud_dot:        rts
 
@@ -346,15 +348,15 @@ z_ud_dot:        rts
         ; """
 xt_ud_dot_r:
                 jsr underflow_3
-
-                jsr xt_to_r
-                jsr xt_less_number_sign
-                jsr xt_number_sign_s
-                jsr xt_number_sign_greater
-                jsr xt_r_from
-                jsr xt_over
-                jsr xt_minus
-                jsr xt_spaces
-                jsr xt_type
+w_ud_dot_r:
+                jsr w_to_r
+                jsr w_less_number_sign
+                jsr w_number_sign_s
+                jsr w_number_sign_greater
+                jsr w_r_from
+                jsr w_over
+                jsr w_minus
+                jsr w_spaces
+                jsr w_type
 
 z_ud_dot_r:      rts

--- a/words/ed.asm
+++ b/words/ed.asm
@@ -10,6 +10,7 @@
         ; ed.asm or the manual for details.
         ; """
 xt_ed:
+w_ed:
                 jsr ed6502      ; kept in separate file
 
 z_ed:           rts
@@ -98,10 +99,10 @@ ed6502:
                 ; (the "target") on the stack. Because the stack picture is
                 ; going to get very confusing very fast, we'll mark them
                 ; specially with "-t" suffixes in the stack comments.
-                jsr xt_zero
-                jsr xt_zero             ; ( addr-t u-t )
+                jsr w_zero
+                jsr w_zero             ; ( addr-t u-t )
 
-                jsr xt_cr
+                jsr w_cr
 
 ed_input_loop:
                 ; Set parameter flag to none (bit 7); default printing is
@@ -134,7 +135,7 @@ ed_input_loop:
                 lda #%10000000
                 tsb ed_flags
 
-                jsr xt_one_plus         ; ( addr-t u-t u+1 )
+                jsr w_one_plus         ; ( addr-t u-t u+1 )
                 jsr ed_is_valid_line
                 bcs +
 
@@ -144,7 +145,7 @@ ed_input_loop:
                 ; We have a legal line number, but we need two entries on
                 ; the parameter list (four if you count the target
                 ; address) to be able to work with the rest of the program.
-                jsr xt_zero             ; ( addr-t u-t u+1 0 )
+                jsr w_zero             ; ( addr-t u-t u+1 0 )
 
                 jmp _line_number_only_from_external
 
@@ -156,8 +157,8 @@ _command_mode:
                 ; computer people. Some commands like "a" will take a "line 0",
                 ; however. We use the ed_flags bit 7 to signal if we are
                 ; without parameters.
-                jsr xt_zero             ; parameter 1 is NOS ( addr-t u-t 0 )
-                jsr xt_zero             ; parameter 2 is TOS ( addr-t u-t 0 0 )
+                jsr w_zero             ; parameter 1 is NOS ( addr-t u-t 0 )
+                jsr w_zero             ; parameter 2 is TOS ( addr-t u-t 0 0 )
 
                 ; We start off by taking care of any parameters. These can be
                 ; '%' for the complete text, '$' for the last line, a line
@@ -265,10 +266,10 @@ _command_mode:
                 lda ciblen+1
                 sta 1,x
 
-                jsr xt_one_minus        ; ( addr-t u-t para1 0 addr u-1 )
-                jsr xt_swap             ; ( addr-t u-t para1 0 u-1 addr )
-                jsr xt_one_plus         ; ( addr-t u-t para1 0 u-1 addr+1 )
-                jsr xt_swap             ; ( addr-t u-t para1 0 addr+1 u-1 )
+                jsr w_one_minus        ; ( addr-t u-t para1 0 addr u-1 )
+                jsr w_swap             ; ( addr-t u-t para1 0 u-1 addr )
+                jsr w_one_plus         ; ( addr-t u-t para1 0 u-1 addr+1 )
+                jsr w_swap             ; ( addr-t u-t para1 0 addr+1 u-1 )
 
                 jmp _check_for_para2
 
@@ -284,7 +285,7 @@ _prefix_dollar:
                 inx                     ; ( addr-t u-t 0 )
 
                 jsr ed_last_line          ; ( addr-t u-t 0 para1 )
-                jsr xt_swap             ; SWAP ( addr-t u-t para1 0 )
+                jsr w_swap             ; SWAP ( addr-t u-t para1 0 )
 
                 ; We have a parameter
                 lda #%10000000
@@ -374,8 +375,8 @@ _prefix_number:
                 ; Set up >NUMBER using CIB and CIBLEN as the location of the
                 ; string to check. First, though, add the "accumulator" of
                 ; >NUMBER as a double number, that is, to single-cell numbers
-                jsr xt_zero
-                jsr xt_zero             ; ( addr-t u-t 0 0 0 0 )
+                jsr w_zero
+                jsr w_zero             ; ( addr-t u-t 0 0 0 0 )
 
                 dex
                 dex
@@ -392,7 +393,7 @@ _prefix_number:
                 lda ciblen+1
                 sta 1,x                 ; ( addr-t u-t 0 0 0 0 cib ciblen )
 
-                jsr xt_to_number        ; ( addr-t u-t 0 0 ud addr2 u2 )
+                jsr w_to_number        ; ( addr-t u-t 0 0 ud addr2 u2 )
 
                 ; If we converted all the characters in the string (u2 is
                 ; zero), then the user just gave us a line number to
@@ -409,14 +410,14 @@ _prefix_number:
                 inx
                 inx                     ; 2DROP ( addr-t u-t 0 0 ud )
 
-                jsr xt_d_to_s           ; D>S ( addr-t u-t 0 0 u )
-                jsr xt_not_rote         ; -ROT ( addr-t u-t u 0 0 )
+                jsr w_d_to_s           ; D>S ( addr-t u-t 0 0 u )
+                jsr w_not_rote         ; -ROT ( addr-t u-t u 0 0 )
 
                 inx
                 inx                     ; ( addr-t u-t u 0 ) drop through
 
 _line_number_only_from_external:
-                jsr xt_swap             ; ( addr-t u-t 0 u )
+                jsr w_swap             ; ( addr-t u-t 0 u )
 
                 jsr ed_is_valid_line
                 bcs +
@@ -425,7 +426,7 @@ _line_number_only_from_external:
                 jmp ed_error_2drop
 +
                 ; Legal line number, so make it the current number
-                jsr xt_swap             ; ( addr-t u-t u 0 )
+                jsr w_swap             ; ( addr-t u-t u 0 )
                 jsr ed_para1_to_cur
 
                 ; We have a parameter
@@ -440,7 +441,7 @@ _have_unconverted_chars:
                 ; command character and need to skip the rest of the prefix
                 ; processing. In this case, the number of unconverted
                 ; characters is equal to the length of the string.
-                jsr xt_dup              ; ( addr-t u-t 0 0 ud addr2 u2 u2 )
+                jsr w_dup              ; ( addr-t u-t 0 0 ud addr2 u2 u2 )
 
                 dex
                 dex                     ; ( addr-t u-t 0 0 ud addr2 u2 u2 ? )
@@ -450,7 +451,7 @@ _have_unconverted_chars:
                 lda ciblen+1
                 sta 1,x                 ; ( addr-t u-t 0 0 ud addr2 u2 u2 ciblen )
 
-                jsr xt_equal            ; ( addr-t u-t 0 0 ud addr2 u2 f )
+                jsr w_equal            ; ( addr-t u-t 0 0 ud addr2 u2 f )
 
                 lda 0,x
                 ora 1,x
@@ -487,9 +488,9 @@ _no_command_yet:
                 inx
                 inx                     ; ( ... 0 0 ud addr2 u2 )
 
-                jsr xt_to_r             ; >R ( ... 0 0 ud addr2 ) (R: u2)
-                jsr xt_not_rote         ; -ROT ( ... 0 0 addr2 ud ) (R: u2)
-                jsr xt_d_to_s           ; D>S  ( ... 0 0 addr2 para1 ) (R: u2)
+                jsr w_to_r             ; >R ( ... 0 0 ud addr2 ) (R: u2)
+                jsr w_not_rote         ; -ROT ( ... 0 0 addr2 ud ) (R: u2)
+                jsr w_d_to_s           ; D>S  ( ... 0 0 addr2 para1 ) (R: u2)
 
                 lda 0,x                 ; LSB
                 sta 6,x
@@ -498,7 +499,7 @@ _no_command_yet:
 
                 inx
                 inx                     ; ( addr-t u-t para1 0 addr2 ) (R: u2)
-                jsr xt_r_from           ; R> ( addr-t u-t para1 0 addr2 u2 ) fall through
+                jsr w_r_from           ; R> ( addr-t u-t para1 0 addr2 u2 ) fall through
 
                 ; We have a parameter
                 lda #%10000000
@@ -584,24 +585,24 @@ _para2_not_dollar:
                 ; 0 addr2+1 u2-1 ), which u2-1 pointing to the first mystery
                 ; character after the comma. Again, we skip the ( addr-t u-t )
                 ; at the beginning of the stack comment here.
-                jsr xt_to_r             ; >R ( ... para1 0 addr2+1 ) (R: u2-1)
-                jsr xt_zero             ; 0 ( ... para1 0 addr2+1 0 ) (R: u2-1)
-                jsr xt_zero             ; 0 ( ... para1 0 addr2+1 0 0 ) (R: u2-1)
-                jsr xt_rot              ; ROT ( ... para1 0 0 0 addr2+1 ) (R: u2-1)
-                jsr xt_r_from           ; R> ( ... para1 0 0 0 addr2+1 u2-1)
+                jsr w_to_r             ; >R ( ... para1 0 addr2+1 ) (R: u2-1)
+                jsr w_zero             ; 0 ( ... para1 0 addr2+1 0 ) (R: u2-1)
+                jsr w_zero             ; 0 ( ... para1 0 addr2+1 0 0 ) (R: u2-1)
+                jsr w_rot              ; ROT ( ... para1 0 0 0 addr2+1 ) (R: u2-1)
+                jsr w_r_from           ; R> ( ... para1 0 0 0 addr2+1 u2-1)
 
                 ; We'll need a copy of the length of the rest of the string to
                 ; see if we've actually done any work
-                jsr xt_dup              ; DUP ( ... para1 0 0 0 addr2+1 u2-1 u2-1)
-                jsr xt_to_r             ; >R ( ... para1 0 0 0 addr2+1 u2-1 ) (R: u2-1)
+                jsr w_dup              ; DUP ( ... para1 0 0 0 addr2+1 u2-1 u2-1)
+                jsr w_to_r             ; >R ( ... para1 0 0 0 addr2+1 u2-1 ) (R: u2-1)
 
-                jsr xt_to_number        ; >NUMBER ( ... para1 0 ud addr3 u3 ) (R: u2-1)
+                jsr w_to_number        ; >NUMBER ( ... para1 0 ud addr3 u3 ) (R: u2-1)
 
                 ; If the original string and the leftover string have the same
                 ; length, then nothing was converted and we have an error
-                jsr xt_dup              ; DUP ( ... para1 0 ud addr3 u3 u3 ) (R: u2-1)
-                jsr xt_r_from           ; R> ( ... para1 0 ud addr3 u3 u3 u2-1 )
-                jsr xt_equal            ; = ( ... para1 0 ud addr3 u3 f )
+                jsr w_dup              ; DUP ( ... para1 0 ud addr3 u3 u3 ) (R: u2-1)
+                jsr w_r_from           ; R> ( ... para1 0 ud addr3 u3 u3 u2-1 )
+                jsr w_equal            ; = ( ... para1 0 ud addr3 u3 f )
 
                 lda 0,x
                 ora 1,x
@@ -630,9 +631,9 @@ _second_number:
                 pha
 
                 ; Clean up the stack
-                jsr xt_two_drop         ; 2DROP ( addr-t u-t para1 0 ud )
-                jsr xt_d_to_s           ; D>S  ( addr-t u-t para1 0 para2 )
-                jsr xt_nip              ; NIP ( addr-t u-t para1 para2 )
+                jsr w_two_drop         ; 2DROP ( addr-t u-t para1 0 ud )
+                jsr w_d_to_s           ; D>S  ( addr-t u-t para1 0 para2 )
+                jsr w_nip              ; NIP ( addr-t u-t para1 para2 )
 
                 ply
 
@@ -724,7 +725,7 @@ ed_all_done:
                 stz ciblen+1
 
                 ; Clean up the stack
-                jsr xt_two_drop                 ; 2DROP ( addr-t u-t )
+                jsr w_two_drop                 ; 2DROP ( addr-t u-t )
 
                 ; Restore the base
                 lda ed_base
@@ -783,7 +784,7 @@ ed_entry_cmd_i:
 
 ; ed_cmd_a_have_para:
                 jsr ed_num_to_addr        ;  ( addr-t u-t addr1 )
-                jsr xt_cr
+                jsr w_cr
 
 _next_string_loop:
                 ; This is where we land when we are continuing in with another
@@ -815,34 +816,34 @@ _next_string_loop:
                 lda #%01000000
                 tsb ed_flags
 
-                jsr xt_cr
+                jsr w_cr
                 jmp ed_input_loop
 
 _add_line:
                 ; Break the linked list so we can insert another node
-                jsr xt_dup              ; DUP ( addr-t u-t addr1 addr1 )
-                jsr xt_here             ; HERE ( addr-t u-t addr1 addr1 here )
-                jsr xt_swap             ; SWAP ( addr-t u-t addr1 here addr1 )
-                jsr xt_fetch            ; @  ( addr-t u-t addr1 here addr2 )
-                jsr xt_comma            ; ,  ( addr-t u-t addr1 here )
+                jsr w_dup              ; DUP ( addr-t u-t addr1 addr1 )
+                jsr w_here             ; HERE ( addr-t u-t addr1 addr1 here )
+                jsr w_swap             ; SWAP ( addr-t u-t addr1 here addr1 )
+                jsr w_fetch            ; @  ( addr-t u-t addr1 here addr2 )
+                jsr w_comma            ; ,  ( addr-t u-t addr1 here )
 
                 ; We're going to need that HERE for the next line if more
                 ; than one line is added. This is a good time to save it on
                 ; the stack
-                jsr xt_tuck             ; TUCK ( addr-t u-t here addr1 here )
+                jsr w_tuck             ; TUCK ( addr-t u-t here addr1 here )
 
                 ; We have now saved the link to the next node at HERE, which is
                 ; where the CP was pointing. CP has been advanced by one cell,
                 ; but we still have the original as HERE on the stack. That
                 ; address now has to go where addr2 was before.
-                jsr xt_swap             ; SWAP ( addr-t u-t here here addr1 )
-                jsr xt_store            ; ! ( addr-t u-t here )
+                jsr w_swap             ; SWAP ( addr-t u-t here here addr1 )
+                jsr w_store            ; ! ( addr-t u-t here )
 
                 ; Thus concludes the mucking about with node links. Now we have
                 ; to create a new header. The CP we access with HERE points to
                 ; the cell after the new node address, which is where we want
                 ; to put ( ) for the new string
-                jsr xt_here             ; HERE ( addr-t u-t here here2)
+                jsr w_here             ; HERE ( addr-t u-t here here2)
 
                 ; Reserve two cells (four bytes on the 65c02) for the ( addr u )
                 ; of the new string
@@ -866,8 +867,8 @@ _add_line:
                 ; is where the new string needs to be. The MOVE command we're
                 ; going to use has the format ( addr1 addr2 u )
 
-                jsr xt_here     ; HERE ( addr-t u-t here here2 here3 )
-                jsr xt_dup      ; DUP ( addr-t u-t here here2 here3 here3 )
+                jsr w_here     ; HERE ( addr-t u-t here here2 here3 )
+                jsr w_dup      ; DUP ( addr-t u-t here here2 here3 here3 )
 
                 dex
                 dex             ; ( addr-t u-t here here2 here3 here3 ? )
@@ -876,7 +877,7 @@ _add_line:
                 lda cib+1
                 sta 1,x         ; ( addr-t u-t here here2 here3 here3 cib )
 
-                jsr xt_swap     ; SWAP ( addr-t u-t here here2 here3 cib here3 )
+                jsr w_swap     ; SWAP ( addr-t u-t here here2 here3 cib here3 )
 
                 dex
                 dex             ; ( addr-t u-t here here2 here3 cib here3 ? )
@@ -885,7 +886,7 @@ _add_line:
                 lda ciblen+1
                 sta 1,x         ; ( addr-t u-t here here2 here3 cib here3 ciblen )
 
-                jsr xt_move     ; ( addr-t u-t here here2 here3 )
+                jsr w_move     ; ( addr-t u-t here here2 here3 )
 
                 ; We need to adjust CP be the length of the string
                 clc
@@ -900,22 +901,22 @@ _add_line:
                 ; The string is now moved safely out of the input buffer to the
                 ; main memory at ( here3 ciblin ). Now we have to fix that
                 ; fact in the header. We start with the address.
-                jsr xt_over             ; OVER ( addr-t u-t here here2 here3 here2 )
-                jsr xt_store            ; ! ( addr-t u-t here here2 )
+                jsr w_over             ; OVER ( addr-t u-t here here2 here3 here2 )
+                jsr w_store            ; ! ( addr-t u-t here here2 )
 
-                jsr xt_one_plus         ; 1+
-                jsr xt_one_plus         ; 1+ ( addr-t u-t here here2+2 )
-                jsr xt_dup              ; DUP ( addr-t u-t here here2+2 here2+2 )
+                jsr w_one_plus         ; 1+
+                jsr w_one_plus         ; 1+ ( addr-t u-t here here2+2 )
+                jsr w_dup              ; DUP ( addr-t u-t here here2+2 here2+2 )
 
                 lda ciblen
                 sta 2,x
                 lda ciblen+1
                 sta 3,x                 ; ( addr-t u-t here ciblen here2+2 )
 
-                jsr xt_store            ; ! ( addr-t u-t here )
+                jsr w_store            ; ! ( addr-t u-t here )
 
                 ; Add a line feed for visuals
-                jsr xt_cr
+                jsr w_cr
 
                 ; Remeber that original HERE we've been dragging along all the
                 ; time? Now we find out why. We return to the loop to pick up
@@ -940,7 +941,7 @@ ed_cmd_d:
                 bne +
 
                 ; The second parameter is a zero, so delete one line
-                jsr xt_over             ; ( addr-t u-t para1 0 para1 )
+                jsr w_over             ; ( addr-t u-t para1 0 para1 )
                 jsr _cmd_d_common       ; ( addr-t u-t para1 0 )
                 bra _cmd_d_done
 +
@@ -958,8 +959,8 @@ _cmd_d_loop:
                 ; error if we start out that way, we might do that in future as
                 ; well. This is not the same code as for 'p', because we have
                 ; to delete from the back
-                jsr xt_two_dup          ; 2DUP ( addr-t u-t para1 para2 para1 para2 )
-                jsr xt_greater_than     ; > ( addr-t u-t para1 para2 f )
+                jsr w_two_dup          ; 2DUP ( addr-t u-t para1 para2 para1 para2 )
+                jsr w_greater_than     ; > ( addr-t u-t para1 para2 f )
 
                 lda 0,x
                 ora 1,x
@@ -970,9 +971,9 @@ _cmd_d_loop:
                 inx
                 inx                     ; Get rid of the flag from >
 
-                jsr xt_dup              ; DUP ( addr-t u-t para1 para2 para2 )
+                jsr w_dup              ; DUP ( addr-t u-t para1 para2 para2 )
                 jsr _cmd_d_common       ; ( addr-t u-t para1 para2 )
-                jsr xt_one_minus        ; 1- ( addr-t u-t para1 para2-1 )
+                jsr w_one_minus        ; 1- ( addr-t u-t para1 para2-1 )
 
                 bra _cmd_d_loop
 
@@ -999,7 +1000,7 @@ _cmd_d_done:
                 lda #%01000000
                 tsb ed_flags
 
-                jsr xt_cr
+                jsr w_cr
 
                 jmp ed_next_command
 
@@ -1009,13 +1010,13 @@ _cmd_d_common:
         ; node and put it in the previous node. The caller is responsible
         ; for setting ed_changed. We arrive here with ( u )
 
-                jsr xt_dup              ; DUP ( addr-t u-t u u )
+                jsr w_dup              ; DUP ( addr-t u-t u u )
                 jsr ed_num_to_addr        ; ( addr-t u-t u addr )
-                jsr xt_fetch            ; @ ( addr-t u-t u addr1 )
-                jsr xt_swap             ; SWAP ( addr-t u-t addr1 u )
-                jsr xt_one_minus        ; 1- ( addr-t u-t addr1 u-1 )
+                jsr w_fetch            ; @ ( addr-t u-t u addr1 )
+                jsr w_swap             ; SWAP ( addr-t u-t addr1 u )
+                jsr w_one_minus        ; 1- ( addr-t u-t addr1 u-1 )
                 jsr ed_num_to_addr        ; ( addr-t u-t addr1 addr-1 )
-                jsr xt_store            ; ! ( addr-t u-t )
+                jsr w_store            ; ! ( addr-t u-t )
 
                 rts
 
@@ -1070,16 +1071,16 @@ _cmd_equ_have_para:
                 bne _cmd_equ_two_paras
 
                 ; We've got one parameter
-                jsr xt_over             ; ( addr-t u-t para1 para2 para1)
+                jsr w_over             ; ( addr-t u-t para1 para2 para1)
                 bra _cmd_equ_done
 
 _cmd_equ_two_paras:
-                jsr xt_dup              ; ( addr-t u-t para1 para2 para2) drop through
+                jsr w_dup              ; ( addr-t u-t para1 para2 para2) drop through
 
 _cmd_equ_done:
-                jsr xt_cr               ; number goes on new line
-                jsr xt_u_dot            ; ( addr-t u-t para1 para2 )
-                jsr xt_cr
+                jsr w_cr               ; number goes on new line
+                jsr w_u_dot            ; ( addr-t u-t para1 para2 )
+                jsr w_cr
 
                 jmp ed_next_command
 
@@ -1095,17 +1096,17 @@ ed_cmd_f:
                 bit ed_flags
                 bmi _cmd_f_have_para
 
-                jsr xt_cr
+                jsr w_cr
 
                 ; No parameters, just a naked "f", so print the address buried
                 ; at the fourth position of the stack: We arrive here with
                 ; ( addr-t u-t 0 0 )
-                jsr xt_to_r             ; >R   ( addr-t u-t 0 ) ( R: 0 )
-                jsr xt_rot              ; ROT  ( u-t 0 addr-t ) ( R: 0 )
-                jsr xt_dup              ; DUP  ( u-t 0 addr-t addr-t ) ( R: 0 )
-                jsr xt_u_dot            ; U.   ( u-t 0 addr-t ) ( R: 0 )
-                jsr xt_not_rote         ; -ROT ( addr-t u-t 0 ) ( R: 0 )
-                jsr xt_r_from           ; R>   ( addr-t u-t 0 0 )
+                jsr w_to_r             ; >R   ( addr-t u-t 0 ) ( R: 0 )
+                jsr w_rot              ; ROT  ( u-t 0 addr-t ) ( R: 0 )
+                jsr w_dup              ; DUP  ( u-t 0 addr-t addr-t ) ( R: 0 )
+                jsr w_u_dot            ; U.   ( u-t 0 addr-t ) ( R: 0 )
+                jsr w_not_rote         ; -ROT ( addr-t u-t 0 ) ( R: 0 )
+                jsr w_r_from           ; R>   ( addr-t u-t 0 0 )
 
                 bra _cmd_f_done
 
@@ -1113,9 +1114,9 @@ _cmd_f_have_para:
                 ; We do no sanity tests at all. This is Forth, if the user
                 ; wants to blow up the Zero Page and the Stack, sure, go right
                 ; ahead, whatever.
-                jsr xt_over
-                jsr xt_cr
-                jsr xt_u_dot
+                jsr w_over
+                jsr w_cr
+                jsr w_u_dot
 
                 lda 2,x
                 sta 6,x
@@ -1123,7 +1124,7 @@ _cmd_f_have_para:
                 sta 7,x                 ; fall through to _cmd_f_done
 
 _cmd_f_done:
-                jsr xt_cr
+                jsr w_cr
 
                 jmp ed_next_command
 
@@ -1159,9 +1160,9 @@ _cmd_i_have_para:
                 beq _cmd_i_done
 
                 ; We have some other line number, so we start one above it
-                jsr xt_one_minus        ; 1-  ( addr-t u-t para1-1 )
-                jsr xt_zero             ; 0   ( addr-t u-t para1-1 0 )
-                jsr xt_max              ; MAX ( addr-t u-t para1-1 | 0 )
+                jsr w_one_minus        ; 1-  ( addr-t u-t para1-1 )
+                jsr w_zero             ; 0   ( addr-t u-t para1-1 0 )
+                jsr w_max              ; MAX ( addr-t u-t para1-1 | 0 )
 _cmd_i_done:
                 jmp ed_entry_cmd_i
 
@@ -1200,7 +1201,7 @@ ed_cmd_p_entry_for_cmd_n:
                 jsr ed_have_text
                 jsr ed_no_line_zero
 
-                jsr xt_cr
+                jsr w_cr
 
                 ; We now know that there is some number in para1. The most
                 ; common case is that para2 is zero and we're being asked to
@@ -1218,7 +1219,7 @@ ed_cmd_p_entry_for_cmd_n:
                 ; Print a single line and be done with it. We could use
                 ; DROP here and leave immediately but we want this routine
                 ; to have a single exit at the bottom.
-                jsr xt_over             ; OVER ( addr-t u-t para1 para2 para1 )
+                jsr w_over             ; OVER ( addr-t u-t para1 para2 para1 )
                 jsr _cmd_p_common       ; ( addr-t u-t para1 para2 )
 
                 bra _cmd_p_all_done
@@ -1228,8 +1229,8 @@ _cmd_p_loop:
                 ; is a bit trickier. If para1 is larger than para2, we're
                 ; done. Note that Unix ed throws an error if we start out
                 ; that way, we might do that in future as well
-                jsr xt_two_dup          ; 2DUP ( addr-t u-t para1 para2 para1 para2 )
-                jsr xt_greater_than     ; > ( addr-t u-t para1 para2 f )
+                jsr w_two_dup          ; 2DUP ( addr-t u-t para1 para2 para1 para2 )
+                jsr w_greater_than     ; > ( addr-t u-t para1 para2 f )
 
                 lda 0,x
                 ora 1,x
@@ -1239,7 +1240,7 @@ _cmd_p_loop:
                 ; continue
                 inx
                 inx                     ; Get rid of the flag from >
-                jsr xt_over             ; ( addr-t u-t para1 para2 para1 )
+                jsr w_over             ; ( addr-t u-t para1 para2 para1 )
                 jsr _cmd_p_common       ; ( addr-t u-t para1 para2 )
 
                 inc 2,x
@@ -1276,8 +1277,8 @@ _cmd_p_common:
 
                 ; Bit 0 is set, this is coming from n. Print the line number
                 ; followed by a tab
-                jsr xt_dup              ; DUP ( addr-t u-t para1 para1 )
-                jsr xt_u_dot            ; U. ( addr-t u-t para1 )
+                jsr w_dup              ; DUP ( addr-t u-t para1 para1 )
+                jsr w_u_dot            ; U. ( addr-t u-t para1 )
 
                 lda #$09                 ; ASCII for Tab
                 jsr emit_a
@@ -1373,11 +1374,11 @@ _cmd_w_para_ready:
                 ; We need to keep a copy of the original target address to
                 ; calculate how many chars (including carriage returns) we
                 ; saved at the end of this routine
-                jsr xt_over             ; OVER ( addr-t u-t addr-t addr-h addr-t )
-                jsr xt_to_r             ; >R ( addr-t u-t addr-t addr-h ) ( R: addr-t )
+                jsr w_over             ; OVER ( addr-t u-t addr-t addr-h addr-t )
+                jsr w_to_r             ; >R ( addr-t u-t addr-t addr-h ) ( R: addr-t )
 
 _cmd_w_loop:
-                jsr xt_fetch            ; @ ( addr-t u-t addr-t addr1 ) ( R: addr-t )
+                jsr w_fetch            ; @ ( addr-t u-t addr-t addr1 ) ( R: addr-t )
 
                 ; If we're at the end of the list, quit. For the next block of
                 ; text, we ignore the ( addr-t u-t ) at the beginning
@@ -1385,42 +1386,42 @@ _cmd_w_loop:
                 ora 1,x
                 beq _cmd_w_eol
 
-                jsr xt_two_dup          ; 2DUP ( addr-t addr-1 addr-t addr-1 ) ( R: addr-t addr-1 addr-t )
-                jsr xt_two_to_r         ; 2>R  ( addr-t addr-1 ) (R: ... )
+                jsr w_two_dup          ; 2DUP ( addr-t addr-1 addr-t addr-1 ) ( R: addr-t addr-1 addr-t )
+                jsr w_two_to_r         ; 2>R  ( addr-t addr-1 ) (R: ... )
 
                 ; Get the address and length of the string from the header
                 ; of this node
-                jsr xt_one_plus         ; 1+ ( addr-t addr1+1 ) (R: ... )
-                jsr xt_one_plus         ; 1+ ( addr-t addr1+2 ) (R: ... )
-                jsr xt_dup              ; DUP ( addr-t addr1+2 addr1+2 ) ( R: ... )
-                jsr xt_fetch            ; @ ( addr-t addr1+2 addr-s ) ( R: ... )
-                jsr xt_swap             ; SWAP ( addr-t addr-s addr1+2 ) ( R: ... )
-                jsr xt_one_plus         ; 1+ ( addr-t addr-s addr1+1 ) (R: ... )
-                jsr xt_one_plus         ; 1+ ( addr-t addr-s addr1+2 ) (R: ... )
-                jsr xt_fetch            ; @ ( addr-t addr-s u-s ) ( R: ... )
-                jsr xt_not_rote         ; -ROT ( u-s addr-t addr-s ) ( R: ... )
-                jsr xt_swap             ; SWAP ( u-s addr-s addr-t ) ( R: ... )
-                jsr xt_rot              ; ROT (addr-s addr-t u-s ) ( R: ... )
+                jsr w_one_plus         ; 1+ ( addr-t addr1+1 ) (R: ... )
+                jsr w_one_plus         ; 1+ ( addr-t addr1+2 ) (R: ... )
+                jsr w_dup              ; DUP ( addr-t addr1+2 addr1+2 ) ( R: ... )
+                jsr w_fetch            ; @ ( addr-t addr1+2 addr-s ) ( R: ... )
+                jsr w_swap             ; SWAP ( addr-t addr-s addr1+2 ) ( R: ... )
+                jsr w_one_plus         ; 1+ ( addr-t addr-s addr1+1 ) (R: ... )
+                jsr w_one_plus         ; 1+ ( addr-t addr-s addr1+2 ) (R: ... )
+                jsr w_fetch            ; @ ( addr-t addr-s u-s ) ( R: ... )
+                jsr w_not_rote         ; -ROT ( u-s addr-t addr-s ) ( R: ... )
+                jsr w_swap             ; SWAP ( u-s addr-s addr-t ) ( R: ... )
+                jsr w_rot              ; ROT (addr-s addr-t u-s ) ( R: ... )
 
                 ; We need a copy of the string length u-s to adjust the pointer
                 ; to the store area later
-                jsr xt_dup              ; DUP (addr-s addr-t u-s u-s ) ( R: ... )
-                jsr xt_to_r             ; >R (addr-s addr-t u-s ) ( R: ... u-s )
+                jsr w_dup              ; DUP (addr-s addr-t u-s u-s ) ( R: ... )
+                jsr w_to_r             ; >R (addr-s addr-t u-s ) ( R: ... u-s )
 
-                jsr xt_move             ; MOVE ( )( R: addr-t addr-1 addr-t )
+                jsr w_move             ; MOVE ( )( R: addr-t addr-1 addr-t )
 
                 ; Calculate the position of the next string in the save area.
                 ; What we don't do is remember the length of the individual
                 ; strings; instead at the end we will subtract addresses to
                 ; get the length of the string
-                jsr xt_r_from           ; R> ( u-s )  ( R: addr-t addr-h addr-t )
-                jsr xt_two_r_from       ; 2R> ( u-s addr-t addr-h ) ( R: addr-t )
-                jsr xt_not_rote         ; -ROT ( addr-h u-s addr-t ) ( R: addr-t )
-                jsr xt_plus             ; + ( addr-h addr-t1 ) ( R: addr-t )
+                jsr w_r_from           ; R> ( u-s )  ( R: addr-t addr-h addr-t )
+                jsr w_two_r_from       ; 2R> ( u-s addr-t addr-h ) ( R: addr-t )
+                jsr w_not_rote         ; -ROT ( addr-h u-s addr-t ) ( R: addr-t )
+                jsr w_plus             ; + ( addr-h addr-t1 ) ( R: addr-t )
 
                 ; But wait, our strings are terminated by Line Feeds in
                 ; memory, so we need to add one
-                jsr xt_dup              ; DUP ( addr-h addr-t1 addr-t1 ) ( R: addr-t )
+                jsr w_dup              ; DUP ( addr-h addr-t1 addr-t1 ) ( R: addr-t )
 
                 dex
                 dex                     ; ( addr-h addr-t1 addr-t1 ? ) ( R: addr-t )
@@ -1428,12 +1429,12 @@ _cmd_w_loop:
                 sta 0,x
                 stz 1,x                 ; ( addr-h addr-t1 addr-t1 c ) ( R: addr-t )
 
-                jsr xt_swap             ; SWAP ( addr-h addr-t1 c addr-t1 ) ( R: addr-t )
-                jsr xt_store            ; ! ( addr-h addr-t1 ) ( R: addr-t )
-                jsr xt_one_plus         ; 1+ ( addr-h addr-t1+1 ) ( R: addr-t )
+                jsr w_swap             ; SWAP ( addr-h addr-t1 c addr-t1 ) ( R: addr-t )
+                jsr w_store            ; ! ( addr-h addr-t1 ) ( R: addr-t )
+                jsr w_one_plus         ; 1+ ( addr-h addr-t1+1 ) ( R: addr-t )
 
                 ; Now we can handle the next line
-                jsr xt_swap             ; SWAP ( addr-t1+1 addr-h ) ( R: addr-t )
+                jsr w_swap             ; SWAP ( addr-t1+1 addr-h ) ( R: addr-t )
 
                 bra _cmd_w_loop
 
@@ -1442,9 +1443,9 @@ _cmd_w_eol:
                 ; ( addr-tn addr-n ) ( R: addr-t ) What we do now is calculate
                 ; the number of characters saved and put that value in the 3OS
                 ; position
-                jsr xt_swap             ; SWAP ( addr-t u-t addr-n addr-tn ) ( R: addr-t )
-                jsr xt_r_from           ; R> ( addr-t u-t addr-n addr-tn addr-t )
-                jsr xt_minus            ; - ( addr-t u-t addr-n u )
+                jsr w_swap             ; SWAP ( addr-t u-t addr-n addr-tn ) ( R: addr-t )
+                jsr w_r_from           ; R> ( addr-t u-t addr-n addr-tn addr-t )
+                jsr w_minus            ; - ( addr-t u-t addr-n u )
 
                 lda 0,x
                 sta 4,x
@@ -1453,10 +1454,10 @@ _cmd_w_eol:
 
                 ; Unix ed puts the number of characters on a new line, so we
                 ; do as well
-                jsr xt_cr
-                jsr xt_dup              ; DUP ( addr-t u addr-n u u )
-                jsr xt_u_dot            ; U. ( addr-t u addr-n u )
-                jsr xt_cr
+                jsr w_cr
+                jsr w_dup              ; DUP ( addr-t u addr-n u u )
+                jsr w_u_dot            ; U. ( addr-t u addr-n u )
+                jsr w_cr
 
                 ; Reset the changed flag
                 lda #%01000000
@@ -1481,12 +1482,12 @@ ed_error:
                 ; clean up the stack itself: We expect it to be empty. Note that
                 ; ed currently does not support reporting the type of error on
                 ; demand like Unix ed does
-                jsr xt_cr
+                jsr w_cr
 
                 lda #'?'
                 jsr emit_a
 
-                jsr xt_cr
+                jsr w_cr
 
                 jmp ed_input_loop
 
@@ -1496,7 +1497,7 @@ ed_error:
 ed_get_input:
         ; Use REFILL to get input from the user, which is left in
         ; ( cib ciblen ) as usual.
-                jsr xt_refill           ;  ( addr-t u-t f )
+                jsr w_refill           ;  ( addr-t u-t f )
 
                 ; If something went wrong while getting the user input, print
                 ; a question mark and try again. No fancy error messages
@@ -1550,10 +1551,10 @@ ed_is_valid_line:
                 beq _is_valid_line_nope_zero    ; ( n )
 
                 ; Not a zero. Now see if we're beyond the last line
-                jsr xt_dup                      ; DUP ( n n )
+                jsr w_dup                      ; DUP ( n n )
                 jsr ed_last_line                  ; ( n n last )
-                jsr xt_swap                     ; SWAP ( n last n )
-                jsr xt_less_than                ; < ( n f )
+                jsr w_swap                     ; SWAP ( n last n )
+                jsr w_less_than                ; < ( n f )
 
                 lda 0,x                         ; 0 flag is good
                 ora 1,x
@@ -1595,7 +1596,7 @@ ed_last_line:
                 sta 1,x                 ; ( addr )
 
 _last_line_loop:
-                jsr xt_fetch            ; ( addr | 0 )
+                jsr w_fetch            ; ( addr | 0 )
 
                 ; If that's over, we're at the end of the list and we're done
                 lda 0,x
@@ -1665,32 +1666,32 @@ ed_num_to_addr:
                 bne _num_to_addr_loop
 
                 ; It's zero, so we're already done
-                jsr xt_nip              ; ( addr-h )
+                jsr w_nip              ; ( addr-h )
                 bra _num_to_addr_done
 
 _num_to_addr_loop:
                 ; Get the first line
-                jsr xt_fetch            ; @ ( u addr1 )
+                jsr w_fetch            ; @ ( u addr1 )
 
                 ; If that's zero, we're at the end of the list and it's over
                 lda 0,x
                 ora 1,x
                 bne +
 
-                jsr xt_nip              ; NIP ( addr1 )
+                jsr w_nip              ; NIP ( addr1 )
                 bra _num_to_addr_done
 +
                 ; It's not zero. See if this is the nth element we're looking
                 ; for
-                jsr xt_swap             ; SWAP ( addr1 u )
-                jsr xt_one_minus        ; 1- ( addr1 u-1 )
+                jsr w_swap             ; SWAP ( addr1 u )
+                jsr w_one_minus        ; 1- ( addr1 u-1 )
 
                 lda 0,x
                 ora 1,x
                 beq _num_to_addr_finished
 
                 ; Not zero yet, try again
-                jsr xt_swap             ; SWAP ( u-1 addr1 )
+                jsr w_swap             ; SWAP ( u-1 addr1 )
 
                 bra _num_to_addr_loop
 
@@ -1721,21 +1722,21 @@ ed_print_addr:
         ; Assumes we have made sure that this address exists. It would be
         ; nice to put the CR at the beginning, but that doesn't work with
         ; the n commands, so at the end it goes. Consumes TOS.
-                jsr xt_one_plus
-                jsr xt_one_plus         ; ( addr+2 )
+                jsr w_one_plus
+                jsr w_one_plus         ; ( addr+2 )
 
-                jsr xt_dup              ; ( addr+2 addr+2 )
+                jsr w_dup              ; ( addr+2 addr+2 )
 
-                jsr xt_one_plus
-                jsr xt_one_plus         ; ( addr+2 addr+4 )
+                jsr w_one_plus
+                jsr w_one_plus         ; ( addr+2 addr+4 )
 
-                jsr xt_fetch            ; ( addr+2 u-s )
-                jsr xt_swap             ; ( u-s addr+2 )
-                jsr xt_fetch            ; ( u-s addr-s )
+                jsr w_fetch            ; ( addr+2 u-s )
+                jsr w_swap             ; ( u-s addr+2 )
+                jsr w_fetch            ; ( u-s addr-s )
 
-                jsr xt_swap             ; ( addr-s u-s )
-                jsr xt_type
-                jsr xt_cr
+                jsr w_swap             ; ( addr-s u-s )
+                jsr w_type
+                jsr w_cr
 
                 rts
 

--- a/words/editor.asm
+++ b/words/editor.asm
@@ -5,22 +5,24 @@
 ; to get a buffer for the given screen number and set SCR to
 ; the given screen number.  This word is not in the dictionary.
 xt_editor_screen_helper:
-                jsr xt_dup
-                jsr xt_scr
-                jsr xt_store
-                jmp xt_buffer
+w_editor_screen_helper:
+                jsr w_dup
+                jsr w_scr
+                jsr w_store
+                jmp w_buffer
 
 
 ; ## EDITOR_ENTER_SCREEN ( scr# -- ) "Enter all lines for given screen"
 ; ## "enter-screen"  auto  Tali Editor
 
 xt_editor_enter_screen:
+w_editor_enter_screen:
                 ; Set the variable SCR and get a buffer for the
                 ; given screen number.
-                jsr xt_editor_screen_helper
+                jsr w_editor_screen_helper
 
                 ; Drop the buffer address.
-                jsr xt_drop
+                jsr w_drop
 
                 ; Overwrite the lines one at a time.
                 stz ed_head
@@ -33,7 +35,7 @@ _prompt_loop:
                 stz 1,x
 
                 ; Use the O word to prompt for overwrite.
-                jsr xt_editor_o
+                jsr w_editor_o
 
                 ; Move on to the next line.
                 inc ed_head
@@ -49,9 +51,10 @@ z_editor_enter_screen:
 ; ## EDITOR_ERASE_SCREEN ( scr# -- ) "Erase all lines for given screen"
 ; ## "erase-screen"  tested  Tali Editor
 xt_editor_erase_screen:
+w_editor_erase_screen:
                 ; Set the variable SCR and get a buffer for the
                 ; given screen number.
-                jsr xt_editor_screen_helper
+                jsr w_editor_screen_helper
 
                 ; Put 1024 (chars/screen) on stack.
                 dex
@@ -61,10 +64,10 @@ xt_editor_erase_screen:
                 sta 1,x
 
                 ; Erase the entire block (fill with spaces).
-                jsr xt_blank
+                jsr w_blank
 
                 ; Mark buffer as updated.
-                jsr xt_update
+                jsr w_update
 
 z_editor_erase_screen:
                 rts
@@ -74,10 +77,11 @@ z_editor_erase_screen:
 ; ## EDITOR_EL ( line# -- ) "Erase the given line number"
 ; ## "el"  tested  Tali Editor
 xt_editor_el:
+w_editor_el:
                 ; Turn the line number into buffer offset.
                 ; This also loads the block into the buffer if it's
                 ; not there for some reason.
-                jsr xt_editor_line
+                jsr w_editor_line
 
                 ; Put 64 (# of chars/line) on the stack.
                 dex
@@ -87,10 +91,10 @@ xt_editor_el:
                 stz 1,x
 
                 ; Fill with spaces.
-                jsr xt_blank
+                jsr w_blank
 
                 ; Mark buffer as updated.
-                jsr xt_update
+                jsr w_update
 
 z_editor_el:    rts
 
@@ -101,6 +105,7 @@ z_editor_el:    rts
 ; note "l" is used by LIST in the block words
 
 xt_editor_l:
+w_editor_l:
                 ; Load the current screen
                 dex             ; Put SCR on the stack.
                 dex
@@ -110,9 +115,9 @@ xt_editor_l:
                 iny
                 lda (up),y
                 sta 1,x
-                jsr xt_block    ; Get the current screen.
+                jsr w_block    ; Get the current screen.
 
-                jsr xt_cr
+                jsr w_cr
 
                 ; Print the screen number.
                 ; We're using sliteral, so we need to set up the
@@ -126,17 +131,17 @@ _after_screen_msg:
                 jsr sliteral_runtime
                 .word _screen_msg, _after_screen_msg-_screen_msg
 
-                jsr xt_type
+                jsr w_type
 
                 ; Put the screen number and printed size for u.r on the stack.
-                jsr xt_scr
-                jsr xt_fetch
+                jsr w_scr
+                jsr w_fetch
                 dex
                 dex
                 lda #4          ; four spaces
                 sta 0,x
                 stz 1,x
-                jsr xt_u_dot_r
+                jsr w_u_dot_r
 
                 ; The address of the buffer is currently on the stack.
                 ; Print 64 chars at a time. TYPE uses tmp1, so we'll
@@ -144,7 +149,7 @@ _after_screen_msg:
                 stz tmp3
 
 _line_loop:
-                jsr xt_cr
+                jsr w_cr
 
                 ; Print the line number (2-space fixed width)
                 dex
@@ -157,17 +162,17 @@ _line_loop:
                 stz 1,x
                 lda #2
                 sta 0,x
-                jsr xt_u_dot_r
-                jsr xt_space
+                jsr w_u_dot_r
+                jsr w_space
 
                 ; Print one line using the address on the stack.
-                jsr xt_dup
+                jsr w_dup
                 dex
                 dex
                 lda #64
                 sta 0,x
                 stz 1,x
-                jsr xt_type
+                jsr w_type
 
                 ; Add 64 to the address on the stack to move to the next line.
                 clc
@@ -185,7 +190,7 @@ _line_loop:
                 cmp #16
                 bne _line_loop
 
-                jsr xt_cr
+                jsr w_cr
                 ; Drop the address on the stack.
                 inx
                 inx
@@ -199,7 +204,7 @@ z_editor_l:            rts
 
 xt_editor_line:
                 jsr underflow_1
-
+w_editor_line:
                 ; Multiply the TOS by 64 (chars/line) to compute offset.
                 ldy #6          ; *64 is same as left shift 6 times.
 _shift_tos_left:
@@ -209,12 +214,12 @@ _shift_tos_left:
                 bne _shift_tos_left
                 ; Load the current screen into a buffer
                 ; and get the buffer address
-                jsr xt_scr
-                jsr xt_fetch
-                jsr xt_block
+                jsr w_scr
+                jsr w_fetch
+                jsr w_block
 
                 ; Add the offset to the buffer base address.
-                jsr xt_plus
+                jsr w_plus
 
 z_editor_line:  rts
 
@@ -223,41 +228,42 @@ z_editor_line:  rts
 ; ## EDITOR_O ( line# -- ) "Overwrite the given line"
 ; ## "o"  tested  Tali Editor
 xt_editor_o:
+w_editor_o:
                 ; Print prompt
-                jsr xt_cr
-                jsr xt_dup
-                jsr xt_two
-                jsr xt_u_dot_r
-                jsr xt_space
+                jsr w_cr
+                jsr w_dup
+                jsr w_two
+                jsr w_u_dot_r
+                jsr w_space
                 lda #'*'
                 jsr emit_a
-                jsr xt_space
+                jsr w_space
 
                 ; Accept new input (directly into the buffer)
-                jsr xt_editor_line
-                jsr xt_dup      ; Save a copy of the line address for later.
+                jsr w_editor_line
+                jsr w_dup      ; Save a copy of the line address for later.
                 dex
                 dex
                 lda #64         ; chars/line
                 sta 0,x
                 stz 1,x
-                jsr xt_accept
+                jsr w_accept
 
                 ; Fill the rest with spaces.
                 ; Stack is currently ( line_address numchars_from_accept )
-                jsr xt_dup
-                jsr xt_not_rote ; -rot
-                jsr xt_plus
+                jsr w_dup
+                jsr w_not_rote ; -rot
+                jsr w_plus
                 dex
                 dex
                 lda #64         ; chars/line
                 sta 0,x
                 stz 1,x
-                jsr xt_rot
-                jsr xt_minus
-                jsr xt_blank
+                jsr w_rot
+                jsr w_minus
+                jsr w_blank
 
                 ; Mark buffer as updated.
-                jsr xt_update
+                jsr w_update
 
 z_editor_o:     rts

--- a/words/string.asm
+++ b/words/string.asm
@@ -10,7 +10,7 @@
         ; """
 xt_cmove:
                 jsr underflow_3
-
+w_cmove:
                 ; move destination address to where we can work with it
                 lda 2,x
                 sta tmp2        ; use tmp2 because easier to remember
@@ -69,7 +69,7 @@ z_cmove:        rts
         ; """
 xt_cmove_up:
                 jsr underflow_3
-
+w_cmove_up:
                 ; Move destination address to where we can work with it
                 lda 2,x
                 sta tmp2        ; use tmp2 because easier to remember
@@ -132,7 +132,7 @@ z_cmove_up:     rts
         ; """
 xt_compare:
                 jsr underflow_4
-
+w_compare:
                 ; Load the two string addresses into tmp1 and tmp2.
                 lda 2,x
                 sta tmp2
@@ -233,7 +233,7 @@ z_compare:      rts
 
 xt_minus_leading:
                 jsr underflow_2
-
+w_minus_leading:
 _loop:
                 ; Quit if we were given an empty string. This also terminates
                 ; the main loop
@@ -246,8 +246,8 @@ _loop:
                 bcc _done
 
                 ; It's whitespace, move one down
-                jsr xt_one              ; ( addr u 1 )
-                jsr xt_slash_string     ; ( addr+ u-1 )
+                jsr w_one              ; ( addr u 1 )
+                jsr w_slash_string     ; ( addr+ u-1 )
 
                 bra _loop
 _done:
@@ -264,7 +264,7 @@ z_minus_leading:
 
 xt_minus_trailing:
                 jsr underflow_2
-
+w_minus_trailing:
                 ; if length entry is zero, return a zero and leave the
                 ; address part untouched
                 lda 0,x         ; LSB of n
@@ -337,7 +337,7 @@ z_minus_trailing:
 
 xt_search:
                 jsr underflow_4
-
+w_search:
                 ; ANS says if the second string is a zero-length string it
                 ; automatically matches.
                 lda 0,x
@@ -355,7 +355,7 @@ xt_search:
 
 _start_search:
                 ; Put an offset (starting at zero) on the stack.
-                jsr xt_zero
+                jsr w_zero
 
 _search_loop:
                 ; We stop (not found) when u2 + offset > u1
@@ -425,7 +425,7 @@ _comparison_loop:
 
                 ; One of the letters didn't match.
                 ; Increment the offset and try again.
-                jsr xt_one_plus
+                jsr w_one_plus
                 bra _search_loop
 
 _letters_match:
@@ -496,7 +496,7 @@ z_search:       rts
 
 xt_slash_string:
                 jsr underflow_3
-
+w_slash_string:
                 clc             ; 3OS+TOS
                 lda 0,x
                 adc 4,x
@@ -530,7 +530,7 @@ z_slash_string: rts
 
 xt_sliteral:
                 jsr underflow_2
-
+w_sliteral:
                 ; We can't assume that ( addr u ) of the current string is in
                 ; a stable area (eg. already in the dictionary.)
                 ; We'll compile the string data into the dictionary using move
@@ -542,22 +542,22 @@ xt_sliteral:
                 ;   < _str u >
 
                 jsr cmpl_jump_later
-                jsr xt_to_r
+                jsr w_to_r
                 ; ( addr u  R: jmp-target )
-                jsr xt_here
-                jsr xt_swap
+                jsr w_here
+                jsr w_swap
                 ; ( addr addr' u )
-                jsr xt_dup
-                jsr xt_allot            ; reserve u bytes for string
-                jsr xt_here
+                jsr w_dup
+                jsr w_allot            ; reserve u bytes for string
+                jsr w_here
                 ; ( addr addr' u addr'+u )
-                jsr xt_r_from
-                jsr xt_store            ; point jmp past string
-                jsr xt_two_dup
-                jsr xt_two_to_r
+                jsr w_r_from
+                jsr w_store            ; point jmp past string
+                jsr w_two_dup
+                jsr w_two_to_r
                 ; ( addr addr' u  R: addr' u )
-                jsr xt_move             ; copy u bytes from addr -> addr'
-                jsr xt_two_r_from
+                jsr w_move             ; copy u bytes from addr -> addr'
+                jsr w_two_r_from
                 ; Stack is now ( addr' u ) with the new string location
 
 cmpl_sliteral:

--- a/words/tali.asm
+++ b/words/tali.asm
@@ -1,6 +1,7 @@
 ; ## ALLOW_NATIVE ( -- ) "Flag last word to allow native compiling"
 ; ## "allow-native"  auto  Tali Forth
 xt_allow_native:
+w_allow_native:
                 jsr current_to_dp
                 ldy #1          ; offset for status byte
                 lda (dp),y
@@ -14,6 +15,7 @@ z_allow_native:
 ; ## ALWAYS_NATIVE ( -- ) "Flag last word as always natively compiled"
 ; ## "always-native"  auto  Tali Forth
 xt_always_native:
+w_always_native:
                 jsr current_to_dp
                 ldy #1          ; offset for status byte
                 lda (dp),y
@@ -28,6 +30,7 @@ z_always_native:
 ; ## BELL ( -- ) "Emit ASCII BELL"
 ; ## "bell"  tested  Tali Forth
 xt_bell:
+w_bell:
                 lda #7          ; ASCII value for BELl
                 jsr emit_a
 
@@ -44,7 +47,7 @@ z_bell:         rts
         ; """
 xt_bounds:
                 jsr underflow_2
-
+w_bounds:
                 clc
                 lda 0,x                 ; LSB u
                 ldy 2,x                 ; LSB addr
@@ -79,19 +82,19 @@ z_bounds:       rts
         ; """
 xt_cleave:
                 jsr underflow_2
-
+w_cleave:
                 ; We arrive here with ( addr u ). We need to strip any leading
                 ; spaces by hand: PARSE-NAME does do that, but it doesn't
                 ; remember how many spaces were stripped. This means we can't
                 ; calculate the length of the remainder. Fortunately, Tali
                 ; Forth has just the word we need for this:
-                jsr xt_minus_leading    ; -LEADING ( addr u )
+                jsr w_minus_leading    ; -LEADING ( addr u )
 
                 ; The main part we can turn over to PARSE-NAME, except that we
                 ; have a string ( addr u ) and not stuff in the input buffer.
                 ; We get around this by cheating: We place ( addr u ) in the
                 ; input buffer and then call PARSE-NAME.
-                jsr xt_input_to_r       ; save old imput state
+                jsr w_input_to_r       ; save old imput state
 
                 lda 0,x         ; u is new ciblen
                 sta ciblen
@@ -107,7 +110,7 @@ xt_cleave:
                 stz toin+1
 
                 ; PARSE-NAME gives us back the substring of the first word
-                jsr xt_parse_name       ; ( addr u addr-s u-s )
+                jsr w_parse_name       ; ( addr u addr-s u-s )
 
                 ; If we were given an empty string, then we're done. It's the
                 ; resposibility of the user to catch this as a sign to end the
@@ -138,12 +141,12 @@ xt_cleave:
                 ; There is one small problem: PARSE-NAME will probably have
                 ; left the string with the rest of the words with leading
                 ; delimiters. We use our magic -LEADING again
-                jsr xt_two_swap         ; ( addr-s u-s addr u )
-                jsr xt_minus_leading
-                jsr xt_two_swap         ; ( addr u addr-s u-s )
+                jsr w_two_swap         ; ( addr-s u-s addr u )
+                jsr w_minus_leading
+                jsr w_two_swap         ; ( addr u addr-s u-s )
 _done:
                 ; Restore input
-                jsr xt_r_to_input
+                jsr w_r_to_input
 
 z_cleave:       rts
 
@@ -161,7 +164,7 @@ z_cleave:       rts
 
 xt_digit_question:
                 jsr underflow_1
-
+w_digit_question:
                 ; one way or another, we're going to need room for the
                 ; flag on the stack
                 dex
@@ -233,9 +236,9 @@ z_digit_question:
         ; """
 xt_execute_parsing:
                 jsr underflow_3
-
-                jsr xt_input_to_r       ; save normal input for later
-                jsr xt_not_rote         ; -ROT ( xt addr u )
+w_execute_parsing:
+                jsr w_input_to_r       ; save normal input for later
+                jsr w_not_rote         ; -ROT ( xt addr u )
 
                 lda 0,x                 ; TOS is new ciblen
                 sta ciblen
@@ -250,10 +253,10 @@ xt_execute_parsing:
                 stz toin                ; Set >IN to zero
                 stz toin+1
 
-                jsr xt_two_drop         ; 2DROP ( xt )
-                jsr xt_execute
+                jsr w_two_drop         ; 2DROP ( xt )
+                jsr w_execute
 
-                jsr xt_r_to_input
+                jsr w_r_to_input
 
 z_execute_parsing:
                 rts
@@ -274,7 +277,7 @@ xt_find_name:
         ; FIND calls this word
         ; """
                 jsr underflow_2
-
+w_find_name:
                 ; check for special case of an empty string (length zero)
                 lda 0,x
                 ora 1,x
@@ -345,6 +348,7 @@ z_find_name:    rts
 ; ## "havekey" tested Tali Forth
 
 xt_havekey:
+w_havekey:
                 dex
                 dex
                 lda #<havekey
@@ -365,9 +369,9 @@ z_havekey:      rts
 
 xt_hexstore:
                 jsr underflow_3
-
-                jsr xt_dup              ; Save copy of original address
-                jsr xt_two_to_r         ; ( addr1 u1 ) ( R: addr2 addr2 )
+w_hexstore:
+                jsr w_dup              ; Save copy of original address
+                jsr w_two_to_r         ; ( addr1 u1 ) ( R: addr2 addr2 )
 
 _loop:
                 ; Loop until string is totally consumed
@@ -375,14 +379,14 @@ _loop:
                 ora 1,x
                 beq _done
 
-                jsr xt_cleave           ; ( addr1 u1 addr3 u3 ) ( R: addr2 addr2 )
+                jsr w_cleave           ; ( addr1 u1 addr3 u3 ) ( R: addr2 addr2 )
 
                 ; Prepare the conversion of the number.
-                jsr xt_two_to_r
-                jsr xt_zero
-                jsr xt_zero
-                jsr xt_two_r_from       ; ( addr1 u1 0 0 addr3 u3 ) ( R: addr2 addr2 )
-                jsr xt_to_number        ; ( addr1 u1 n n addr4 u4 ) ( R: addr2 addr2 )
+                jsr w_two_to_r
+                jsr w_zero
+                jsr w_zero
+                jsr w_two_r_from       ; ( addr1 u1 0 0 addr3 u3 ) ( R: addr2 addr2 )
+                jsr w_to_number        ; ( addr1 u1 n n addr4 u4 ) ( R: addr2 addr2 )
 
                 ; If u4 is not zero, we have leftover chars and have to do
                 ; things differently
@@ -391,17 +395,17 @@ _loop:
                 bne _have_chars_left
 
                 ; Normal case, this number is all done
-                jsr xt_two_drop         ; ( addr1 u1 n n ) ( R: addr2 addr2 )
-                jsr xt_d_to_s           ; ( addr1 u1 n ) ( R: addr2 addr2 )
+                jsr w_two_drop         ; ( addr1 u1 n n ) ( R: addr2 addr2 )
+                jsr w_d_to_s           ; ( addr1 u1 n ) ( R: addr2 addr2 )
 
                 ; Store the new value
-                jsr xt_r_fetch          ; ( addr1 u1 n addr2 ) ( R: addr2 addr2 )
-                jsr xt_c_store          ; ( addr1 u1 ) ( R: addr2 addr2 )
+                jsr w_r_fetch          ; ( addr1 u1 n addr2 ) ( R: addr2 addr2 )
+                jsr w_c_store          ; ( addr1 u1 ) ( R: addr2 addr2 )
 
                 ; Increase counter
-                jsr xt_r_from           ; R>
-                jsr xt_one_plus         ; 1+
-                jsr xt_to_r             ; >R ( addr1 u1 ) ( R: addr2+1 addr2 )
+                jsr w_r_from           ; R>
+                jsr w_one_plus         ; 1+
+                jsr w_to_r             ; >R ( addr1 u1 ) ( R: addr2+1 addr2 )
                 bra _loop
 
 _have_chars_left:
@@ -421,9 +425,9 @@ _done:
                 inx
                 inx                     ; 2DROP
 
-                jsr xt_two_r_from       ; ( addr2+n addr2 )
-                jsr xt_swap
-                jsr xt_minus            ; ( n )
+                jsr w_two_r_from       ; ( addr2+n addr2 )
+                jsr w_swap
+                jsr w_minus            ; ( n )
 
 z_hexstore:     rts
 
@@ -433,6 +437,7 @@ z_hexstore:     rts
 ; ## "input" tested Tali Forth
 
 xt_input:
+w_input:
                 dex
                 dex
                 lda #<input
@@ -466,6 +471,7 @@ z_input:        rts
         ; """
 
 xt_input_to_r:
+w_input_to_r:
                 ; We arrive here with the return address on the top of the
                 ; 65c02's stack. We need to move it out of the way first
                 pla
@@ -502,7 +508,7 @@ z_input_to_r: 	rts
 
 xt_int_to_name:
                 jsr underflow_1
-
+w_int_to_name:
                 ; Unfortunately, to find the header, we have to walk through
                 ; all of the wordlists. We are running out of tmp variables.
                 ; (I'm assuming there is a reason this is avoiding tmp1) so
@@ -618,6 +624,7 @@ z_int_to_name:  rts
         ; The Gforth version of this word is called LATEST
         ; """
 xt_latestnt:
+w_latestnt:
                 dex
                 dex
 
@@ -635,8 +642,9 @@ z_latestnt:     rts
 ; ## "latestxt"  auto  Gforth
         ; """http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Anonymous-Definitions.html"""
 xt_latestxt:
-                jsr xt_latestnt         ; ( nt )
-                jsr xt_name_to_int      ; ( xt )
+w_latestxt:
+                jsr w_latestnt         ; ( nt )
+                jsr w_name_to_int      ; ( xt )
 
 z_latestxt:     rts
 
@@ -650,7 +658,7 @@ z_latestxt:     rts
 
 xt_name_to_int:
                 jsr underflow_1
-
+w_name_to_int:
                 ; The xt starts four bytes down from the nt
                 lda 0,x
                 clc
@@ -680,7 +688,7 @@ z_name_to_int:  rts
 
 xt_name_to_string:
                 jsr underflow_1
-
+w_name_to_string:
                 dex
                 dex
 
@@ -706,6 +714,7 @@ z_name_to_string:
 ; ## "nc-limit"  tested  Tali Forth
 
 xt_nc_limit:
+w_nc_limit:
                 lda #nc_limit_offset
                 jmp push_upvar_tos
 z_nc_limit:
@@ -715,6 +724,7 @@ z_nc_limit:
 ; ## NEVER_NATIVE ( -- ) "Flag last word as never natively compiled"
 ; ## "never-native"  auto  Tali Forth
 xt_never_native:
+w_never_native:
                 jsr current_to_dp
                 ldy #1          ; offset for status byte
                 lda (dp),y
@@ -732,7 +742,7 @@ z_never_native:
 
 xt_not_rote:
                 jsr underflow_3
-
+w_not_rote:
                 ldy 1,x         ; MSB first
                 lda 3,x
                 sta 1,x
@@ -773,7 +783,7 @@ z_not_rote:     rts
 
 xt_number:
                 jsr underflow_2
-
+w_number:
                 ; we keep the flags for sign and double in tmpdsp because
                 ; we've run out of temporary variables
                 ; sign will be the sign bit, and double will be bit 1
@@ -786,7 +796,7 @@ xt_number:
                 pha
 
                 ; Make a copy of the addr u in case we need to print an error message.
-                jsr xt_two_dup
+                jsr w_two_dup
 
                 ; Look at the first character.
                 lda (2,x)
@@ -923,7 +933,7 @@ _main:
                 stz 6,x
                 stz 7,x
 
-                jsr xt_to_number        ; (ud addr u -- ud addr u )
+                jsr w_to_number        ; (ud addr u -- ud addr u )
 
                 ; test length of returned string, which should be zero
                 lda 0,x
@@ -938,15 +948,15 @@ _number_error:
                 ; Drop the addr u from >NUMBER and the double
                 ; (partially converted number) and print the unkown
                 ; word using the original addr u we saved at the beginning.
-                jsr xt_two_drop ; >NUMBER modified addr u
-                jsr xt_two_drop ; ud   (partially converted number)
+                jsr w_two_drop ; >NUMBER modified addr u
+                jsr w_two_drop ; ud   (partially converted number)
 
                 lda #'>'
                 jsr emit_a
-                jsr xt_type
+                jsr w_type
                 lda #'<'
                 jsr emit_a
-                jsr xt_space
+                jsr w_space
 
                 ; Pull the base of the stack and restore it.
                 pla
@@ -962,8 +972,8 @@ _all_converted:
                 inx
                 inx
 _drop_original_string:
-                jsr xt_two_swap  ; Drop the original addr u
-                jsr xt_two_drop  ; (was saved for unknown word error message)
+                jsr w_two_swap  ; Drop the original addr u
+                jsr w_two_drop  ; (was saved for unknown word error message)
 
                 ; We have a double-cell number on the Data Stack that might
                 ; actually have a minus and might actually be single-cell
@@ -979,7 +989,7 @@ _drop_original_string:
                 ; This is a double cell number. If it had a minus (C=1) negate it
                 bcc _done       ; no minus, all done
 
-                jsr xt_dnegate
+                jsr w_dnegate
 
                 bra _done
 
@@ -995,7 +1005,7 @@ _single:
                 ; If we had a minus (C=1), we'll have to negate it
                 bcc _done       ; no minus, all done
 
-                jsr xt_negate
+                jsr w_negate
 _done:
                 ; Restore the base (in case it was changed by #/$/%)
                 pla
@@ -1009,6 +1019,8 @@ z_number:       rts
         ; """This is also the code for EDITOR-WORDLIST"""
 xt_editor_wordlist:
 xt_one:
+w_editor_wordlist:
+w_one:
                 dex
                 dex
                 lda #1
@@ -1024,6 +1036,7 @@ z_one:
 ; ## OUTPUT ( -- addr ) "Return the address of the EMIT vector address"
 ; ## "output"  tested  Tali Forth
 xt_output:
+w_output:
         ; """Return the address where the jump target for EMIT is stored (but
         ; not the vector itself). By default, this will hold the value of
         ; kernel_putc routine, but this can be changed by the user, hence this
@@ -1049,7 +1062,7 @@ z_output:       rts
         ; """
 
 xt_r_to_input:
-
+w_r_to_input:
                 ; We arrive here with the return address on the top of the
                 ; 65c02's stack. We need to move it out of the way first
                 pla
@@ -1086,6 +1099,7 @@ z_r_to_input: 	rts
         ; Default is false.
         ; """
 xt_strip_underflow:
+w_strip_underflow:
                 lda #uf_strip_offset
                 jmp push_upvar_tos
 z_strip_underflow:
@@ -1098,6 +1112,8 @@ z_strip_underflow:
         ; This code is shared with ASSEMBLER-WORDLIST
 xt_assembler_wordlist:
 xt_two:
+w_assembler_wordlist:
+w_two:
                 dex
                 dex
                 lda #2
@@ -1112,6 +1128,7 @@ z_two:          rts
 ; ## USERADDR ( -- addr ) "Push address of base address of user variables"
 ; ## "useraddr"  tested  Tali Forth
 xt_useraddr:
+w_useraddr:
                 dex
                 dex
                 lda #<up
@@ -1131,7 +1148,7 @@ z_useraddr:     rts
         ; """
 xt_wordsize:
                 jsr underflow_1
-
+w_wordsize:
                 ; We get the start address of the word from its header entry
                 ; for the start of the actual code (execution token, xt)
                 ; which is four bytes down, and the pointer to the end of the
@@ -1171,6 +1188,10 @@ xt_case:
 xt_false:
 xt_forth_wordlist:
 xt_zero:
+w_case:
+w_false:
+w_forth_wordlist:
+w_zero:
                 dex             ; push
                 dex
                 stz 0,x

--- a/words/tools.asm
+++ b/words/tools.asm
@@ -2,6 +2,7 @@
 ; ## "bye"  tested  ANS tools ext
         ; """https://forth-standard.org/standard/tools/BYE"""
 xt_bye:
+w_bye:
                 ; Use the kernel_bye routine provided in the platform
                 ; file.  For simulators, this is traditionally just a
                 ; brk instruction, but platforms with another OS can
@@ -23,7 +24,8 @@ z_bye:
         ; """
 
 xt_dot_s:
-                jsr xt_depth    ; ( -- u )
+w_dot_s:
+                jsr w_depth    ; ( -- u )
 
                 ; Print stack depth in brackets
                 lda #'<'
@@ -77,7 +79,7 @@ _loop:
                 dec tmp3
                 phy
 
-                jsr xt_dot
+                jsr w_dot
 
                 ply
                 dey
@@ -102,6 +104,7 @@ z_dot_s:        rts
 
 xt_dump:
                 jsr underflow_2
+w_dump:
 _row:
                 ; start counter for 16 numbers per row
                 ldy #16
@@ -111,7 +114,7 @@ _row:
                 ; start saving them at HERE (CP)
                 stz tmp2
 
-                jsr xt_cr
+                jsr w_cr
 
                 ; print address number
                 lda 3,x
@@ -119,8 +122,8 @@ _row:
                 lda 2,x
                 jsr byte_to_ascii
 
-                jsr xt_space
-                jsr xt_space
+                jsr w_space
+                jsr w_space
 _loop:
                 ; if there are zero bytes left to display, we're done
                 lda 0,x
@@ -131,7 +134,7 @@ _loop:
                 lda (2,x)
                 pha                     ; byte_to_ascii destroys A
                 jsr byte_to_ascii
-                jsr xt_space
+                jsr w_space
                 pla
 
                 ; Handle ASCII printing
@@ -148,7 +151,7 @@ _printable:
                 ; extra space after eight bytes
                 cpy #9
                 bne _next_char
-                jsr xt_space
+                jsr w_space
 
 _next_char:
                 inc 2,x
@@ -167,7 +170,7 @@ _counter:
 
                 ; Done with one line, print the ASCII version of these
                 ; characters
-                jsr xt_space
+                jsr w_space
                 jsr dump_print_ascii
 
                 bra _row                ; new row
@@ -184,10 +187,10 @@ _all_printed:
                 ; then there is the gap after eight entries) and it
                 ; makes it harder to read. We settle for one extra
                 ; space instead for the moment
-                jsr xt_space
+                jsr w_space
                 jsr dump_print_ascii
 _done:
-                jsr xt_two_drop         ; one byte less than 4x INX
+                jsr w_two_drop         ; one byte less than 4x INX
 z_dump:         rts
 
 
@@ -205,7 +208,7 @@ _ascii_loop:
                 ; extra space after eight chars
                 cpy #8
                 bne +
-                jsr xt_space
+                jsr w_space
 +
                 dec tmp2
                 bne _ascii_loop
@@ -222,9 +225,10 @@ _ascii_loop:
         ; save size and just go for the subroutine jumps
         ; """
 xt_question:
+w_question:
                 ; FETCH takes care of underflow check
-                jsr xt_fetch
-                jsr xt_dot
+                jsr w_fetch
+                jsr w_dot
 
 z_question:     rts
 
@@ -239,8 +243,9 @@ z_question:     rts
         ; """
 
 xt_see:
-                jsr xt_parse_name       ; ( addr u )
-                jsr xt_find_name        ; ( nt | 0 )
+w_see:
+                jsr w_parse_name       ; ( addr u )
+                jsr w_find_name        ; ( nt | 0 )
 
                 ; If we got back a zero we don't know that word and so we quit
                 ; with an error
@@ -251,39 +256,39 @@ xt_see:
                 lda #err_noname
                 jmp error
 +
-                jsr xt_cr
+                jsr w_cr
 
                 ; We have a legal word, so let's get serious. Save the current
                 ; number base and use hexadecimal instead.
                 lda base
                 pha
-                jsr xt_hex
+                jsr w_hex
 
                 lda #str_see_nt
                 jsr print_string_no_lf
 
-                jsr xt_dup              ; ( nt nt )
-                jsr xt_u_dot
-                jsr xt_space            ; ( nt )
+                jsr w_dup              ; ( nt nt )
+                jsr w_u_dot
+                jsr w_space            ; ( nt )
 
-                jsr xt_dup              ; ( nt nt )
-                jsr xt_name_to_int      ; ( nt xt )
+                jsr w_dup              ; ( nt nt )
+                jsr w_name_to_int      ; ( nt xt )
 
                 lda #str_see_xt
                 jsr print_string_no_lf
 
-                jsr xt_dup              ; ( nt xt xt )
-                jsr xt_u_dot
-                jsr xt_cr               ; ( nt xt )
+                jsr w_dup              ; ( nt xt xt )
+                jsr w_u_dot
+                jsr w_cr               ; ( nt xt )
 
                 ; We print letters for flags and then later follow it with 1 or
                 ; 0 to mark if which flag is set
                 lda #str_see_flags
                 jsr print_string_no_lf
 
-                jsr xt_over             ; ( nt xt nt )
-                jsr xt_one_plus         ; ( nt xt nt+1 )
-                jsr xt_fetch            ; ( nt xt flags )
+                jsr w_over             ; ( nt xt nt )
+                jsr w_one_plus         ; ( nt xt nt+1 )
+                jsr w_fetch            ; ( nt xt flags )
 
                 lda 0,x
 
@@ -295,7 +300,7 @@ _flag_loop:
                 clc
                 adc #'0'
                 jsr emit_a
-                jsr xt_space
+                jsr w_space
 
                 pla
                 ror                     ; Next flag
@@ -303,7 +308,7 @@ _flag_loop:
                 dey
                 bne _flag_loop
 
-                jsr xt_cr
+                jsr w_cr
 
                 inx
                 inx                     ; ( nt xt )
@@ -312,22 +317,22 @@ _flag_loop:
                 lda #str_see_size
                 jsr print_string_no_lf
 
-                jsr xt_swap             ; ( xt nt )
-                jsr xt_wordsize         ; ( xt u )
-                jsr xt_dup              ; ( xt u u ) for DUMP and DISASM
-                jsr xt_decimal
-                jsr xt_u_dot            ; ( xt u )
-                jsr xt_hex
-                jsr xt_cr
+                jsr w_swap             ; ( xt nt )
+                jsr w_wordsize         ; ( xt u )
+                jsr w_dup              ; ( xt u u ) for DUMP and DISASM
+                jsr w_decimal
+                jsr w_u_dot            ; ( xt u )
+                jsr w_hex
+                jsr w_cr
 
                 ; Dump hex and disassemble
 .if "disassembler" in TALI_OPTIONAL_WORDS
-                jsr xt_two_dup          ; ( xt u xt u )
+                jsr w_two_dup          ; ( xt u xt u )
 .endif
-                jsr xt_dump
-                jsr xt_cr
+                jsr w_dump
+                jsr w_cr
 .if "disassembler" in TALI_OPTIONAL_WORDS
-                jsr xt_disasm
+                jsr w_disasm
 .endif
                 pla
                 sta base
@@ -344,9 +349,10 @@ z_see:          rts
         ; """
 
 xt_words:
+w_words:
                 ; we follow Gforth by starting on the next
                 ; line
-                jsr xt_cr
+                jsr w_cr
 
                 ; We pretty-format the output by inserting a line break
                 ; before the end of the line. We can get away with pushing
@@ -389,8 +395,8 @@ _have_wordlist:
                 sta 1,x
 
 _loop:
-                jsr xt_dup              ; ( nt nt )
-                jsr xt_name_to_string   ; ( nt addr u )
+                jsr w_dup              ; ( nt nt )
+                jsr w_name_to_string   ; ( nt addr u )
 
                 ; Insert line break if we're about to go past the end of the
                 ; line
@@ -401,21 +407,21 @@ _loop:
                 cmp #MAX_LINE_LENGTH    ; usually 79
                 bcc +
 
-                jsr xt_cr
+                jsr w_cr
 
                 lda 0,x                 ; After going to next line, start
                 ina                     ; with length of this word.
 +
                 pha
-                jsr xt_type             ; ( nt )
+                jsr w_type             ; ( nt )
 
                 lda #AscSP
                 jsr emit_a
 
                 ; get next word, which begins two down
-                jsr xt_one_plus         ; 1+
-                jsr xt_one_plus         ; 1+
-                jsr xt_fetch            ; @ ( nt+1 )
+                jsr w_one_plus         ; 1+
+                jsr w_one_plus         ; 1+
+                jsr w_fetch            ; @ ( nt+1 )
 
                 ; if next address is zero, we're done
                 lda 0,x

--- a/words/wordlist.asm
+++ b/words/wordlist.asm
@@ -2,11 +2,12 @@
 ; ## "also"  auto  ANS search ext
         ; """http://forth-standard.org/standard/search/ALSO"""
 xt_also:
-                jsr xt_get_order
-                jsr xt_over
-                jsr xt_swap
-                jsr xt_one_plus
-                jsr xt_set_order
+w_also:
+                jsr w_get_order
+                jsr w_over
+                jsr w_swap
+                jsr w_one_plus
+                jsr w_set_order
 
 z_also:         rts
 
@@ -27,6 +28,7 @@ z_also:         rts
 ; ## DEFINITIONS ( -- ) "Make first wordlist in search order the current wordlist"
 ; ## "definitions" auto ANS search
 xt_definitions:
+w_definitions:
                 ldy #search_order_offset    ; Transfer byte variable
                 lda (up),y                  ; SEARCH_ORDER[0] to
                 ldy #current_offset         ; byte variable CURRENT.
@@ -53,6 +55,7 @@ z_definitions:  rts
 ; ## "forth"  auto  ANS search ext
         ; """https://forth-standard.org/standard/search/FORTH"""
 xt_forth:
+w_forth:
                 ldy #search_order_offset
                 lda #0          ; The WID for Forth is 0.
 
@@ -74,6 +77,7 @@ z_forth:
         ; """https://forth-standard.org/standard/search/GET-CURRENT"""
 
 xt_get_current:
+w_get_current:
                 ; This is a little different than some of the variables
                 ; in the user area as we want the value rather than
                 ; the address.
@@ -93,6 +97,7 @@ z_get_current:  rts
         ; """https://forth-standard.org/standard/search/GET-ORDER"""
 
 xt_get_order:
+w_get_order:
                 ; Get #ORDER - the number of wordlists in the search order.
                 ldy #num_order_offset
                 lda (up),y
@@ -140,10 +145,11 @@ z_get_order:    rts
         ; """https://forth-standard.org/standard/search/ONLY"""
 
 xt_only:
+w_only:
                 ; Put -1 on data stack.
-                jsr xt_true
+                jsr w_true
                 ; Invoke set-order to set the minimum search order.
-                jsr xt_set_order
+                jsr w_set_order
 
 z_only:         rts
 
@@ -176,8 +182,9 @@ z_only:         rts
         ; """
 
 xt_order:
-                jsr xt_cr
-                jsr xt_get_order        ; ( wid_n ... wid_1 n )
+w_order:
+                jsr w_cr
+                jsr w_get_order        ; ( wid_n ... wid_1 n )
 
                 ; Paranoid: Check if there are no wordlists, a rather
                 ; pathological case. this would mean ( 0 ) on the stack. In
@@ -202,13 +209,13 @@ _loop:
 
                 ; We've printed the wordlists, now we add the current wordlist.
                 ; This follows the convention of Gforth
-                jsr xt_space
-                jsr xt_space
-                jsr xt_get_current      ; ( wid )
+                jsr w_space
+                jsr w_space
+                jsr w_get_current      ; ( wid )
 
                 lda 0,x
                 jsr order_print_wid_string
-                jsr xt_cr
+                jsr w_cr
 
 _drop_done:
                 inx
@@ -239,7 +246,7 @@ order_print_wid_string:
                 dex
                 sta 0,x
                 stz 1,x
-                jmp xt_u_dot            ; JSR/RTS as this routine is not compiled
+                jmp w_u_dot            ; JSR/RTS as this routine is not compiled
 
 _output_string:
                 ; Get the string number based on WID 0 to 3
@@ -264,10 +271,11 @@ _wid_data:
         ; """http://forth-standard.org/standard/search/PREVIOUS"""
 
 xt_previous:
-                jsr xt_get_order
-                jsr xt_nip
-                jsr xt_one_minus
-                jsr xt_set_order
+w_previous:
+                jsr w_get_order
+                jsr w_nip
+                jsr w_one_minus
+                jsr w_set_order
 
 z_previous:     rts
 
@@ -276,6 +284,7 @@ z_previous:     rts
 ; ## ROOT_WORDLIST ( -- u ) "WID for the Root (minimal) wordlist"
 ; ## "root-wordlist"  tested  Tali Editor
 xt_root_wordlist:
+w_root_wordlist:
                 dex             ; The WID for the Root wordlist is 3.
                 dex
                 lda #3
@@ -293,7 +302,7 @@ z_root_wordlist:
 
 xt_search_wordlist:
                 jsr underflow_3
-
+w_search_wordlist:
                 ; Set up tmp1 with the wordlist indicated by wid
                 ; on the stack. Start by putting the base address
                 ; of the wordlists in tmp2.
@@ -355,9 +364,9 @@ xt_search_wordlist:
 
                 ; Change the nt into an xt, but save a copy of the nt
                 ; to look up whether the word is immediate or not.
-                jsr xt_dup              ; ( nt nt )
-                jsr xt_name_to_int      ; ( nt xt )
-                jsr xt_swap             ; ( xt nt )
+                jsr w_dup              ; ( nt nt )
+                jsr w_name_to_int      ; ( nt xt )
+                jsr w_swap             ; ( xt nt )
 
                 ldy #0                  ; Prepare flag
 
@@ -400,7 +409,7 @@ z_search_wordlist:
 
 xt_set_current:
                 jsr underflow_1
-
+w_set_current:
                 ; Save the value from the data stack.
                 ldy #current_offset
                 lda 0,x         ; CURRENT is byte variable
@@ -418,6 +427,7 @@ z_set_current:  rts
         ; """https://forth-standard.org/standard/search/SET-ORDER"""
 
 xt_set_order:
+w_set_order:
                 ; Test for -1 TOS
                 lda #$FF
                 cmp 1,x
@@ -479,19 +489,20 @@ z_set_order:    rts
         ; """https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Word-Lists.html"""
 
 xt_to_order:
+w_to_order:
                 ; Put the wid on the return stack for now.
-                jsr xt_to_r
+                jsr w_to_r
 
                 ; Get the current search order.
-                jsr xt_get_order
+                jsr w_get_order
 
                 ; Get back the wid and add it to the list.
-                jsr xt_r_from
-                jsr xt_swap
-                jsr xt_one_plus
+                jsr w_r_from
+                jsr w_swap
+                jsr w_one_plus
 
                 ; Set the search order with the new list.
-                jsr xt_set_order
+                jsr w_set_order
 
 z_to_order:     rts
 
@@ -505,6 +516,7 @@ z_to_order:     rts
         ; """
 
 xt_wordlist:
+w_wordlist:
                 ; Get the current number of wordlists
                 ldy #num_wordlists_offset
                 lda (up),y      ; This is a byte variable, so only


### PR DESCRIPTION
Adds all the w_ labels and switches from using xt_ to w_ internally.  Fix #93 

Adds missing underflow checks to a few words (including some that were already flagged as containing them, supporting the idea of #107).

Fixes up some header flags, notably the extraneous HC ones.