### PR TITLE
Bugfix for user0 not starting at $0000.

### DIFF
--- a/words/all.asm
+++ b/words/all.asm
@@ -52,7 +52,7 @@ w_cold:
 _load_zp_loop:
                 ; This loop loads them back to front.
                 lda cold_zp_table,y
-                sta zpage,y
+                sta user0,y
                 dey
                 bpl _load_zp_loop           ; <128 bytes so safe to loop until y<0
 


### PR DESCRIPTION
On systems where the zeropage RAM does not start at $0000, the system would crash on start-up, due to wrong label used for setup.