### PR TITLE
Refactor some duplicated ascii>digit code; >number speedup

### DIFF
--- a/taliforth.asm
+++ b/taliforth.asm
@@ -271,13 +271,19 @@ _nibble_to_ascii:
 
 
 ascii_to_byte:
-        ; convert characters in Y, A to byte, with C=0 on success, C=1 if invalid
-        ; uses tmpdsp
-        jsr ascii_to_nibble     ; lower nibble
+        ; convert two ascii hex digit characters in Y (hi) and A (lo) to a byte,
+        ; returning the result in A with C=0 on success, C=1 if invalid.
+        ; Uses tmpdsp.
+        phx
+        ldx base
+        phx
+        ldx #16                 ; parsing hex digits
+        stx base
+        jsr ascii_to_digit      ; lower nibble
         bcs _done
         sta tmpdsp
         tya
-        jsr ascii_to_nibble     ; high nibble
+        jsr ascii_to_digit      ; high nibble
         bcs _done
         asl                     ; $0-$f on success so shifts leave C=0
         asl
@@ -285,30 +291,15 @@ ascii_to_byte:
         asl
         ora tmpdsp              ; combine with lower nibble
 _done:
+        plx
+        stx base                ; restore original base
+        plx
         rts
 
 
-ascii_to_nibble:
-        ; convert A from ASCII character [0-9A-Fa-f] to hex $0-f
-        ; with C=0 on success, C=1 on invalid char
-        cmp #$40
-        bcs _hi
-
-        sbc #'0'-1              ; < '0' => large
-        cmp #10                 ; C=1 if >= 10 (error)
-        bra _done
-_hi:
-        and #$1f                ; mask to accept uc & lc
-        beq _done               ; @ or ` is error (C=1 from above)
-        adc #8                  ; A=1 => 1+8+1=10
-        cmp #$10                ; set C=1 if not $a-$f
-_done:
-        rts
-
-
-ascii_to_base:
-        ; convert A from ASCII character [0-9A-Za-z] to 0-(base-1)
-        ; with C=0 on success, C=1 on invalid char
+ascii_to_digit:
+        ; convert A from ASCII character [0-9A-Za-z] to a digit in the
+        ; current base, with C=0 on success or C=1 with invalid char
         cmp #$40
         bcs _hi
 

--- a/words/tali.asm
+++ b/words/tali.asm
@@ -171,50 +171,15 @@ w_digit_question:
                 stz 1,x
                 stz 3,x                 ; paranoid
 
-                ; Check the character, now in the LSB of NOS. First, make
-                ; sure we're not below the ASCII code for "0"
+                ; Check the character, now in the LSB of NOS.
                 lda 2,x
-                cmp #'0'
-                bcc _done               ; failure flag already set
+                jsr ascii_to_base
+                bcs _done               ; failure flag already set
 
-                ; Next, see if we are below "9", because that would make
-                ; this a normal number
-                cmp #'9'+1               ; this is actually ":"
-                bcc _checkbase
-
-                ; Well, then let's see if this is the gap between "9" and "A"
-                ; so we can treat the whole range as a number
-                cmp #'A'
-                bcc _done               ; failure flag is already set
-
-                ; probably a letter, so we make sure it is uppercase
-                cmp #'a'
-                bcc _case_done          ; not lower case, too low
-                cmp #'z'+1
-                bcs _case_done          ; not lower case, too high
-
-                clc                     ; just right
-                adc #$E0                ; offset to upper case (wraps)
-
-_case_done:
-                ; get rid of the gap between "9" and "A" so we can treat
-                ; the whole range as one number
-                sec
-                sbc #7                  ; fall through to _checkbase
-
-_checkbase:
-                ; we have a number, now see if it falls inside the range
-                ; provided by BASE
-                sec
-                sbc #'0'                 ; this is also the conversion step
-                cmp base
-                bcs _done               ; already have false flag
-
-                ; Found a legal number
+                ; Found a legal number for current base
                 sta 2,x                 ; put number in NOS
                 dec 0,x                 ; set success flag
                 dec 1,x
-
 _done:
 z_digit_question:
                 rts

--- a/words/tali.asm
+++ b/words/tali.asm
@@ -173,7 +173,7 @@ w_digit_question:
 
                 ; Check the character, now in the LSB of NOS.
                 lda 2,x
-                jsr ascii_to_base
+                jsr ascii_to_digit
                 bcs _done               ; failure flag already set
 
                 ; Found a legal number for current base


### PR DESCRIPTION
I needed the ascii>digit code for some srecord words I'm working on, so it made sense to factor out some duplicated code and put it near the inverse byte_to_ascii code.   I also made some improvements to >number so it's a little simpler and runs about twice as fast.