### PR TITLE
more robust test output parsing

### DIFF
--- a/tests/talitest_c65.py
+++ b/tests/talitest_c65.py
@@ -114,7 +114,6 @@ outlines = out.splitlines()
 undefined = []
 
 for line in outlines:
-
     if 'undefined' in line:
         undefined.append(line)
 


### PR DESCRIPTION
I've had a lot of experience breaking tests lately and noticed the test parsing was failing sometimes due to non-ascii characters.  This tweak makes it more robust.