### PR TITLE
Minor print refactor and standardize names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ else
 	PYTHON = python3
 endif
 
-COMMON_SOURCES=taliforth.asm definitions.asm $(wildcard words/*.asm) strings.asm forth_words.asc user_words.asc
+COMMON_SOURCES=taliforth.asm definitions.asm $(wildcard words/*.asm) stringtable.asm forth_words.asc user_words.asc
 TEST_SUITE=tests/core_a.fs tests/core_b.fs tests/core_c.fs tests/string.fs tests/double.fs \
     tests/facility.fs tests/ed.fs tests/asm.fs tests/tali.fs \
     tests/tools.fs tests/block.fs tests/search.fs tests/user.fs tests/cycles.fs

--- a/definitions.asm
+++ b/definitions.asm
@@ -263,7 +263,7 @@ OpBITzp = $24   ; used to save a branch occasionally
 
 N_FLAGS = 8
 
-; This list should match s_see_flags in strings.asm.  See words/headers.asm for details.
+; This list should match s_see_flags in stringtable.asm.  See words/headers.asm for details.
 
 FP = 1                      ; Far previous NT (LSB/MSB not just LSB within previous page)
 LC = 2                      ; Long code (two byte vs one byte length for native compile)

--- a/strings.asm
+++ b/strings.asm
@@ -94,7 +94,7 @@ s_see_cfapfa: .shift "CFA 3  PFA "
 ; must match DICTIONARY FLAGS in definitions.asm and calculated flag order in xt_see
 ; hi-bit (shift) characters indicate flag insertion points, terminated by (shifted) NUL
 see_flags_template:
-        .text "flags: HC", s"N","N", s"A","N", s"I", "M", s"C","O", s"D","C", s"L","C", s"F","P", s"|"," UF", s"S","T", $80
+        .text "flags: HC", s"N","N", s"A","N", s"I","M", s"C","O", s"D","C", s"L","C", s"F","P", s"|"," UF", s"S","T", $80
 
 .if "disassembler" in TALI_OPTIONAL_WORDS
 s_disasm_sdc: .shift " STACK DEPTH CHECK"

--- a/strings.asm
+++ b/strings.asm
@@ -92,7 +92,9 @@ s_see_cfapfa: .shift "CFA 3  PFA "
 
 ; this string is referenced directly, not via string table
 ; must match DICTIONARY FLAGS in definitions.asm and calculated flag order in xt_see
-see_flags_template:     .shift "flags: HC",0,"NN",0,"AN",0,"IM",0,"CO",0,"DC",0,"LC",0,"FP",0,"| UF",0,"ST",0
+; hi-bit (shift) characters indicate flag insertion points, terminated by (shifted) NUL
+see_flags_template:
+        .text "flags: HC", s"N","N", s"A","N", s"I", "M", s"C","O", s"D","C", s"L","C", s"F","P", s"|"," UF", s"S","T", $80
 
 .if "disassembler" in TALI_OPTIONAL_WORDS
 s_disasm_sdc: .shift " STACK DEPTH CHECK"

--- a/stringtable.asm
+++ b/stringtable.asm
@@ -71,7 +71,7 @@ string_table:
 .endif
 
 ; note .shift is like .text but terminates the string by setting bit 7 of the last character
-; print_common in taliforth.asm shows how we use these
+; print_shift_string in taliforth.asm shows how we use these
 
 s_ok:         .shift " ok"              ; note space at beginning
 s_compiled:   .shift " compiled"        ; note space at beginning

--- a/taliforth.asm
+++ b/taliforth.asm
@@ -905,7 +905,7 @@ print_tos:
         ; """basic printing routine used by higher-level constructs,
         ; the equivalent of the forth word  0 <# #s #> type  which is
         ; basically u. without the space at the end. used for various
-        ; outputs
+        ; outputs.   Compare w
         ; """
                 jsr w_zero                     ; 0
                 jsr w_less_number_sign         ; <#

--- a/taliforth.asm
+++ b/taliforth.asm
@@ -51,7 +51,7 @@ user_words_start:
 user_words_end:
 
 .include "words/headers.asm"          ; Headers of native words
-.include "strings.asm"          ; Strings, including error messages
+.include "stringtable.asm"          ; Strings, including error messages
 
 
 ; =====================================================================
@@ -340,7 +340,7 @@ nt_to_nt:
                 ;       cmp #32
                 ;       bcc +
                 ;       lda #str_see_nt
-                ;       jsr print_string_no_lf
+                ;       jsr print_string_n
                 ;       lda #$0a
                 ;       jsr kernel_putc
                 ; -     bra -
@@ -815,14 +815,14 @@ error:
         ; """Given the error number in a, display the error and call abort. Uses tmp3.
         ; """
                 pha                     ; save error
-                jsr print_error
+                jsr print_error_n
                 jsr w_cr
                 pla
                 cmp #err_underflow      ; should we display return stack?
                 bne _no_underflow
 
                 lda #err_returnstack
-                jsr print_error
+                jsr print_error_n
 
                 ; dump return stack from SP...$1FF to help debug source of underflow
                 ; the data stack pointer in X is already corrupted so safe to reuse here
@@ -843,22 +843,22 @@ _no_underflow:
 ; =====================================================================
 ; PRINTING ROUTINES
 
-; print_string_no_lf prints a high-bit terminated string
-; from string_table (see strings.asm) indexed by the accumulator,
+; print_string_n prints a high-bit terminated string from string_table
+; (see stringtable.asm) indexed by the accumulator,
 ; with no trailing line ending.
 
-; print_error does likewise, with A indexing error_table
+; print_error_n does likewise, with A indexing error_table
 
-; print_common provides a lower-level alternative for error
+; print_shift_string provides a lower-level alternative for error
 ; handling and anything else that provides the address of a
 ; high-bit terminated string directly in tmp3. These routines assume that
 ; printing should be more concerned with size than speed, because anything to
 ; do with humans reading text is going to be slow.
 
-print_string_no_lf:
-        ; """Given the number of a zero-terminated string in A, print it to the
+print_string_n:
+        ; """Given the index of a high-bit terminated message in A, print it to the
         ; current output without adding a LF. Uses Y and tmp3 by falling
-        ; through to print_common
+        ; through to print_shift_string
         ; """
                 ; Get the entry from the string table
                 asl
@@ -868,28 +868,26 @@ print_string_no_lf:
                 lda string_table+1,y
                 sta tmp3+1              ; MSB
 
-                ; fall through to print_common
-print_common:
+                ; fall through to print_shift_string
+print_shift_string:
         ; """Common print routine used by both printing routines.
-        ; Assumes tmp3 points to a high-bit terminated string.
+        ; Assumes tmp3 points to a high-bit terminated string of at most 256 characters.
         ; Uses Y.
         ; """
                 ldy #0
 _loop:
                 lda (tmp3),y
-                bpl +                           ; strings are high-bit terminated
-
-                and #$7f                        ; last character, clear high bit
-                ldy #$ff                        ; flag end of loop
-+
+                php                             ; save the sign bit (terminator) status
+                and #$7f                        ; ensure high bit is clear
                 jsr emit_a                      ; allows vectoring via output
                 iny
-                bne _loop
+                plp                             ; was this the last character?
+                bpl _loop
 
                 rts
 
 
-print_error:
+print_error_n:
         ; """Given the error number in a, print the associated error string. Uses tmp3.
         ; """
                 asl
@@ -900,10 +898,10 @@ print_error:
                 lda error_table,y
                 sta tmp3+1                      ; MSB
 
-                bra print_common
+                bra print_shift_string
 
 
-print_u:
+print_tos:
         ; """basic printing routine used by higher-level constructs,
         ; the equivalent of the forth word  0 <# #s #> type  which is
         ; basically u. without the space at the end. used for various

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -3552,12 +3552,12 @@ here 5       ' blank         cycle_test            CYCLES:    327 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  20240 ok
+             ' :             cycle_test wrd ;      CYCLES:  20238 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:    101 ok
 ' aword      ' compile,      cycle_test            CYCLES:    947 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     69 ok
-5            ' constant      cycle_test mycnst     CYCLES:  20996 ok
+5            ' constant      cycle_test mycnst     CYCLES:  20995 ok
 here         ' count         cycle_test 2drop      CYCLES:     59 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3606,7 +3606,7 @@ nc-limit !  ok
 5 5          ' =             cycle_test drop       CYCLES:     64 ok
 here 5       ' erase         cycle_test            CYCLES:    325 ok
 here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  21341 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  21345 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     84 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3641,7 +3641,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:   1310 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    407 ok
-             ' marker        cycle_test marka      CYCLES:  23460 ok
+             ' marker        cycle_test marka      CYCLES:  23458 ok
              ' marka         cycle_test            CYCLES:    781 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
@@ -3725,10 +3725,10 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  22265 ok
+             ' 2variable     cycle_test eword      CYCLES:  22263 ok
              ' eword         cycle_test drop       CYCLES:     45 ok
 s" *"        ' type          cycle_test           *CYCLES:    123 ok
-5            ' u.            cycle_test          5 CYCLES:   1168 ok
+5            ' u.            cycle_test          5 CYCLES:   1180 ok
 5 5          ' u>            cycle_test drop       CYCLES:     60 ok
 5 5          ' u<            cycle_test drop       CYCLES:     60 ok
              ' strip-underflow   cycle_test drop   CYCLES:     40 ok
@@ -3736,10 +3736,10 @@ s" *"        ' type          cycle_test           *CYCLES:    123 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    331 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  22384 ok
+5            ' value         cycle_test fword      CYCLES:  22382 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
 5            ' to            cycle_test fword      CYCLES:   1224 ok
-             ' variable      cycle_test gword      CYCLES:  22251 ok
+             ' variable      cycle_test gword      CYCLES:  22249 ok
              ' gword         cycle_test drop       CYCLES:     45 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    620 ok
 \ skipping     words  ok
@@ -3752,4 +3752,4 @@ char "       ' word          cycle_test "txt" drop CYCLES:    620 ok
 5            ' 0<            cycle_test drop       CYCLES:     47 ok
 5            ' 0<>           cycle_test drop       CYCLES:     48 ok
   ok
-bye c65: PC=f016 A=98 X=78 Y=98 S=f6 FLAGS=<N0 V0 B0 D0 I1 Z0 C1> ticks=176305038
+bye c65: PC=f016 A=98 X=78 Y=98 S=f6 FLAGS=<N0 V0 B1 D0 I1 Z0 C1> ticks=176357259

--- a/words/all.asm
+++ b/words/all.asm
@@ -212,7 +212,7 @@ _stack_ok:
 
                 lda #1                  ; number for "compile" string
 _print:
-                jsr print_string_no_lf
+                jsr print_string_n
                 jsr w_cr
 
                 ; Awesome line, everybody! Now get the next one.

--- a/words/core.asm
+++ b/words/core.asm
@@ -618,11 +618,11 @@ w_at_xy:
                 lda #'['
                 jsr emit_a
                 jsr w_one_plus ; AT-XY is zero based, but ANSI is 1 based
-                jsr print_u
+                jsr print_tos
                 lda #';'
                 jsr emit_a
                 jsr w_one_plus ; AT-XY is zero based, but ANSI is 1 based
-                jsr print_u
+                jsr print_tos
                 lda #'H'
                 jsr emit_a
 
@@ -1182,7 +1182,7 @@ _too_long:
 _redefined_name:
                 ; Print the message that the name is redefined.
                 lda #str_redefined
-                jsr print_string_no_lf
+                jsr print_string_n
 
                 jsr w_two_dup           ; ( cfa addr u addr u )
                 jsr w_type
@@ -2103,7 +2103,7 @@ z_environment_q:
 
 ; Tables for ENVIRONMENT?. We use two separate ones, one for the single-cell
 ; results and one for the double-celled results. The strings themselves
-; are defined consecutively in strings.asm so that we can calculate
+; are defined consecutively in stringtable.asm so that we can calculate
 ; length as the difference in offsets.
 
 env_table_single:
@@ -5309,7 +5309,7 @@ _setsz:
                 jsr w_name_to_string    ; ( nt -- addr u )
 
                 lda #str_redefined      ; address of string "redefined"
-                jsr print_string_no_lf
+                jsr print_string_n
 
                 ; Now we print the offending word.
                 jsr w_type
@@ -6693,13 +6693,13 @@ z_type:         rts
         ; """https://forth-standard.org/standard/core/Ud
         ;
         ; This is : U. 0 <# #S #> TYPE SPACE ; in Forth
-        ; We use the internal assembler function print_u followed
+        ; We use the internal assembler function print_tos followed
         ; by a single space
         ; """
 xt_u_dot:
                 jsr underflow_1
 w_u_dot:
-                jsr print_u
+                jsr print_tos
                 lda #AscSP
                 jsr emit_a
 

--- a/words/core.asm
+++ b/words/core.asm
@@ -6700,8 +6700,7 @@ xt_u_dot:
                 jsr underflow_1
 w_u_dot:
                 jsr print_tos
-                lda #AscSP
-                jsr emit_a
+                jsr w_space
 
 z_u_dot:        rts
 

--- a/words/disasm.asm
+++ b/words/disasm.asm
@@ -314,7 +314,7 @@ _found_handler:
                 jsr emit_a                  ; print the char stored as (ch - 32) << 2
 _no_prefix:
                 lda _special_handlers+2,y   ; string index
-                jsr print_string_no_lf
+                jsr print_string_n
                 pla
                 and #3                      ; payload is 0, 1 or 2 words
                 beq _done

--- a/words/tools.asm
+++ b/words/tools.asm
@@ -43,7 +43,7 @@ w_dot_s:
                 sta 0,x
                 stz 1,x
 
-                jsr print_u
+                jsr print_tos
 
                 lda #'>'
                 jsr emit_a
@@ -252,7 +252,7 @@ w_see:
                 jsr w_hex
 
                 lda #str_see_nt
-                jsr print_string_no_lf
+                jsr print_string_n
 
                 jsr w_dup               ; ( nt nt )
                 jsr w_u_dot
@@ -262,14 +262,14 @@ w_see:
                 jsr w_name_to_int       ; ( nt xt )
 
                 lda #str_see_xt
-                jsr print_string_no_lf
+                jsr print_string_n
 
                 jsr w_dup               ; ( nt xt xt )
                 jsr w_u_dot             ; ( nt xt )
                 jsr w_space
 
                 lda #str_see_header
-                jsr print_string_no_lf
+                jsr print_string_n
                 jsr w_over
                 ; calculate header length from status flag byte
                 lda (0,x)               ; fetch status byte
@@ -368,7 +368,7 @@ _done:
 
                 ; Figure out the size
                 lda #str_see_size
-                jsr print_string_no_lf
+                jsr print_string_n
 
                 jsr w_swap              ; ( xt nt )
                 jsr w_wordsize          ; ( xt u )
@@ -382,7 +382,7 @@ _done:
                 beq +
 
                 lda #str_see_cfapfa
-                jsr print_string_no_lf  ; print "CFA: 3  PFA: "
+                jsr print_string_n  ; print "CFA: 3  PFA: "
 
                 sec
                 lda 0,x                 ; reduce to u-3

--- a/words/tools.asm
+++ b/words/tools.asm
@@ -321,8 +321,8 @@ _show_header:
                 bra -
 +
 .endif
-                ; use a high-bit terminated template string to show flag names
-                ; and insert flag values at placeholders marked by ascii zeros
+                ; use a zero-terminated template string to show flag names with placeholders
+                ; marked by shifted characters
                 lda #<see_flags_template
                 sta tmp3                ; LSB
                 lda #>see_flags_template
@@ -331,12 +331,11 @@ _show_header:
                 ldy #0                  ; index the string
 _show_flags:
                 lda (tmp3),y            ; next char in template
-                bpl +                   ; end of string?
+                bpl _emit               ; normal char?  just show it
 
-                ldy #$ff                ; flag end of loop
-                and #$7f                ; clear high bit of A to get last character
-+
-                bne _emit               ; flag placeholder?
+                ; otherwise insert a flag first
+                and #$7f                ; clear hi bit and save next char
+                pha
 
                 ; for each flag, print "<space><flag><space>"
                 jsr w_space             ; no stack effect
@@ -351,13 +350,16 @@ _synthetic:
                 lda #'0'                ; convert C=0/1 into '0' or '1'
                 adc #0
                 jsr emit_a              ; write the flag digit
+                jsr w_space             ; and a space
 
-                lda #' '                ; fall through and add trailing space
+                pla                     ; recover next character
+                beq _done
 _emit:
                 jsr emit_a
 
                 iny
                 bne _show_flags
+_done:
 
                 jsr w_cr
 

--- a/words/tools.asm
+++ b/words/tools.asm
@@ -334,7 +334,7 @@ _show_flags:
                 bpl _emit               ; normal char?  just show it
 
                 ; otherwise insert a flag first
-                and #$7f                ; clear hi bit and save next char
+                and #$7f                ; clear hi bit and save char that follows flag
                 pha
 
                 ; for each flag, print "<space><flag><space>"
@@ -352,7 +352,7 @@ _synthetic:
                 jsr emit_a              ; write the flag digit
                 jsr w_space             ; and a space
 
-                pla                     ; recover next character
+                pla                     ; recover following character
                 beq _done
 _emit:
                 jsr emit_a

--- a/words/tools.asm
+++ b/words/tools.asm
@@ -38,17 +38,13 @@ w_dot_s:
                 pha
 
                 ; print unsigned number without the trailing space
-                dex             ; DUP
-                dex
-                sta 0,x
-                stz 1,x
+                jsr w_dup
 
                 jsr print_tos
 
                 lda #'>'
                 jsr emit_a
-                lda #AscSP      ; ASCII for SPACE
-                jsr emit_a
+                jsr w_space
 
                 inx
                 inx

--- a/words/wordlist.asm
+++ b/words/wordlist.asm
@@ -225,9 +225,9 @@ order_print_wid_string:
         ; corresponding string. If there is no such word list defined, just
         ; print the number. Assumes we will not have more than 256 WIDs; also
         ; assumes we have just loaded A so Z reflects status of byte.  In
-        ; theory, we could speed this up by having the WID be the same as the
-        ; number of the strings. However, ORDER is used rather infrequently and
-        ; this would make changes to the strings.asm file very dangerous, so we
+        ; theory, we could speed this up by having the WID be the same as
+        ; string table index. However, ORDER is used rather infrequently and
+        ; this would make changes to the stringtable.asm file very dangerous, so we
         ; follow the slightly more complicated route with a translation table.
         ; """
                 ; If the WID is larger than 3, we have no string avaliable and
@@ -239,10 +239,7 @@ order_print_wid_string:
 
                 ; Our WID is not less than 4, that is, 4 or larger. We just
                 ; print the number
-                dex
-                dex
-                sta 0,x
-                stz 1,x
+                jsr push_a_tos
                 jmp w_u_dot            ; JSR/RTS as this routine is not compiled
 
 _output_string:
@@ -251,11 +248,10 @@ _output_string:
                 lda _wid_data,y
 
                 ; Print without a line feed
-                jmp print_string_no_lf  ; JSR/RTS as this routine is not compiled
+                jmp print_string_n  ; JSR/RTS as this routine is not compiled
 
 _wid_data:
-        ; Table of string numbers (see strings.asm) indexed by the WID if
-        ; less than 4.
+        ; Table of string numbers for word list names 0-3 (see stringtable.asm)
         .byte str_wid_forth            ; WID 0: "Forth "
         .byte str_wid_editor           ; WID 1: "Editor "
         .byte str_wid_assembler        ; WID 2: "Assembler "


### PR DESCRIPTION
Coming back to the code after a while, there are a couple of things that might make sense to tidy a bit.

The print routine naming has always been a bit confusing to me, as is the similarity of the ./strings.asm and words/string.asm file names.  

This PR suggests renaming strings.asm => stringtable.asm, and using `print_[error|string]_n` as the names of the routines that print indexed strings from the table.  I also made a couple of tiny tweaks to save a few bytes in a couple of the actual printing routines.   Tests still look good.
