### PR TITLE
fix: simplify execute

### DIFF
--- a/words/core.asm
+++ b/words/core.asm
@@ -2274,15 +2274,12 @@ z_fill:         rts
 
 ; ## EXECUTE ( xt -- ) "Jump to word based on execution token"
 ; ## "execute"  auto  ANS core
+        ; This word is never natively compiled so that the return
+        ; from the xt will always return to the caller of EXECUTE
         ; """https://forth-standard.org/standard/core/EXECUTE"""
 xt_execute:
                 jsr underflow_1
 w_execute:
-                jsr doexecute   ; do not combine to JMP (native coding)
-
-z_execute:      rts
-
-doexecute:
                 lda 0,x
                 sta ip
                 lda 1,x
@@ -2295,7 +2292,7 @@ doexecute:
                 ; the word we're calling to get back to xt_execute
                 jmp (ip)
 
-; end of doexecute
+z_execute:      ; never reached
 
 
 

--- a/words/headers.asm
+++ b/words/headers.asm
@@ -487,7 +487,7 @@ nt_question:
 #nt_header dot, "."
 #nt_header type
 #nt_header emit, "emit", NN
-#nt_header execute
+#nt_header execute, "execute", NN
 #nt_header two, "2"
 #nt_header one, "1"
 #nt_header zero, "0"


### PR DESCRIPTION
As far as I can tell this had an extra level of indirection so that it could be natively compiled.  But given it would be natively compiled as `jsr ...` I didn't see the point of the added complexity.

This saves a few bytes and cycles.