### PR TITLE
Fix broken c65 block IO

### DIFF
--- a/platform/platform-c65.asm
+++ b/platform/platform-c65.asm
@@ -5,6 +5,8 @@
         ; No special text encoding (eg. ASCII)
         .enc "none"
 
+TALI_ARCH := "c65"
+
 ram_end = $7fff
 
         ; Set the origin for Tali Forth 2 in ROM (or RAM if loading it)

--- a/platform/platform-minimal.asm
+++ b/platform/platform-minimal.asm
@@ -12,6 +12,8 @@
         ; No special text encoding (eg. ASCII)
         .enc "none"
 
+TALI_ARCH := "c65"
+
 ram_end = $c000-1
 
 ; Where to start Tali Forth 2 in ROM (or RAM if loading it)

--- a/platform/platform-py65mon.asm
+++ b/platform/platform-py65mon.asm
@@ -5,6 +5,8 @@
         ; No special text encoding (eg. ASCII)
         .enc "none"
 
+TALI_ARCH := "py65mon"
+
 ram_end = $7fff
 
         ; Set the origin for Tali Forth 2 in ROM (or RAM if loading it)

--- a/platform/simulator.asm
+++ b/platform/simulator.asm
@@ -37,18 +37,20 @@ io_clk_stop:    .byte ?         ; $f007     *read* to stop the cycle counter
 io_clk_cycles:  .word ?,?       ; $f008-b   32-bit cycle count in NUXI order
                 .word ?,?
 
+.cerror * != io_start + $10, "Mismatched magic IO interface"
+
+.if TALI_ARCH == "c65"
+
 ; These magic block IO addresses are only implemented by c65 (not py65mon)
 ; see c65/README.md for more detail
 
-.if TALI_ARCH == "c65"
 io_blk_action:  .byte ?         ; $f010     Write to act (status=0 read=1 write=2)
 io_blk_status:  .byte ?         ; $f011     Read action result (OK=0)
 io_blk_number:  .word ?         ; $f012     Little endian block number 0-ffff
 io_blk_buffer:  .word ?         ; $f014     Little endian memory address
-.else
-                .word ?,?,?
+
+.cerror * != io_start + $16, "Mismatched magic block IO interface"
 .endif
-.cerror * != io_start + $16, "Mismatched magic IO spec"
 
 ; Now we're safe to inject the required kernel routines to interface to
 ; our "hardware" which is a simulator in this configuration.

--- a/platform/simulator.asm
+++ b/platform/simulator.asm
@@ -31,6 +31,7 @@ io_putc:        .byte ?         ; $f001     write byte to stdout
                 .byte ?
 io_kbhit:       .byte ?         ; $f003     read non-zero on key ready (c65 only)
 io_getc:        .byte ?         ; $f004     non-blocking read input character (0 if no key)
+                .byte ?
 io_clk_start:   .byte ?         ; $f006     *read* to start cycle counter
 io_clk_stop:    .byte ?         ; $f007     *read* to stop the cycle counter
 io_clk_cycles:  .word ?,?       ; $f008-b   32-bit cycle count in NUXI order
@@ -39,12 +40,15 @@ io_clk_cycles:  .word ?,?       ; $f008-b   32-bit cycle count in NUXI order
 ; These magic block IO addresses are only implemented by c65 (not py65mon)
 ; see c65/README.md for more detail
 
-io_blk_action:  .byte ?     ; $f010     Write to act (status=0 read=1 write=2)
-io_blk_status:  .byte ?     ; $f011     Read action result (OK=0)
-io_blk_number:  .word ?     ; $f012     Little endian block number 0-ffff
-io_blk_buffer:  .word ?     ; $f014     Little endian memory address
-
-io_end:
+.if TALI_ARCH == "c65"
+io_blk_action:  .byte ?         ; $f010     Write to act (status=0 read=1 write=2)
+io_blk_status:  .byte ?         ; $f011     Read action result (OK=0)
+io_blk_number:  .word ?         ; $f012     Little endian block number 0-ffff
+io_blk_buffer:  .word ?         ; $f014     Little endian memory address
+.else
+                .word ?,?,?
+.endif
+.cerror * != io_start + $16, "Mismatched magic IO spec"
 
 ; Now we're safe to inject the required kernel routines to interface to
 ; our "hardware" which is a simulator in this configuration.

--- a/taliforth.asm
+++ b/taliforth.asm
@@ -25,6 +25,9 @@ TALI_OPTION_TERSE :?= 0
 ; Default to ctrl-n/p accept history
 TALI_OPTION_HISTORY :?= 1
 
+; Optional hardware/simulator architecture name for customization
+TALI_ARCH :?= ""
+
 ; Label used to calculate UNUSED based on the hardware configuration in platform/
 code0:
 

--- a/words/block.asm
+++ b/words/block.asm
@@ -103,16 +103,8 @@ _done:
 
 z_block:        rts
 
-.weak
-; These labels allow this to assemble even if c65 is not the target platform.
-; Because they are weak, they will be replaced when c65 is the target platform.
-io_blk_status = 0
-io_blk_action = 0
-io_blk_number = 0
-io_blk_buffer = 0
-.endweak
 
-.if io_blk_action != 0
+.if TALI_ARCH == "c65"
 
 ; ## BLOCK_C65_INIT ( -- f ) "Initialize c65 simulator block storage"
 ; ## "block-c65-init"  auto  Tali block

--- a/words/core.asm
+++ b/words/core.asm
@@ -4286,7 +4286,7 @@ _char_found:
         ; Since PARSE does not skip leading delimiters, we assume we are on a
         ; useful string if there are any characters at all. As with
         ; PARSE-NAME, we must be able to handle strings with a length of
-        ; 16-bit for EVALUTE, which is a pain on an 8-bit machine.
+        ; 16-bit for EVALUATE, which is a pain on an 8-bit machine.
         ; """
 
 xt_parse:

--- a/words/headers.asm
+++ b/words/headers.asm
@@ -1345,17 +1345,18 @@ nt_thru:
         .word +, xt_thru, z_thru
         .text "thru"
 +
-
-.if "editor" in TALI_OPTIONAL_WORDS
-nt_list:
-        .byte 4, 0
-        .word nt_block_c65_init, xt_list, z_list
-        .text "list"
-
+.if TALI_ARCH == "c65"
 nt_block_c65_init:
         .byte 14, 0
         .word +, xt_block_c65_init, z_block_c65_init
         .text "block-c65-init"
++
+.endif
+.if "editor" in TALI_OPTIONAL_WORDS
+nt_list:
+        .byte 4, 0
+        .word +, xt_list, z_list
+        .text "list"
 +
 .endif
 .endif

--- a/words/tali.asm
+++ b/words/tali.asm
@@ -452,7 +452,7 @@ z_input:        rts
 ; ## INPUT_TO_R ( -- ) ( R: -- n n n n ) "Save input state to the Return Stack"
 ; ## "input>r"  tested  Tali Forth
    	; """Save the current input state as defined by insrc, cib, ciblen, and
-        ; toin to the Return Stack. Used by EVALUTE.
+        ; toin to the Return Stack. Used by EVALUATE.
         ;
         ; The naive way of doing
         ; this is to push each two-byte variable to the stack in the form of


### PR DESCRIPTION
It looks like I broke the c65 block IO interface address mapping in #90 by inadvertently dropping a `.byte ?` line.

This fixes it, adds a check so I don't break it again, and makes conditional compilation easier.  Platforms with  `TALI_ARCH=c65` get the `block-c65-init` word which checks if there's an active block file before adding the read/write vectors and returning true/false.  Other platforms like `py65mon` don't have that word at all, even if the optional `block` words are included.