### PR TITLE
One liner for py65mon platform to maintain c65 compatibility 

### DIFF
--- a/platform/platform-py65mon.asm
+++ b/platform/platform-py65mon.asm
@@ -35,8 +35,8 @@ TALI_OPTION_TERSE := 0
 
 .include "simulator.asm"
 
-; py65mon doesn't have kbhit so we roll our own, using io_kbhit as a one character buffer
-io_bufc = io_kbhit
+; py65mon doesn't have kbhit so we roll our own, using a spare byte in the IO area
+io_bufc = io_putc+1
 
 kernel_getc:
         ; """Get a single character from the keyboard.


### PR DESCRIPTION
I noticed the benchmark script didn't work using c65 with the py65mon platform binary because I'd picked a dumb default for the kbhit buffer.   This fixes it. 