### PR TITLE
Refactor sliteral and use standard NUXI ordering for 2literal etc 

### DIFF
--- a/definitions.asm
+++ b/definitions.asm
@@ -256,6 +256,8 @@ OpBNE   = $D0
 OpBEQ   = $F0
 OpRTS   = $60
 OpBRA   = $80
+OpBITzp = $24   ; used to save a branch occasionally
+
 
 ; DICTIONARY FLAGS
 ; The first two bits (7, 6) are currently unused.  COMPILE, assumes bit7 is usually 0.

--- a/docs/ch_disasm.adoc
+++ b/docs/ch_disasm.adoc
@@ -120,30 +120,29 @@ disassembly, the literal value will be printed and the disassembler will resume
 disassembling from just after the literal value.  Doubles are saved in memory as
 two single cell literal values.
 
-Strings are similar, however they are saved in memory as a jmp over the string
-data, then the string data, then a jsr to the string handling routine, and
-finally the address and length of the string (similar to how literals are
+Strings are similar, they are saved in memory as a jsr to the string handling routine,
+then the string length and inline string data (similar to how literals are
 handled).  When the disassembler encounters a string, it will print SLITERAL
-followed by the address and length of the string.
+followed by the length of the string and a snippet of the data:
 ----
 : example s" This is a string" ;  ok
 see example
-nt: 800  xt: 80F
-flags (CO AN IM NN HC ST): 0 0 0 1 1 0
-size (decimal): 26
+nt: 827  xt: 836
+flags: CO 0 IM 0 AN 0 NN 0 HC 0 | UF 0 ST 0
+size (decimal): 21
 
-080F  4C 22 08 54 68 69 73 20  69 73 20 61 20 73 74 72  L".This  is a str
-081F  69 6E 67 20 A9 A0 12 08  10 00  ing .... ..
+0836  20 29 A2 10 00 54 68 69  73 20 69 73 20 61 20 73   )...Thi s is a s
+0846  74 72 69 6E 67                                    tring
 
-80F    822 jmp
-822   A0A9 jsr     SLITERAL 812 10
+836   A229 jsr     SLITERAL 10 This is a strin...
  ok
 ----
 To see the value of the string, you can either look at the memory dump above the
 disassembly or you can `type` the string yourself (note that `see` will always
 give the values in hex while `disasm` will use the current `base`):
 ----
-hex 812 10 type
+hex 836 5 + 10 cr type
+This is a string ok
 ----
 
 ==== Gotchas and known issues

--- a/taliforth.asm
+++ b/taliforth.asm
@@ -551,7 +551,7 @@ is_printable:
                 bcs _failed
 
                 sec
-                bra _done
+                .byte OpBITzp
 _failed:
                 clc
 _done:

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -1,5 +1,5 @@
 c65: reading ../taliforth-c65.bin to $8000:$ffff
-c65: PC=f015 A=00 X=00 Y=00 S=fd FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=0
+c65: PC=f016 A=00 X=00 Y=00 S=fd FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=0
 Tali Forth 2 default kernel for c65 (01. Jun 2024)
 
 
@@ -868,11 +868,11 @@ create result  ok
 92 c, ( \\ )  ok
   ok
 T{ result here result - 2dup dump ( Make a string out of result ) 
-0FC1  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-0FD1   ok
+0FA8  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+ ok
    s\" \a\b\e\f\l\m\n\q\r\t\v\z\"\x41\\" 2dup dump compare -> 0 }T 
-0FD4  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-0FE4   ok
+11B8  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+ ok
 hex  ok
   ok
 \ ------------------------------------------------------------------------  ok
@@ -2237,8 +2237,9 @@ T{ saved-string s\"  ok\ned: \nq  ok\nrestore-output  " compare -> 0 }T  ok
 \ Test --- q --- Don't quit if we have unsaved changes  ok
 test-ed  ok
 saved-string dump 
-0F8E  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
-0F9E  0A 51 20  .Q  ok
+0EC0  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
+0ED0  0A 51 20                                          .Q 
+ ok
 T{ s\" \na \nzzz \n. \nq \n?\nQ " compare -> 0 }T  ok
   ok
   ok
@@ -2750,14 +2751,19 @@ T{ 2 -> 5 3 - }T  ok
   ok
 T{ 36 constant max-base -> }T \ ANS standard says 2 - 36  ok
 T{ base @  constant orig-base -> }T  ok
-T{ s" 0123456789" ( addr u ) drop  constant digit_numeral -> }T  ok
-T{ s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop  constant digit_lower -> }T  ok
-T{ s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop  constant digit_upper -> }T  ok
+\ T{ s" 0123456789" ( addr u ) drop  constant digit_numeral -> }T  ok
+\ T{ s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop  constant digit_lower -> }T  ok
+\ T{ s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop  constant digit_upper -> }T  ok
+T{ : digit_numeral s" 0123456789" ( addr u ) drop ; -> }T  ok
+T{ : digit_lower s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop ; -> }T  ok
+T{ : digit_upper s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop ; -> }T  ok
+  ok
   ok
 \ "/" and ":" are before and after ASCII numbers  ok
 \ "@" and "[" are before and after upper case ASCII letters  ok
 \ "`" and "{" are before and after lower case ASCII letters  ok
-T{ s" /:@[`{"  ( addr u )  drop  constant digit_bad -> }T  ok
+\ T{ s" /:@[`{"  ( addr u )  drop  constant digit_bad -> }T  ok
+T{ : digit_bad s" /:@[`{"  ( addr u )  drop ; -> }T  ok
   ok
 : digit_numeral ( -- f )  compiled
    true  compiled
@@ -3321,12 +3327,12 @@ decimal  ok
 \ skipping     quit  ok
 \ skipping     abort"  ok
 5            ' abs           cycle_test drop       CYCLES:     35 ok
-pad 20       ' accept        cycle_test some text  CYCLES:   1306 ok
+pad 20       ' accept        cycle_test some text  CYCLES:   1309 ok
 drop \ accept test complete  ok
              ' align         cycle_test            CYCLES:     12 ok
 5            ' aligned       cycle_test drop       CYCLES:     12 ok
 5            ' allot         cycle_test            CYCLES:     73 ok
-: aword ;    ' always-native cycle_test            CYCLES:     74 ok
+: aword ;    ' always-native cycle_test            CYCLES:     75 ok
 5 5          ' and           cycle_test drop       CYCLES:     56 ok
 \ skipping     at-xy  ok
              ' \             cycle_test            CYCLES:     41 ok
@@ -3353,12 +3359,12 @@ here 5       ' blank         cycle_test            CYCLES:    327 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  15087 ok
+             ' :             cycle_test wrd ;      CYCLES:  15096 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:    101 ok
-' aword      ' compile,      cycle_test            CYCLES:    889 ok
+' aword      ' compile,      cycle_test            CYCLES:    900 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
-5            ' constant      cycle_test mycnst     CYCLES:  15855 ok
+5            ' constant      cycle_test mycnst     CYCLES:  15867 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3382,7 +3388,7 @@ nc-limit @  ok
 0 nc-limit !  ok
 : fib2 0 1 rot 0 ?do over + swap loop drop ;  ok
 nc-limit !  ok
-100          ' fib1          cycle_test drop       CYCLES:  14360 ok
+100          ' fib1          cycle_test drop       CYCLES:  14359 ok
 100          ' fib2          cycle_test drop       CYCLES:  24463 ok
 : doword 100 0 do loop ;  ok
              ' doword        cycle_test            CYCLES:   1252 ok
@@ -3391,15 +3397,15 @@ nc-limit !  ok
 : dodoword 100 0 do 10 0 do loop loop ;  ok
              ' dodoword      cycle_test            CYCLES:  27552 ok
 : dodowordij 100 0 do 10 0 do i drop j drop loop loop ;  ok
-             ' dodowordij    cycle_test            CYCLES: 150552 ok
+             ' dodowordij    cycle_test            CYCLES: 151552 ok
 : dodowordbigi 10 0 do 1024 0 do i drop loop loop ;  ok
              ' dodowordbigi  cycle_test            CYCLES: 647442 ok
 : doword+loop 100 0 do 5 +loop ;  ok
-             ' doword+loop   cycle_test            CYCLES:   2259 ok
+             ' doword+loop   cycle_test            CYCLES:   2286 ok
 \ skipping     does  ok
 \ skipping     .  ok
 \ skipping     ."  ok
-             ' s"            cycle_test " 2drop    CYCLES:    483 ok
+             ' s"            cycle_test " 2drop    CYCLES:    252 ok
 5            ' drop          cycle_test            CYCLES:     32 ok
 \ skipping     dump  ok
 5            ' dup           cycle_test 2drop      CYCLES:     48 ok
@@ -3407,7 +3413,7 @@ nc-limit !  ok
 5 5          ' =             cycle_test drop       CYCLES:     66 ok
 here 5       ' erase         cycle_test            CYCLES:    325 ok
 here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17019 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17027 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3415,8 +3421,8 @@ here         ' @             cycle_test drop       CYCLES:     59 ok
 \ making counted string for find  ok
 here 5 c, char a c, char w c, char o c,  ok
 char r c, char d c,  ok
-             ' find          cycle_test 2drop      CYCLES:   1274 ok
-s" aword"    ' find-name     cycle_test drop       CYCLES:   1020 ok
+             ' find          cycle_test 2drop      CYCLES:   1285 ok
+s" aword"    ' find-name     cycle_test drop       CYCLES:   1025 ok
 5. 5         ' fm/mod        cycle_test 2drop      CYCLES:   1281 ok
 5 5          ' >             cycle_test drop       CYCLES:     81 ok
              ' here          cycle_test drop       CYCLES:     30 ok
@@ -3427,7 +3433,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:   1020 ok
              ' ifloop        cycle_test            CYCLES:  18134 ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   2439 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   2444 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
@@ -3442,13 +3448,13 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:   1020 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    588 ok
-             ' marker        cycle_test marka      CYCLES:  17843 ok
-             ' marka         cycle_test            CYCLES:    781 ok
+             ' marker        cycle_test marka      CYCLES:  17856 ok
+             ' marka         cycle_test            CYCLES:    791 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
 5 5          ' -             cycle_test drop       CYCLES:     58 ok
-s" txt   "   ' -trailing     cycle_test 2drop      CYCLES:    228 ok
-here s" a"   ' move          cycle_test            CYCLES:    148 ok
+s" txt   "   ' -trailing     cycle_test 2drop      CYCLES:    224 ok
+here s" a"   ' move          cycle_test            CYCLES:    137 ok
 ' + int>name ' name>int      cycle_test drop       CYCLES:     71 ok
 ' + int>name ' name>string   cycle_test 2drop      CYCLES:     61 ok
              ' nc-limit      cycle_test drop       CYCLES:     40 ok
@@ -3464,7 +3470,7 @@ decimal  ok
              ' nops          cycle_test            CYCLES:     29 ok
 5 5          ' <>            cycle_test drop       CYCLES:     70 ok
 5 5 5        ' -rot          cycle_test 2drop drop CYCLES:     76 ok
-s" 5"        ' number        cycle_test drop       CYCLES:   1539 ok
+s" 5"        ' number        cycle_test drop       CYCLES:   1538 ok
 \ skipping     #  ok
 \ skipping     #>  ok
 \ skipping     #s  ok
@@ -3491,7 +3497,7 @@ drop \ refill  ok
 \ skipping     ]  ok
 5 5 5        ' rot           cycle_test 2drop drop CYCLES:     76 ok
 5 5          ' rshift        cycle_test drop       CYCLES:    126 ok
-             ' s"            cycle_test " 2drop    CYCLES:    483 ok
+             ' s"            cycle_test " 2drop    CYCLES:    252 ok
 5            ' s>d           cycle_test 2drop      CYCLES:     47 ok
 \ skipping     ;  ok
 \ skipping     sign  ok
@@ -3506,9 +3512,9 @@ s" abc" 1    ' /string       cycle_test 2drop      CYCLES:     84 ok
              ' state         cycle_test drop       CYCLES:     28 ok
 5 here       ' !             cycle_test            CYCLES:     65 ok
 5 5          ' swap          cycle_test 2drop      CYCLES:     60 ok
-             ' '             cycle_test aword drop CYCLES:   1953 ok
+             ' '             cycle_test aword drop CYCLES:   1959 ok
 \ postponing   to ( see value )  ok
-' aword      ' >body         cycle_test drop       CYCLES:   1419 ok
+' aword      ' >body         cycle_test drop       CYCLES:   1426 ok
              ' >in           cycle_test drop       CYCLES:     28 ok
 0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2338 ok
 \ skipping     >r  ok
@@ -3526,7 +3532,7 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  16628 ok
+             ' 2variable     cycle_test eword      CYCLES:  16637 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
 s" *"        ' type          cycle_test           *CYCLES:    123 ok
 5            ' u.            cycle_test          5 CYCLES:   1842 ok
@@ -3537,10 +3543,10 @@ s" *"        ' type          cycle_test           *CYCLES:    123 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    476 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  16844 ok
+5            ' value         cycle_test fword      CYCLES:  16853 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
 5            ' to            cycle_test fword      CYCLES:   1136 ok
-             ' variable      cycle_test gword      CYCLES:  16673 ok
+             ' variable      cycle_test gword      CYCLES:  16682 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    620 ok
 \ skipping     words  ok
@@ -3553,4 +3559,4 @@ char "       ' word          cycle_test "txt" drop CYCLES:    620 ok
 5            ' 0<            cycle_test drop       CYCLES:     47 ok
 5            ' 0<>           cycle_test drop       CYCLES:     48 ok
   ok
-bye c65: PC=f015 A=98 X=78 Y=01 S=f6 FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=143116258
+bye c65: PC=f016 A=98 X=78 Y=01 S=f6 FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=143304862

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -884,7 +884,7 @@ T{ result here result - 2dup dump ( Make a string out of result )
 30DA  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
  ok
    s\" \a\b\e\f\l\m\n\q\r\t\v\z\"\x41\\" 2dup dump compare -> 0 }T 
-32EA  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+30EA  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
  ok
 hex  ok
   ok
@@ -2231,7 +2231,7 @@ dump
 0D67  0A 51 20                                          .Q 
  ok
 T{ s\" \na \nzzz \n. \nq \n?\nQ " compare -> 0 }T Data stack underflow
-Return stack: 8B A0 E3 87 EB D7 9A 80
+Return stack: 99 A0 E3 87 F9 D7 9A 80
   ok
   ok
 \ Test --- p --- print one line, no line number  ok
@@ -2746,15 +2746,15 @@ T{ 2 -> 5 3 - }T  ok
   ok
 T{ 36 constant max-base -> }T \ ANS standard says 2 - 36  ok
 T{ base @  constant orig-base -> }T  ok
-T{ : digit_numeral s" 0123456789" ( addr u ) drop ; -> }T  ok
-T{ : digit_lower s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop ; -> }T  ok
-T{ : digit_upper s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop ; -> }T  ok
+T{ s" 0123456789" ( addr u ) drop  constant digit_numeral -> }T  ok
+T{ s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop  constant digit_lower -> }T  ok
+T{ s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop  constant digit_upper -> }T  ok
   ok
   ok
 \ "/" and ":" are before and after ASCII numbers  ok
 \ "@" and "[" are before and after upper case ASCII letters  ok
 \ "`" and "{" are before and after lower case ASCII letters  ok
-T{ : digit_bad s" /:@[`{"  ( addr u )  drop ; -> }T  ok
+T{ s" /:@[`{"  ( addr u )  drop  constant digit_bad -> }T  ok
   ok
 : digit_numeral ( -- f )  compiled
    true  compiled
@@ -3517,7 +3517,7 @@ drop \ accept test complete  ok
              ' \             cycle_test            CYCLES:     41 ok
              ' base          cycle_test drop       CYCLES:     26 ok
 : beginuntil 100 begin 1- ?dup 0= until ;  ok
-             ' beginuntil    cycle_test            CYCLES:  12904 ok
+             ' beginuntil    cycle_test            CYCLES:  12805 ok
 : beginwhile 100 begin 1- ?dup while repeat ;  ok
              ' beginwhile    cycle_test            CYCLES:   9306 ok
              ' bell          cycle_test            CYCLES:     36 ok
@@ -3541,9 +3541,9 @@ pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
              ' :             cycle_test wrd ;      CYCLES:  15764 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:    101 ok
-' aword      ' compile,      cycle_test            CYCLES:    878 ok
+' aword      ' compile,      cycle_test            CYCLES:    890 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
-5            ' constant      cycle_test mycnst     CYCLES:  16533 ok
+5            ' constant      cycle_test mycnst     CYCLES:  16536 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3567,7 +3567,7 @@ nc-limit @  ok
 0 nc-limit !  ok
 : fib2 0 1 rot 0 ?do over + swap loop drop ;  ok
 nc-limit !  ok
-100          ' fib1          cycle_test drop       CYCLES:  14458 ok
+100          ' fib1          cycle_test drop       CYCLES:  14359 ok
 100          ' fib2          cycle_test drop       CYCLES:  24463 ok
 : doword 100 0 do loop ;  ok
              ' doword        cycle_test            CYCLES:   1252 ok
@@ -3584,7 +3584,7 @@ nc-limit !  ok
 \ skipping     does  ok
 \ skipping     .  ok
 \ skipping     ."  ok
-             ' s"            cycle_test " 2drop    CYCLES:    252 ok
+             ' s"            cycle_test " 2drop    CYCLES:    234 ok
 5            ' drop          cycle_test            CYCLES:     32 ok
 \ skipping     dump  ok
 5            ' dup           cycle_test 2drop      CYCLES:     48 ok
@@ -3592,7 +3592,7 @@ nc-limit !  ok
 5 5          ' =             cycle_test drop       CYCLES:     66 ok
 here 5       ' erase         cycle_test            CYCLES:    325 ok
 here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17695 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17698 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3600,8 +3600,8 @@ here         ' @             cycle_test drop       CYCLES:     59 ok
 \ making counted string for find  ok
 here 5 c, char a c, char w c, char o c,  ok
 char r c, char d c,  ok
-             ' find          cycle_test 2drop      CYCLES:   1274 ok
-s" aword"    ' find-name     cycle_test drop       CYCLES:   1020 ok
+             ' find          cycle_test 2drop      CYCLES:   1276 ok
+s" aword"    ' find-name     cycle_test drop       CYCLES:   1022 ok
 5. 5         ' fm/mod        cycle_test 2drop      CYCLES:   1281 ok
 5 5          ' >             cycle_test drop       CYCLES:     81 ok
              ' here          cycle_test drop       CYCLES:     30 ok
@@ -3612,7 +3612,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:   1020 ok
              ' ifloop        cycle_test            CYCLES:  18134 ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   3410 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   3408 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
@@ -3627,13 +3627,13 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:   1020 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    588 ok
-             ' marker        cycle_test marka      CYCLES:  18533 ok
+             ' marker        cycle_test marka      CYCLES:  18538 ok
              ' marka         cycle_test            CYCLES:    781 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
 5 5          ' -             cycle_test drop       CYCLES:     58 ok
 s" txt   "   ' -trailing     cycle_test 2drop      CYCLES:    224 ok
-here s" a"   ' move          cycle_test            CYCLES:    137 ok
+here s" a"   ' move          cycle_test            CYCLES:     58 ok
 ' + int>name ' name>int      cycle_test drop       CYCLES:     71 ok
 ' + int>name ' name>string   cycle_test 2drop      CYCLES:     61 ok
              ' nc-limit      cycle_test drop       CYCLES:     40 ok
@@ -3649,7 +3649,7 @@ decimal  ok
              ' nops          cycle_test            CYCLES:     29 ok
 5 5          ' <>            cycle_test drop       CYCLES:     70 ok
 5 5 5        ' -rot          cycle_test 2drop drop CYCLES:     76 ok
-s" 5"        ' number        cycle_test drop       CYCLES:   1539 ok
+s" 5"        ' number        cycle_test drop       CYCLES:   1538 ok
 \ skipping     #  ok
 \ skipping     #>  ok
 \ skipping     #s  ok
@@ -3676,7 +3676,7 @@ drop \ refill  ok
 \ skipping     ]  ok
 5 5 5        ' rot           cycle_test 2drop drop CYCLES:     76 ok
 5 5          ' rshift        cycle_test drop       CYCLES:    126 ok
-             ' s"            cycle_test " 2drop    CYCLES:    252 ok
+             ' s"            cycle_test " 2drop    CYCLES:    234 ok
 5            ' s>d           cycle_test 2drop      CYCLES:     47 ok
 \ skipping     ;  ok
 \ skipping     sign  ok
@@ -3691,9 +3691,9 @@ s" abc" 1    ' /string       cycle_test 2drop      CYCLES:     84 ok
              ' state         cycle_test drop       CYCLES:     28 ok
 5 here       ' !             cycle_test            CYCLES:     65 ok
 5 5          ' swap          cycle_test 2drop      CYCLES:     60 ok
-             ' '             cycle_test aword drop CYCLES:   1953 ok
+             ' '             cycle_test aword drop CYCLES:   1955 ok
 \ postponing   to ( see value )  ok
-' aword      ' >body         cycle_test drop       CYCLES:   1419 ok
+' aword      ' >body         cycle_test drop       CYCLES:   1425 ok
              ' >in           cycle_test drop       CYCLES:     28 ok
 0. s" 55"    ' >number       cycle_test 4drop      CYCLES:   2338 ok
 \ skipping     >r  ok
@@ -3711,7 +3711,7 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  17318 ok
+             ' 2variable     cycle_test eword      CYCLES:  17323 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
 s" *"        ' type          cycle_test           *CYCLES:    123 ok
 5            ' u.            cycle_test          5 CYCLES:   1842 ok
@@ -3722,10 +3722,10 @@ s" *"        ' type          cycle_test           *CYCLES:    123 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    476 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  17534 ok
+5            ' value         cycle_test fword      CYCLES:  17539 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
 5            ' to            cycle_test fword      CYCLES:   1136 ok
-             ' variable      cycle_test gword      CYCLES:  17367 ok
+             ' variable      cycle_test gword      CYCLES:  17368 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    620 ok
 \ skipping     words  ok
@@ -3738,4 +3738,4 @@ char "       ' word          cycle_test "txt" drop CYCLES:    620 ok
 5            ' 0<            cycle_test drop       CYCLES:     47 ok
 5            ' 0<>           cycle_test drop       CYCLES:     48 ok
   ok
-bye c65: PC=f016 A=98 X=78 Y=01 S=f6 FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=155380339
+bye c65: PC=f016 A=98 X=78 Y=01 S=f6 FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=155188161

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -2751,9 +2751,6 @@ T{ 2 -> 5 3 - }T  ok
   ok
 T{ 36 constant max-base -> }T \ ANS standard says 2 - 36  ok
 T{ base @  constant orig-base -> }T  ok
-\ T{ s" 0123456789" ( addr u ) drop  constant digit_numeral -> }T  ok
-\ T{ s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop  constant digit_lower -> }T  ok
-\ T{ s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop  constant digit_upper -> }T  ok
 T{ : digit_numeral s" 0123456789" ( addr u ) drop ; -> }T  ok
 T{ : digit_lower s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop ; -> }T  ok
 T{ : digit_upper s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop ; -> }T  ok
@@ -2762,7 +2759,6 @@ T{ : digit_upper s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop ; -> }T  ok
 \ "/" and ":" are before and after ASCII numbers  ok
 \ "@" and "[" are before and after upper case ASCII letters  ok
 \ "`" and "{" are before and after lower case ASCII letters  ok
-\ T{ s" /:@[`{"  ( addr u )  drop  constant digit_bad -> }T  ok
 T{ : digit_bad s" /:@[`{"  ( addr u )  drop ; -> }T  ok
   ok
 : digit_numeral ( -- f )  compiled
@@ -3559,4 +3555,4 @@ char "       ' word          cycle_test "txt" drop CYCLES:    620 ok
 5            ' 0<            cycle_test drop       CYCLES:     47 ok
 5            ' 0<>           cycle_test drop       CYCLES:     48 ok
   ok
-bye c65: PC=f016 A=98 X=78 Y=01 S=f6 FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=143304862
+bye c65: PC=f016 A=98 X=78 Y=01 S=f6 FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=143226251

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -881,11 +881,11 @@ create result  ok
 92 c, ( \\ )  ok
   ok
 T{ result here result - 2dup dump ( Make a string out of result ) 
-30F3  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-3103   ok
+30DA  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+ ok
    s\" \a\b\e\f\l\m\n\q\r\t\v\z\"\x41\\" 2dup dump compare -> 0 }T 
-3106  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
-3116   ok
+32EA  07 08 1B 0C 0A 0D 0A 0A  22 0D 09 0B 00 22 41 5C  ........ "...."A\
+ ok
 hex  ok
   ok
 \ ------------------------------------------------------------------------  ok
@@ -2227,10 +2227,11 @@ s\"  ok\ned: \nq  ok\nrestore-output  " compare -> 0 }T  ok
 \ Test --- q --- Don't quit if we have unsaved changes  ok
 test-ed  ok
 dump 
-0D6B  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
-0D7B  0A 51 20  .Q  ok
+0D57  0A 61 20 0A 7A 7A 7A 20  0A 2E 20 0A 71 20 0A 3F  .a .zzz  .. .q .?
+0D67  0A 51 20                                          .Q 
+ ok
 T{ s\" \na \nzzz \n. \nq \n?\nQ " compare -> 0 }T Data stack underflow
-Return stack: 71 A0 E3 87 5B D8 9A 80
+Return stack: 8B A0 E3 87 EB D7 9A 80
   ok
   ok
 \ Test --- p --- print one line, no line number  ok
@@ -2745,14 +2746,15 @@ T{ 2 -> 5 3 - }T  ok
   ok
 T{ 36 constant max-base -> }T \ ANS standard says 2 - 36  ok
 T{ base @  constant orig-base -> }T  ok
-T{ s" 0123456789" ( addr u ) drop  constant digit_numeral -> }T  ok
-T{ s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop  constant digit_lower -> }T  ok
-T{ s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop  constant digit_upper -> }T  ok
+T{ : digit_numeral s" 0123456789" ( addr u ) drop ; -> }T  ok
+T{ : digit_lower s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop ; -> }T  ok
+T{ : digit_upper s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop ; -> }T  ok
+  ok
   ok
 \ "/" and ":" are before and after ASCII numbers  ok
 \ "@" and "[" are before and after upper case ASCII letters  ok
 \ "`" and "{" are before and after lower case ASCII letters  ok
-T{ s" /:@[`{"  ( addr u )  drop  constant digit_bad -> }T  ok
+T{ : digit_bad s" /:@[`{"  ( addr u )  drop ; -> }T  ok
   ok
 : digit_numeral ( -- f )  compiled
    true  compiled
@@ -2990,11 +2992,12 @@ T{ capture-output words restore-output s" drop dup swap" search -rot 2drop -> tr
 \ DUMP tests  ok
   ok
 :noname blkbuffer 32 bounds do i i c! loop ; execute  ok
-T{ blkbuffer 0 capture-output dump restore-output s\" \n0400  " compare -> 0 }T  ok
-T{ blkbuffer 3 capture-output dump restore-output s\" \n0400  00 01 02  ..." compare -> 0 }T  ok
-T{ blkbuffer 3 capture-output dump restore-output s\" \n0400  00 01 02  ..." compare -> 0 }T  ok
-T{ blkbuffer 11 capture-output dump restore-output s\" \n0400  00 01 02 03 04 05 06 07  08 09 0A  ........ ..." compare -> 0 }T  ok
-T{ blkbuffer 32 capture-output dump restore-output s\" \n0400  00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F  ........ ........\n0410  10 11 12 13 14 15 16 17  18 19 1A 1B 1C 1D 1E 1F  ........ ........\n0420  " compare -> 0 }T  ok
+T{ blkbuffer 0 capture-output dump restore-output s\" \n" compare -> 0 }T  ok
+T{ blkbuffer 3 capture-output dump restore-output s\" \n 0400  00 01 02                                          ...\n"  ok
+compare -> 0 }T  ok
+T{ blkbuffer 11 capture-output dump restore-output s\" \n 0400  00 01 02 03 04 05 06 07  08 09 0A                 ........ ...\n"  ok
+compare -> 0 }T  ok
+T{ blkbuffer 32 capture-output dump restore-output s\" \n 0400  00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F  ........ ........\n 0410  10 11 12 13 14 15 16 17  18 19 1A 1B 1C 1D 1E 1F  ........ ........\n " compare -> 0 }T  ok
   ok
   ok
   ok
@@ -3107,7 +3110,7 @@ T{ blkbuffer 32 capture-output dump restore-output s\" \n0400  00 01 02 03 04 05
 ;  ok
   ok
   ok
-: see-/mod-output s\" \n nt: *  xt: * \n flags: CO 0 IM 0 AN 0 NN 0 HC 0 | UF 1 ST 0 \n size (decimal): 26 \n \n *  20 ?? ?? A9 FF 48 20 ??  ?? 20 ?? ?? 20 ?? ?? 20   .??.H ? ? ?? ?? \n *  ?? ?? 68 D0 05 20 ?? ??  E8 E8  ??h..  .?..\n \n *  ????? jsr     2 STACK DEPTH CHECK\n *     FF lda.#\n *        pha\n *  ????? jsr     >r\n *  ????? jsr     s>d\n *  ????? jsr     r>\n *  ????? jsr     sm/rem\n *        pla\n *      5 bne     * v\n *  ????? jsr     swap\n *        inx\n *        inx\n"  compiled
+: see-/mod-output s\" \n nt: *  xt: * \n flags: CO 0 IM 0 AN 0 NN 0 HC 0 | UF 1 ST 0 \n size (decimal): 26 \n \n *  20 ?? ?? A9 FF 48 20 ??  ?? 20 ?? ?? 20 ?? ?? 20   ??..H ? ? ?? ?? \n *  ?? ?? 68 D0 05 20 ?? ??  E8 E8                    ??h.. ?? ..\n \n *  ????? jsr     2 STACK DEPTH CHECK\n *     FF lda.#\n *        pha\n *  ????? jsr     >r\n *  ????? jsr     s>d\n *  ????? jsr     r>\n *  ????? jsr     sm/rem\n *        pla\n *      5 bne     * v\n *  ????? jsr     swap\n *        inx\n *        inx\n"  compiled
 ;  ok
   ok
 \ these tests are a little fiddly since the width of some fields can vary based on the base  ok
@@ -3120,13 +3123,13 @@ T{ capture-output see /mod restore-output see-/mod-output  compare-glob -> 0 }T 
   ok
 \ CASE has CO+IM+NN flags  ok
   ok
-: see-case-output s\" \n nt: *  xt: * \n flags: CO 1 IM 1 AN 0 NN 1 HC 0 | UF 0 ST 0 \n size (decimal): 6 \n \n *  CA CA 74 00 74 01  ..t.t.\n \n *        dex\n *        dex\n *      0 stz.zx\n *      1 stz.zx\n"  compiled
+: see-case-output s\" \n nt: *  xt: * \n flags: CO 1 IM 1 AN 0 NN 1 HC 0 | UF 0 ST 0 \n size (decimal): 6 \n \n *  CA CA 74 00 74 01                                 ..t.t.\n \n *        dex\n *        dex\n *      0 stz.zx\n *      1 stz.zx\n"  compiled
 ;  ok
 T{ capture-output see case restore-output see-case-output  compare-glob -> 0 }T  ok
   ok
 \ EXIT has AN flag  ok
   ok
-: see-exit-output s\" \n nt: *  xt: * \n flags: CO 1 IM 0 AN 1 NN 0 HC 0 | UF 0 ST 0 \n size (decimal): 1 \n \n *  60  `\n \n *        rts\n"  compiled
+: see-exit-output s\" \n nt: *  xt: * \n flags: CO 1 IM 0 AN 1 NN 0 HC 0 | UF 0 ST 0 \n size (decimal): 1 \n \n *  60                                                `\n \n *        rts\n"  compiled
 ;  ok
 T{ capture-output see exit restore-output see-exit-output  compare-glob -> 0 }T  ok
   ok
@@ -3138,7 +3141,7 @@ nc-limit @  ok
 ;  ok
 nc-limit !  ok
   ok
-: disasm-test-output s\" \n *  ????? jsr     LITERAL 10 \n *  ????? jsr     0\n *  ????? jsr     DO \n *  ????? jsr     2LITERAL 305419896 \n *  ????? jsr     2drop\n *  ????? jmp\n *  ????? jsr     SLITERAL * 6 \n *  ????? jsr     2drop\n *  ????? jsr     i\n *  ????? jsr     1\n *  ????? jsr     and\n *  ????? jsr     0BRANCH * \n *  ????? jmp\n *  ????? jsr     LOOP * \n *  ????? jsr     unloop\n *  ????? jsr     0\n *  ????? jsr     0\n *  ????? jsr     ?DO * \n *  ????? jsr     DO \n *  ????? jsr     LITERAL -1 \n *  ????? jsr     +LOOP * \n *  ????? jsr     unloop\n"  compiled
+: disasm-test-output s\" \n *  ????? jsr     LITERAL 10 \n *  ????? jsr     0\n *  ????? jsr     DO \n *  ????? jsr     2LITERAL 305419896 \n *  ????? jsr     2drop\n *  ????? jsr     SLITERAL 6 banana\n *  ????? jsr     2drop\n *  ????? jsr     i\n *  ????? jsr     1\n *  ????? jsr     and\n *  ????? jsr     0BRANCH * \n *  ????? jmp\n *  ????? jsr     LOOP * \n *  ????? jsr     unloop\n *  ????? jsr     0\n *  ????? jsr     0\n *  ????? jsr     ?DO * \n *  ????? jsr     DO \n *  ????? jsr     LITERAL -1 \n *  ????? jsr     +LOOP * \n *  ????? jsr     unloop\n"  compiled
 ;  ok
   ok
 T{  ok
@@ -3514,7 +3517,7 @@ drop \ accept test complete  ok
              ' \             cycle_test            CYCLES:     41 ok
              ' base          cycle_test drop       CYCLES:     26 ok
 : beginuntil 100 begin 1- ?dup 0= until ;  ok
-             ' beginuntil    cycle_test            CYCLES:  12805 ok
+             ' beginuntil    cycle_test            CYCLES:  12904 ok
 : beginwhile 100 begin 1- ?dup while repeat ;  ok
              ' beginwhile    cycle_test            CYCLES:   9306 ok
              ' bell          cycle_test            CYCLES:     36 ok
@@ -3535,12 +3538,12 @@ here 5       ' blank         cycle_test            CYCLES:    327 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  15768 ok
+             ' :             cycle_test wrd ;      CYCLES:  15764 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:    101 ok
-' aword      ' compile,      cycle_test            CYCLES:    889 ok
+' aword      ' compile,      cycle_test            CYCLES:    878 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     72 ok
-5            ' constant      cycle_test mycnst     CYCLES:  16540 ok
+5            ' constant      cycle_test mycnst     CYCLES:  16533 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3564,7 +3567,7 @@ nc-limit @  ok
 0 nc-limit !  ok
 : fib2 0 1 rot 0 ?do over + swap loop drop ;  ok
 nc-limit !  ok
-100          ' fib1          cycle_test drop       CYCLES:  14359 ok
+100          ' fib1          cycle_test drop       CYCLES:  14458 ok
 100          ' fib2          cycle_test drop       CYCLES:  24463 ok
 : doword 100 0 do loop ;  ok
              ' doword        cycle_test            CYCLES:   1252 ok
@@ -3581,7 +3584,7 @@ nc-limit !  ok
 \ skipping     does  ok
 \ skipping     .  ok
 \ skipping     ."  ok
-             ' s"            cycle_test " 2drop    CYCLES:    483 ok
+             ' s"            cycle_test " 2drop    CYCLES:    252 ok
 5            ' drop          cycle_test            CYCLES:     32 ok
 \ skipping     dump  ok
 5            ' dup           cycle_test 2drop      CYCLES:     48 ok
@@ -3589,7 +3592,7 @@ nc-limit !  ok
 5 5          ' =             cycle_test drop       CYCLES:     66 ok
 here 5       ' erase         cycle_test            CYCLES:    325 ok
 here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  17698 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  17695 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3609,7 +3612,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:   1020 ok
              ' ifloop        cycle_test            CYCLES:  18134 ok
 : cword ;    ' immediate     cycle_test            CYCLES:     72 ok
              ' input         cycle_test drop       CYCLES:     28 ok
-' dup        ' int>name      cycle_test drop       CYCLES:   3404 ok
+' dup        ' int>name      cycle_test drop       CYCLES:   3410 ok
 5            ' invert        cycle_test drop       CYCLES:     48 ok
 \ skipping     j  ok
              ' key           cycle_test drop       CYCLES:     48 ok
@@ -3624,13 +3627,13 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:   1020 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    588 ok
-             ' marker        cycle_test marka      CYCLES:  18539 ok
+             ' marker        cycle_test marka      CYCLES:  18533 ok
              ' marka         cycle_test            CYCLES:    781 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
 5 5          ' -             cycle_test drop       CYCLES:     58 ok
 s" txt   "   ' -trailing     cycle_test 2drop      CYCLES:    224 ok
-here s" a"   ' move          cycle_test            CYCLES:    148 ok
+here s" a"   ' move          cycle_test            CYCLES:    137 ok
 ' + int>name ' name>int      cycle_test drop       CYCLES:     71 ok
 ' + int>name ' name>string   cycle_test 2drop      CYCLES:     61 ok
              ' nc-limit      cycle_test drop       CYCLES:     40 ok
@@ -3646,7 +3649,7 @@ decimal  ok
              ' nops          cycle_test            CYCLES:     29 ok
 5 5          ' <>            cycle_test drop       CYCLES:     70 ok
 5 5 5        ' -rot          cycle_test 2drop drop CYCLES:     76 ok
-s" 5"        ' number        cycle_test drop       CYCLES:   1538 ok
+s" 5"        ' number        cycle_test drop       CYCLES:   1539 ok
 \ skipping     #  ok
 \ skipping     #>  ok
 \ skipping     #s  ok
@@ -3673,7 +3676,7 @@ drop \ refill  ok
 \ skipping     ]  ok
 5 5 5        ' rot           cycle_test 2drop drop CYCLES:     76 ok
 5 5          ' rshift        cycle_test drop       CYCLES:    126 ok
-             ' s"            cycle_test " 2drop    CYCLES:    483 ok
+             ' s"            cycle_test " 2drop    CYCLES:    252 ok
 5            ' s>d           cycle_test 2drop      CYCLES:     47 ok
 \ skipping     ;  ok
 \ skipping     sign  ok
@@ -3708,7 +3711,7 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  17324 ok
+             ' 2variable     cycle_test eword      CYCLES:  17318 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
 s" *"        ' type          cycle_test           *CYCLES:    123 ok
 5            ' u.            cycle_test          5 CYCLES:   1842 ok
@@ -3719,10 +3722,10 @@ s" *"        ' type          cycle_test           *CYCLES:    123 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    476 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  17540 ok
+5            ' value         cycle_test fword      CYCLES:  17534 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
 5            ' to            cycle_test fword      CYCLES:   1136 ok
-             ' variable      cycle_test gword      CYCLES:  17369 ok
+             ' variable      cycle_test gword      CYCLES:  17367 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    620 ok
 \ skipping     words  ok
@@ -3735,4 +3738,4 @@ char "       ' word          cycle_test "txt" drop CYCLES:    620 ok
 5            ' 0<            cycle_test drop       CYCLES:     47 ok
 5            ' 0<>           cycle_test drop       CYCLES:     48 ok
   ok
-bye c65: PC=f016 A=98 X=78 Y=01 S=f6 FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=155306722
+bye c65: PC=f016 A=98 X=78 Y=01 S=f6 FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=155380339

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -2750,7 +2750,6 @@ T{ s" 0123456789" ( addr u ) drop  constant digit_numeral -> }T  ok
 T{ s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop  constant digit_lower -> }T  ok
 T{ s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop  constant digit_upper -> }T  ok
   ok
-  ok
 \ "/" and ":" are before and after ASCII numbers  ok
 \ "@" and "[" are before and after upper case ASCII letters  ok
 \ "`" and "{" are before and after lower case ASCII letters  ok
@@ -3738,4 +3737,4 @@ char "       ' word          cycle_test "txt" drop CYCLES:    620 ok
 5            ' 0<            cycle_test drop       CYCLES:     47 ok
 5            ' 0<>           cycle_test drop       CYCLES:     48 ok
   ok
-bye c65: PC=f016 A=98 X=78 Y=01 S=f6 FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=155188161
+bye c65: PC=f016 A=98 X=78 Y=01 S=f6 FLAGS=<N0 V0 B0 D0 I1 Z0 C0> ticks=155187524

--- a/tests/tali.fs
+++ b/tests/tali.fs
@@ -182,15 +182,15 @@ T{ 2 -> 5 3 - }T
 
 T{ 36 constant max-base -> }T \ ANS standard says 2 - 36
 T{ base @  constant orig-base -> }T
-T{ : digit_numeral s" 0123456789" ( addr u ) drop ; -> }T
-T{ : digit_lower s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop ; -> }T
-T{ : digit_upper s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop ; -> }T
+T{ s" 0123456789" ( addr u ) drop  constant digit_numeral -> }T
+T{ s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop  constant digit_lower -> }T
+T{ s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop  constant digit_upper -> }T
 
 
 \ "/" and ":" are before and after ASCII numbers
 \ "@" and "[" are before and after upper case ASCII letters
 \ "`" and "{" are before and after lower case ASCII letters
-T{ : digit_bad s" /:@[`{"  ( addr u )  drop ; -> }T
+T{ s" /:@[`{"  ( addr u )  drop  constant digit_bad -> }T
 
 : digit_numeral ( -- f )
    true

--- a/tests/tali.fs
+++ b/tests/tali.fs
@@ -182,9 +182,6 @@ T{ 2 -> 5 3 - }T
 
 T{ 36 constant max-base -> }T \ ANS standard says 2 - 36
 T{ base @  constant orig-base -> }T
-\ T{ s" 0123456789" ( addr u ) drop  constant digit_numeral -> }T
-\ T{ s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop  constant digit_lower -> }T
-\ T{ s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop  constant digit_upper -> }T
 T{ : digit_numeral s" 0123456789" ( addr u ) drop ; -> }T
 T{ : digit_lower s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop ; -> }T
 T{ : digit_upper s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop ; -> }T
@@ -193,7 +190,6 @@ T{ : digit_upper s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop ; -> }T
 \ "/" and ":" are before and after ASCII numbers
 \ "@" and "[" are before and after upper case ASCII letters
 \ "`" and "{" are before and after lower case ASCII letters
-\ T{ s" /:@[`{"  ( addr u )  drop  constant digit_bad -> }T
 T{ : digit_bad s" /:@[`{"  ( addr u )  drop ; -> }T
 
 : digit_numeral ( -- f )

--- a/tests/tali.fs
+++ b/tests/tali.fs
@@ -182,14 +182,19 @@ T{ 2 -> 5 3 - }T
 
 T{ 36 constant max-base -> }T \ ANS standard says 2 - 36
 T{ base @  constant orig-base -> }T
-T{ s" 0123456789" ( addr u ) drop  constant digit_numeral -> }T
-T{ s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop  constant digit_lower -> }T
-T{ s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop  constant digit_upper -> }T
+\ T{ s" 0123456789" ( addr u ) drop  constant digit_numeral -> }T
+\ T{ s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop  constant digit_lower -> }T
+\ T{ s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop  constant digit_upper -> }T
+T{ : digit_numeral s" 0123456789" ( addr u ) drop ; -> }T
+T{ : digit_lower s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop ; -> }T
+T{ : digit_upper s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop ; -> }T
+
 
 \ "/" and ":" are before and after ASCII numbers
 \ "@" and "[" are before and after upper case ASCII letters
 \ "`" and "{" are before and after lower case ASCII letters
-T{ s" /:@[`{"  ( addr u )  drop  constant digit_bad -> }T
+\ T{ s" /:@[`{"  ( addr u )  drop  constant digit_bad -> }T
+T{ : digit_bad s" /:@[`{"  ( addr u )  drop ; -> }T
 
 : digit_numeral ( -- f )
    true

--- a/tests/tali.fs
+++ b/tests/tali.fs
@@ -186,7 +186,6 @@ T{ s" 0123456789" ( addr u ) drop  constant digit_numeral -> }T
 T{ s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop  constant digit_lower -> }T
 T{ s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop  constant digit_upper -> }T
 
-
 \ "/" and ":" are before and after ASCII numbers
 \ "@" and "[" are before and after upper case ASCII letters
 \ "`" and "{" are before and after lower case ASCII letters

--- a/tests/tools.fs
+++ b/tests/tools.fs
@@ -22,11 +22,17 @@ T{ capture-output words restore-output s" drop dup swap" search -rot 2drop -> tr
 \ DUMP tests
 
 :noname blkbuffer 32 bounds do i i c! loop ; execute
-T{ blkbuffer 0 capture-output dump restore-output s\" \n0400  " compare -> 0 }T
-T{ blkbuffer 3 capture-output dump restore-output s\" \n0400  00 01 02  ..." compare -> 0 }T
-T{ blkbuffer 3 capture-output dump restore-output s\" \n0400  00 01 02  ..." compare -> 0 }T
-T{ blkbuffer 11 capture-output dump restore-output s\" \n0400  00 01 02 03 04 05 06 07  08 09 0A  ........ ..." compare -> 0 }T
-T{ blkbuffer 32 capture-output dump restore-output s\" \n0400  00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F  ........ ........\n0410  10 11 12 13 14 15 16 17  18 19 1A 1B 1C 1D 1E 1F  ........ ........\n0420  " compare -> 0 }T
+T{ blkbuffer 0 capture-output dump restore-output s\" \n" compare -> 0 }T
+T{ blkbuffer 3 capture-output dump restore-output s\" \n
+0400  00 01 02                                          ...\n"
+compare -> 0 }T
+T{ blkbuffer 11 capture-output dump restore-output s\" \n
+0400  00 01 02 03 04 05 06 07  08 09 0A                 ........ ...\n"
+compare -> 0 }T
+T{ blkbuffer 32 capture-output dump restore-output s\" \n
+0400  00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F  ........ ........\n
+0410  10 11 12 13 14 15 16 17  18 19 1A 1B 1C 1D 1E 1F  ........ ........\n
+" compare -> 0 }T
 
 
 
@@ -144,8 +150,8 @@ nt: *  xt: * \n
 flags: CO 0 IM 0 AN 0 NN 0 HC 0 | UF 1 ST 0 \n
 size (decimal): 26 \n
 \n
-*  20 ?? ?? A9 FF 48 20 ??  ?? 20 ?? ?? 20 ?? ?? 20   .??.H ? ? ?? ?? \n
-*  ?? ?? 68 D0 05 20 ?? ??  E8 E8  ??h..  .?..\n
+*  20 ?? ?? A9 FF 48 20 ??  ?? 20 ?? ?? 20 ?? ?? 20   ??..H ? ? ?? ?? \n
+*  ?? ?? 68 D0 05 20 ?? ??  E8 E8                    ??h.. ?? ..\n
 \n
 *  ????? jsr     2 STACK DEPTH CHECK\n
 *     FF lda.#\n
@@ -176,7 +182,7 @@ nt: *  xt: * \n
 flags: CO 1 IM 1 AN 0 NN 1 HC 0 | UF 0 ST 0 \n
 size (decimal): 6 \n
 \n
-*  CA CA 74 00 74 01  ..t.t.\n
+*  CA CA 74 00 74 01                                 ..t.t.\n
 \n
 *        dex\n
 *        dex\n
@@ -192,7 +198,7 @@ nt: *  xt: * \n
 flags: CO 1 IM 0 AN 1 NN 0 HC 0 | UF 0 ST 0 \n
 size (decimal): 1 \n
 \n
-*  60  `\n
+*  60                                                `\n
 \n
 *        rts\n"
 ;
@@ -212,8 +218,7 @@ nc-limit !
 *  ????? jsr     DO \n
 *  ????? jsr     2LITERAL 305419896 \n
 *  ????? jsr     2drop\n
-*  ????? jmp\n
-*  ????? jsr     SLITERAL * 6 \n
+*  ????? jsr     SLITERAL 6 banana\n
 *  ????? jsr     2drop\n
 *  ????? jsr     i\n
 *  ????? jsr     1\n

--- a/words/assembler.asm
+++ b/words/assembler.asm
@@ -1016,7 +1016,7 @@ _done:
 
 xt_asm_push_a:
         ; """push-a puts the content of the 65c02 Accumulator on the Forth
-        ; data stack as the TOS. This is a convenience routine
+        ; data stack as the TOS. This is a convenience routine that
         ; just copies the code for push_a_tos from disasm.asm
         ; """
                 ldy #0

--- a/words/assembler.asm
+++ b/words/assembler.asm
@@ -1015,26 +1015,19 @@ _done:
 
 xt_asm_push_a:
         ; """push-a puts the content of the 65c02 Accumulator on the Forth
-        ; data stack as the TOS. This is a convience routine that encodes the
-        ; instructions  DEX  DEX  STA 0,X  STZ 1,X
+        ; data stack as the TOS. This is a convenience routine
+        ; just copies the code for push_a_tos from disasm.asm
         ; """
                 ldy #0
 _loop:
-                lda asm_push_a_data,y
-                cmp #$FF
-                beq _done
-
+                lda push_a_tos,y
                 jsr cmpl_a      ; does not change Y
                 iny
-                bra _loop
+                cpy #z_push_a_tos - push_a_tos
+                bne _loop
 _done:
 z_asm_push_a:
                 rts
-asm_push_a_data:
-        ; We can't use 00 as a terminator because STA 0,X assembles to 95 00
-        .byte $CA, $CA, $95, 00, $74, $01
-        .byte $FF               ; terminator
-
 
 
 ; ==========================================================

--- a/words/block.asm
+++ b/words/block.asm
@@ -189,8 +189,21 @@ w_block_ramdrive_init:
                 ; don't have the words defined below in the Dictionary until
                 ; we really use them.
                 jsr sliteral_runtime
-                .word ramdrive_code, ramdrive_code_end-ramdrive_code
-
+                .word ramdrive_code_end-ramdrive_code
+ramdrive_code:
+                .text "base @ swap decimal"
+                .text " 1024 *" ; ( Calculate how many bytes are needed for numblocks blocks )
+                .text " dup"    ; ( Save a copy for formatting it at the end )
+                .text " buffer: ramdrive" ; ( Create ramdrive )
+                ; ( These routines just copy between the buffer and the ramdrive blocks )
+                .text " : block-read-ramdrive"  ; ( addr u -- )
+                .text " ramdrive swap 1024 * + swap 1024 move ;"
+                .text " : block-write-ramdrive" ; ( addr u -- )
+                .text " ramdrive swap 1024 * + 1024 move ;"
+                .text " ' block-read-ramdrive block-read-vector !" ; ( Replace I/O vectors )
+                .text " ' block-write-ramdrive block-write-vector !"
+                .text " ramdrive swap blank base !"
+ramdrive_code_end:
                 ; The address and length of the ramdrive code is now on the
                 ; stack. Call EVALUATE to run it.
                 jsr w_evaluate
@@ -198,20 +211,7 @@ w_block_ramdrive_init:
 z_block_ramdrive_init:
                 rts
 
-ramdrive_code:
-        .text "base @ swap decimal"
-        .text " 1024 *" ; ( Calculate how many bytes are needed for numblocks blocks )
-        .text " dup"    ; ( Save a copy for formatting it at the end )
-        .text " buffer: ramdrive" ; ( Create ramdrive )
-        ; ( These routines just copy between the buffer and the ramdrive blocks )
-        .text " : block-read-ramdrive"  ; ( addr u -- )
-        .text " ramdrive swap 1024 * + swap 1024 move ;"
-        .text " : block-write-ramdrive" ; ( addr u -- )
-        .text " ramdrive swap 1024 * + 1024 move ;"
-        .text " ' block-read-ramdrive block-read-vector !" ; ( Replace I/O vectors )
-        .text " ' block-write-ramdrive block-write-vector !"
-        .text " ramdrive swap blank base !"
-ramdrive_code_end:
+
 
 .endif
 

--- a/words/compile.asm
+++ b/words/compile.asm
@@ -268,6 +268,10 @@ _not_uf:        clc                     ; C=0 means it isn't a UF check
 ; We have have various utility routines here for compiling a word in Y/A
 ; and a single byte in A.
 
+; TODO for all of these we could potentially avoid jmp (and NN) and
+; use BRA instaed.  jump_later is a bit harder since we need to remember NN state
+; in case something else changed it
+
 cmpl_jump_later:
     ; compile a jump to be filled in later with dummy address <MSB=Y/LSB=??>
     ; leaving address of the JMP target TOS

--- a/words/compile.asm
+++ b/words/compile.asm
@@ -242,7 +242,7 @@ has_uf_check:
                 bcs _not_uf             ; LSB is too big
 
                 sec                     ; C=1 means it is an UF check
-                .byte $24               ; bit zp opcode masks the clc, with no effect on carry
+                .byte OpBITzp           ; mask the clc, with no effect on carry
 _not_uf:        clc                     ; C=0 means it isn't a UF check
                 inx                     ; clean up stack
                 inx

--- a/words/core.asm
+++ b/words/core.asm
@@ -4755,7 +4755,6 @@ _nt_in_workword:
                 lda workword+1          ; MSB
                 adc #0
                 sta tmp1+1
-
                 lda (tmp1)
                 sta (cp),y
                 phy
@@ -5024,15 +5023,44 @@ w_s_quote:
                 stz tmp2+1
 
 s_quote_start:
-                ; write the string to unallocated space beyond PAD
-                ; by temporarily incrementing cp by $200
-                ;TODO is possible OoM worse than losing space for every interactive string?
+                ; S" has undefined interpretation semantics in the CORE word set, but
+                ; the FILE wordset permits it provided "no standard words other than S"
+                ; ... [should overwrite the] interpreted string"
+                ; (see https://forth-standard.org/standard/file/Sq for the details).
+                ; One approach would be to reserve a fixed buffer of at least 80
+                ; bytes somewhere outside the dictionary, like we do for command history
+                ; or the block buffer.  The alternative adopted here is to always
+                ; allocate space for the string in the dictionary.  This means
+                ; that every interactive use of S" allocates space you won't get back
+                ; (without MARKER or the like) but has the big advantage that strings
+                ; stay where you put them and don't get overwritten by other operations.
 
-                inc cp+1
-                inc cp+1
+                ; We will save a bit of space when interpeting by writing the string
+                ; literal directly HERE.  When we're compiling we'll use SLITERAL
+                ; which needs a five byte prologue (jsr sliteral_runtime / .word length)
+                ; so we'll leave space for that.
 
-                jsr w_here              ; the start of the string
-                ; ( addr )
+                lda state               ; check whether we're interpeting (0) or compiling (-1)
+                ora state+1             ; paranoid
+
+                pha                     ; save zero / nonzero for post-processing
+                beq _interpeting        ; just write string directly
+
+                ; we're compiling, so reserve just enough space for SLITERAL to later
+                ; add the prologue before the string data
+
+                clc
+                lda cp
+                adc #5                  ; reserve five bytes for the prologue (see below)
+                sta cp
+                bcc +
+                inc cp+1
++
+_interpeting:
+                ; Now we'll compile the string bytes into the dictionary
+                ; But first remember the address where we started
+
+                jsr w_here              ; ( addr )
 
 _savechars_loop:
                 ; Start saving the string into the dictionary up to the
@@ -5236,33 +5264,39 @@ _found_string_end:
                 bne +
                 inc toin+1
 +
-                ; We currently have ( addr )
-                ; and need to calculate the length of string
+                ; Finally we've compiled all the string data into the dictionary
+                ; We still have the start address and need the string length
 
+                ; ( addr )
                 jsr w_here
                 jsr w_over
                 jsr w_minus    ; HERE - addr gives string length
-
                 ; ( addr u )
-
-                ; Now reset CP to $200 before addr compiled memory
-                lda 2,x
-                sta cp
-                lda 3,x
-                dea
-                dea
-                sta cp+1
 
                 ; What happens next depends on the state (which is bad, but
                 ; that's the way it works at the moment). If we are
-                ; interpreting (state=0), we're done since we've saved the string
-                ; to a transient buffer (used for file calls, see
-                ; https://forth-standard.org/standard/file/Sq ). If we're
-                ; compiling, we just call SLITERAL
-                lda state
-                ora state+1             ; paranoid
+                ; interpreting (state=0), we're done because we've saved the string
+                ; to a buffer.  (In fact we've over-delivered by compiling the string
+                ; to permanent storage in the dictionary!)
+
+                ; If we're compiling, we need to turn the string into an SLITERAL.
+                ; We'll just rewind the CP to where it was when we started -
+                ; five bytes before the string we've written - and let sliteral
+                ; work its magic.  It'll write the five byte prologue and copy
+                ; the string data onto itself (a no-op) while re-allocating the space.
+
+                pla                     ; fetch the state flag (0 = interpret)
                 beq _done
 
+                sec                     ; rewind the CP to addr-5
+                lda 2,x
+                sbc #5
+                sta cp
+                lda 3,x
+                sbc #0
+                sta cp+1
+
+                ; write the prologue, "copy" the string and reallocate the space
                 jsr w_sliteral         ; ( addr u -- )
 
 _done:

--- a/words/disasm.asm
+++ b/words/disasm.asm
@@ -470,12 +470,17 @@ _sliteral_handler:
         .byte str_disasm_do, 1 + ('?'-32)*4
 _end_handlers:
 
-; used to calculate size of assembled disassembler code
-disassembler_end:
 
+; Push the accumalator to TOS
+; This only saves a byte but improves readability
+; This routine is also used as a template by the assembler "push-a" word
 push_a_tos:  ; ( -- A )
                 dex
                 dex
                 sta 0,x
                 stz 1,x
+z_push_a_tos:
                 rts
+
+; used to calculate size of assembled disassembler code
+disassembler_end:

--- a/words/disasm.asm
+++ b/words/disasm.asm
@@ -417,23 +417,23 @@ _show_payload:
                 jsr w_swap
                 jsr w_one_plus      ; ( addr n u saddr )
                 jsr w_over          ; ( addr n u saddr u )
-                stz scratch+5
-                lda #16
-                ldy 1,x
+                lda #16             ; show max of 16 characters
+                ldy 1,x             ; Y<>0 will flag truncated string
                 bne _big
                 cmp 0,x             ; more than 16 characters?
                 bcs +
 _big:           stz 1,x             ; only print first 16
                 sta 0,x
-                dec scratch+5
+                ldy #3              ; print trailing ...
 +
                 jsr w_type          ; print (start of) string
-                lda scratch+5       ; maybe print ellipses
-                bpl +
+                tya
+                beq +
                 lda #'.'
+_ellipses
                 jsr emit_a
-                jsr emit_a
-                jsr emit_a
+                dey
+                bne _ellipses
 +
                 ; ( addr n u )
                 jsr w_rot           ; ( n u addr )

--- a/words/double.asm
+++ b/words/double.asm
@@ -259,32 +259,24 @@ xt_two_constant:
                 jsr underflow_2
 w_two_constant:
                 jsr w_create
-                jsr w_swap
                 jsr w_comma
                 jsr w_comma
 
                 jsr does_runtime    ; does> turns into these two routines.
                 jsr dodoes
 
-                jsr w_dup
-                jsr w_fetch
-                jsr w_swap
-                jsr w_cell_plus
-                jsr w_fetch
-
+                jsr w_two_fetch
 z_two_constant: rts
 
 
 ; ## TWO_LITERAL (C: d -- ) ( -- d) "Compile a literal double word"
 ; ## "2literal"  auto  ANS double
         ; """https://forth-standard.org/standard/double/TwoLITERAL"""
-        ; Shares code with xt_sliteral for compiling a double word
         ; """
 xt_two_literal:
                 jsr underflow_2 ; double number
 w_two_literal:
-                lda #template_push_tos_size
-                asl
+                lda #2 * template_push_tos_size
                 jsr check_nc_limit
                 bcs _no_inline
 
@@ -293,10 +285,65 @@ w_two_literal:
                 jmp w_literal
 
 _no_inline:
-                jsr cmpl_two_literal
+                ; Compile a subroutine jump that copies the four following
+                ; bytes to the stack, in the same order.  For example
+                ; a four byte double word written from MSB to LSB as UNIX
+                ; is represented on the stack as TOS: .byte N,U and NOS: X,I
+                ; so we'll generate code like:
+                ;       jsr two_literal_runtime
+                ;       .byte N, U, X, I
+
+                ldy #>two_literal_runtime
+                lda #<two_literal_runtime
+                jsr cmpl_subroutine
+
+                ldy #4
+-
+                lda 0,x         ; move four bytes from the stack to cp
+                jsr cmpl_a
+                inx
+                dey
+                bne -
 
 z_two_literal:  rts
 
+
+two_literal_runtime:
+        ; """Run time behavior of 2LITERAL, which stacks two words
+        ; following the jsr to the stack in the same memory order.
+        ; For example if we have
+        ;
+        ;       jsr two_literal_runtime
+        ;       .byte N, U, X, I
+        ;
+        ; Then on return the stack will contain the word N,U TOS
+        ; and the word X, I NOS.  This matches the order expected
+        ; for double words and as specified for 2@, 2!
+        ; see https://forth-standard.org/standard/core/TwoFetch
+        ; """
+
+                pla             ; LSB of address
+                sta tmp1
+                ply             ; MSB of address
+                sty tmp1+1
+
+                clc             ; add four to the return address
+                adc #4
+                bcc +
+                iny
++
+                phy             ; and re-stack
+                pha
+
+                ldy #4
+-
+                lda (tmp1),y    ; copy trailing four bytes to the stack
+                dex
+                sta 0,x
+                dey
+                bne -
+
+                rts
 
 
 ; ## TWO_VARIABLE ( "name" -- ) "Create a variable for a double word"

--- a/words/editor.asm
+++ b/words/editor.asm
@@ -122,14 +122,12 @@ w_editor_l:
                 ; Print the screen number.
                 ; We're using sliteral, so we need to set up the
                 ; appropriate data structure (see sliteral)
-                bra _after_screen_msg
 
+                jsr sliteral_runtime
+                .word _after_screen_msg-_screen_msg
 _screen_msg:
                 .text "Screen #"
-
 _after_screen_msg:
-                jsr sliteral_runtime
-                .word _screen_msg, _after_screen_msg-_screen_msg
 
                 jsr w_type
 
@@ -195,7 +193,7 @@ _line_loop:
                 inx
                 inx
 
-z_editor_l:            rts
+z_editor_l:     rts
 
 
 

--- a/words/string.asm
+++ b/words/string.asm
@@ -598,7 +598,7 @@ sliteral_runtime:
                 sta 0,x         ; LSB of u
 
                 ; we want to continue past the string, i.e. NOS+TOS
-                clc
+                clc             ; A still has LSB of u
                 adc 2,x         ; LSB of continuation address
                 sta tmp1
                 lda 1,x

--- a/words/string.asm
+++ b/words/string.asm
@@ -550,12 +550,12 @@ w_sliteral:
 
                 jsr w_here
                 jsr w_swap
-                ; ( addr addr' u )      ; .byte < u bytes >
+                ; ( addr addr' u )
 
                 jsr w_dup               ; allocate space for the string
                 jsr w_allot
 
-                jsr w_move              ; copy the string data
+                jsr w_move              ; .text < u bytes >
 
 z_sliteral:     rts
 

--- a/words/string.asm
+++ b/words/string.asm
@@ -522,7 +522,7 @@ z_slash_string: rts
 
 
 
-; ## SLITERAL ( addr u -- )( -- addr u ) "Compile a string for runtime"
+; ## SLITERAL (C: addr u -- ) ( -- addr u ) "Compile a string for runtime"
 ; ## "sliteral" auto  ANS string
         ; """https://forth-standard.org/standard/string/SLITERAL
         ; Add the runtime for an existing string.
@@ -533,117 +533,76 @@ xt_sliteral:
 w_sliteral:
                 ; We can't assume that ( addr u ) of the current string is in
                 ; a stable area (eg. already in the dictionary.)
-                ; We'll compile the string data into the dictionary using move
-                ; along with code that stacks the new ( addr' u )
-                ;   jmp _end
-                ; _str:
-                ;   < u data bytes >
-                ; _end: jsr sliteral_runtime
-                ;   < _str u >
+                ; We'll compile the length and string data into the dictionary
+                ; using move along with runtime code that stacks the new ( addr' u )
+                ;
+                ;   jsr sliteral_runtime
+                ;   .word u
+                ;   .byte < u data bytes >
 
-                jsr cmpl_jump_later
-                jsr w_to_r
-                ; ( addr u  R: jmp-target )
-                jsr w_here
-                jsr w_swap
-                ; ( addr addr' u )
-                jsr w_dup
-                jsr w_allot            ; reserve u bytes for string
-                jsr w_here
-                ; ( addr addr' u addr'+u )
-                jsr w_r_from
-                jsr w_store            ; point jmp past string
-                jsr w_two_dup
-                jsr w_two_to_r
-                ; ( addr addr' u  R: addr' u )
-                jsr w_move             ; copy u bytes from addr -> addr'
-                jsr w_two_r_from
-                ; Stack is now ( addr' u ) with the new string location
-
-cmpl_sliteral:
-cmpl_two_literal:
-                ; Compile a subroutine jump to the runtime of SLITERAL that
-                ; pushes the new ( addr u ) pair to the Data Stack.
-                ; When we're done, the code will look like this:
-
-                ; xt -->    jmp a
-                ;           <string data bytes>
-                ;  a -->    jsr sliteral_runtime
-                ;           <string address>
-                ;           <string length>
-                ; rts -->
-
-                ; This means we'll have to adjust the return address for two
-                ; cells, not just one
                 ldy #>sliteral_runtime
                 lda #<sliteral_runtime
-                jsr cmpl_subroutine
+                jsr cmpl_subroutine     ; jsr sliteral_runtime
 
-                ; We want to have the address end up as NOS and the length
-                ; as TOS, so we store the address first
-                ldy 3,x                ; address MSB
-                lda 2,x                ; address LSB
-                jsr cmpl_word
+                lda 0,x
+                ldy 1,x
+                jsr cmpl_word           ; .word u
 
-                ldy 1,x                ; length MSB
-                lda 0,x                ; length LSB
-                jsr cmpl_word
+                jsr w_here
+                jsr w_swap
+                ; ( addr addr' u )      ; .byte < u bytes >
 
-                ; clean up and leave
-                inx
-                inx
-                inx
-                inx
+                jsr w_dup               ; allocate space for the string
+                jsr w_allot
+
+                jsr w_move              ; copy the string data
 
 z_sliteral:     rts
 
 
-
 sliteral_runtime:
-
-        ; """Run time behaviour of SLITERAL: Push ( addr u ) of string to
-        ; the Data Stack. We arrive here with the return address as the
-        ; top of Return Stack, which points to the address of the string.
-        ; Also used for double word where we have ( lo hi ).
+        ; """Run time behaviour of SLITERAL: Push ( addr u ) of the string to
+        ; the Data Stack.  The length and string data follows the JSR here,
+        ; for example if we have
+        ;
+        ;       jsr sliteral_runtime
+        ;       .word u
+        ;    _addr:
+        ;       .byte < u string bytes >
+        ;
+        ; Then we want to stack ( _str u ) and return past the end of the string.
         ; """
-                dex
+                dex             ; make space on the stack
                 dex
                 dex
                 dex
 
-                ; We arrived from code like
-                ;   jsr sliteral_runtime
-                ;   .word addr
-                ;   .word length
-                ; So the return address points one byte before addr.
-                ; Pull that to tmp1 and put tmp1+4 to return past two data words
-                pla
-                sta tmp1        ; LSB of address
-                ply
-                sty tmp1+1      ; MSB of address
+                ; fetch return address which points one byte before u
                 clc
-                adc #4
+                pla             ; LSB of return address
+                sta tmp1
+                adc #3          ; calculate string offset
+                sta 2,x         ; LSB of string address
+                ply             ; MSB of address
+                sty tmp1+1
                 bcc +
                 iny
 +
-                phy
-                pha
+                sty 3,x         ; MSB of string address
 
-                ; Walk through both and save them
-                ldy #1          ; adjust for JSR/RTS mechanics on 65c02
+                ldy #2          ; copy u to TOS
                 lda (tmp1),y
-                sta 2,x         ; LSB of address
-                iny
-
+                sta 1,x         ; MSB of u
+                dey
                 lda (tmp1),y
-                sta 3,x         ; MSB of address
-                iny
+                sta 0,x         ; LSB of u
 
-                lda (tmp1),y
-                sta 0,x         ; LSB of length
-                iny
+                ; we want to continue past the string, i.e. NOS+TOS
+                clc
+                adc 2,x         ; LSB of continuation address
+                sta tmp1
+                lda 1,x
+                adc 3,x
+                sta tmp1+1
 
-                lda (tmp1),y
-                sta 1,x         ; MSB of length
-
-                rts
+                jmp (tmp1)

--- a/words/tools.asm
+++ b/words/tools.asm
@@ -201,19 +201,30 @@ z_dump:         rts
 nextpass:
                 dec 3,x                 ; set flag to -1 for second pass
 
-                cpy #8
-                bcs _fill
-                jsr w_space
-_fill:
-                cpy #16
-                beq +
-                jsr w_space
-                jsr w_space
-                jsr w_space
-                iny
-                bra _fill
+                ; add spaces for alignment
+                ; we want 1 + 3*(16-Y) + (1 if Y<8)
+
+                ; 16-A = 16 + (255-A) + 1 - 256
+
+                tya                     ; 16-A = 16 + (255-A) + 1 - 256
+                eor #$ff
+                sec
+                adc #16
+
+                sta tmpdsp
+                asl                     ; 2*(16-Y), leaving C=0
+                adc tmpdsp              ; 3*(16-Y)
+
+                cpy #8                  ; + 1 if Y < 8
+                bcs +
+                ina
 +
-                jmp w_space             ; extra space and then return for next pass
+                tay
+-
+                jsr w_space
+                dey
+                bpl -                   ; Y...0 inclusive
+                rts
 
 
 ; ## QUESTION ( addr -- ) "Print content of a variable"
@@ -362,7 +373,6 @@ _emit:
                 jsr w_two_dup          ; ( xt u xt u )
 .endif
                 jsr w_dump
-                jsr w_cr
 .if "disassembler" in TALI_OPTIONAL_WORDS
                 jsr w_disasm
 .endif


### PR DESCRIPTION
Switching to standard NUXI memory layout for 2literal PFA became a bit of an odyssey where I refactored sliteral as well.

It now compiles like `jsr sliteral_runtime / .word length / .text <string>` instead of `jmp skip / .text <string> / jsr sliteral_runtime addr n`.  This makes string literal a little smaller and faster but also native-compilable since it loses the `jmp`.   It also simplifies disassembly a lot.    

I noticed that `s"` was always reserving space for the string even when interpreted, so every string claims space in the dictionary.  Presumably that's safer but you'll run out of space faster.  The [spec](https://forth-standard.org/standard/file/Sq) you shared suggests that it could be a temp buffer "...an implementation may choose to provide only one buffer for interpreted strings, an interpreted string is subject to being overwritten by the next execution of S" in interpretation state...".

In the PR currently it writes interpreted `s"` strings at cp+$200 (beyond pad), which meant a minor test change to name a constant string, e.g. `: foo s" const" drop ; ` instead of `s" const" drop constant foo` which isn't safe.  

I don't have strong feelings so happy to revert that if you like the safe alloc instead.

I made a few cosmetic/byte-saving changes to dump like avoiding writing temp data at cp, and adding space padding - lmk if you prefer without.  Also in disasm to show a snippet of sliteral string.  Overall image is about 100 bytes smaller, or more if we dropped cosmetic changes.   Example:

```
see block-ramdrive-init 
nt: C882  xt: AEC4 
flags: CO 0 IM 0 AN 0 NN 0 HC 0 | UF 1 ST 0 
size (decimal): 291 

AEC4  20 27 D8 20 29 A2 18 01  62 61 73 65 20 40 20 73   '. )... base @ s
...
AFD4  77 61 70 20 62 6C 61 6E  6B 20 62 61 73 65 20 21  wap blan k base !
AFE4  20 8E 88                                           ..

AEC4   D827 jsr     1 STACK DEPTH CHECK
AEC7   A229 jsr     SLITERAL 118 base @ swap dec...
AFE4   888E jsr     evaluate
 ok
```
