### PR TITLE
fix: use bpl consistently in underflow comparison, noting alternative bcs option

### DIFF
--- a/definitions.asm
+++ b/definitions.asm
@@ -8,6 +8,26 @@
 ; definitions; platform-specific definitions such as the
 ; memory map are kept in the platform folder.
 
+
+; ZERO PAGE ADDRESSES/VARIABLES
+
+; By default TaliForth reserves the first half of zero page ($0 - zpage_end, inclusive).
+; The top half of zero page is free for kernel/external use (zpage_end+1 to $FF).
+
+; The default TaliForth zero page usage is as follows:
+;   zero page variables: 28 words = 56 bytes ($0000-$0037) - see cold_zp_table
+;   Forth Data Stack: 128 - 56 - 8 = 64 bytes or 32 words ($0038-$0077)
+;   Data Stack floodplain: 8 bytes after stack to protect against underflow ($0078-$007F)
+
+; The maximum size of Tali's data stack is 128 bytes (64 words), after which wraparound
+; underflow checks will trigger (see underflow_error in words/all.asm).
+; An alternate configuration with a maximal stack and no underflow protection
+; might start the data stack at the top of zero page, growing down towards $80:
+;   zpage_end = $ff
+;   dsp0 = $0       ; zpage_end+1, wrapping around
+; Any external variables would then be stored between the end of cold_zp_table and $80
+
+
 ; HARD PHYSICAL ADDRESSES
 
 ; Some of these are somewhat silly for the 65c02, where for example
@@ -15,15 +35,17 @@
 ; these for easier comparisons with Liara Forth's structure and to
 ; help people new to these things.
 
-ram_start = $0000          ; start of installed RAM, must include zpage
-zpage     = ram_start      ; begin of Zero Page ($0000-$00ff)
-stack0    = $0100          ; begin of Return Stack ($0100-$01ff)
+ram_start = $0000           ; start of installed RAM, must include zpage
+zpage     = ram_start       ; begin of Zero Page usage ($0000-$00ff)
+stack0    = $0100           ; begin of Return Stack ($0100-$01ff)
 
-; weak constants can be overridden by the including platform configuration
+; weak constants can be overridden by the included platform configuration
+
 .weak
-zpage_end = $7F            ; end of Zero Page used ($0000-$007f)
-ram_end   = $8000-1        ; end of installed RAM
-hist_buff = ram_end-$03ff  ; begin of history buffers
+zpage_end = $7F             ; last byte (inclusive) of Zero Page reserved for Tali ($0000-$007f)
+                            ; typically Tali's data stack grows down from here, below a small flood plain
+ram_end   = $8000-1         ; end of installed RAM
+hist_buff = ram_end-$03ff   ; begin of history buffers
 .endweak
 
 ; SOFT PHYSICAL ADDRESSES
@@ -35,38 +57,33 @@ hist_buff = ram_end-$03ff  ; begin of history buffers
 ; the page boundry when accessing the RAM System Variables table, which would
 ; cost an extra cycle.
 
-rsp0      = $ff              ; initial Return Stack Pointer (65c02 stack)
-bsize     = $ff              ; size of input/output buffers
+rsp0      = $ff             ; initial Return Stack Pointer (65c02 stack)
+bsize     = $ff             ; size of input/output buffers
 
 .weak
-user0     = zpage            ; TaliForth2 system variables
-buffer0   = stack0+$100      ; input buffer ($0200-$02ff)
-cp0       = buffer0+bsize+1  ; Dictionary starts after last buffer
-                             ; The RAM System Variables and BLOCK buffer are
-                             ; placed right at the beginning of the dictionary.
+user0     = zpage           ; start of TaliForth2 system variables
+buffer0   = stack0+$100     ; input buffer ($0200-$02ff)
+cp0       = buffer0+bsize+1 ; Dictionary starts after last buffer
+                            ; The RAM System Variables and BLOCK buffer are
+                            ; placed right at the beginning of the dictionary.
 .if TALI_OPTION_HISTORY
-cp_end    = hist_buff        ; Last RAM byte available for code
+cp_end    = hist_buff       ; Last RAM byte available for code
 .else
 cp_end    = ram_end
 .endif
-padoffset = $ff              ; offset from CP to PAD (holds number strings)
 
-dsp0      = zpage_end-7      ; initial Data Stack Pointer
+padoffset = $ff             ; offset from CP to PAD (holds number strings)
+
+dsp0      = zpage_end-7     ; initial Data Stack Pointer, used to initialize the X register.
+                            ; The DSP points to the first valid stack entry so points at
+                            ; the first unused byte beyond the data stack when the stack is empty.
+                            ; We subtract seven to leave an eight byte (four word) buffer or "flood plain"
+                            ; between the top of the data stack and unreserved zero page memory which
+                            ; stops small stack underflows from stomping non-Tali memory.
+
 .endweak
 
-
-; ZERO PAGE ADDRESSES/VARIABLES
-
-; TaliForth reserves the first part of zero page ($0 - zpage_end) which is
-; configured by zpage_end and normally 128 bytes.
-; The rest of zero page is free for kernel/external use (zpage_end+1 to $FF)
-
-; TaliForth zeropage usage is as follows:
-;   zero page variables: 30 words = 60 bytes ($0000-$0038) - see cold_zp_table
-;   Forth Data Stack: 128 - 60 - 8 = 60 bytes or 30 words
-;   Data Stack floodplain: 8 bytes after stack (to avoid catastrophic underflow)
-
-; This table defines all of the zero page variables along with their initial
+; The cold_zp_table table defines all of the zero page variables along with their initial
 ; values except the uninitialized temporaries at the end. The most important
 ; variables are defined first since the Data Stack grows towards this area
 ; from dsp0: If there is an overflow, the later, less important variables

--- a/definitions.asm
+++ b/definitions.asm
@@ -51,7 +51,7 @@ cp_end    = ram_end
 .endif
 padoffset = $ff              ; offset from CP to PAD (holds number strings)
 
-dsp0      = zpage_end-7    ; initial Data Stack Pointer
+dsp0      = zpage_end-7      ; initial Data Stack Pointer
 .endweak
 
 

--- a/taliforth.asm
+++ b/taliforth.asm
@@ -783,63 +783,6 @@ _done:
                 rts
 
 
-; Underflow tests. We jump to the label with the number of cells (not: bytes)
-; required for the word. This routine flows into the generic error handling
-; code
-underflow_1:
-        ; """Make sure we have at least one cell on the Data Stack"""
-                cpx #dsp0-1
-                bcs underflow_error
-                rts
-underflow_2:
-        ; """Make sure we have at least two cells on the Data Stack"""
-                cpx #dsp0-3
-                bcs underflow_error
-                rts
-underflow_3:
-        ; """Make sure we have at least three cells on the Data Stack"""
-                cpx #dsp0-5
-                bcs underflow_error
-                rts
-underflow_4:
-        ; """Make sure we have at least four cells on the Data Stack"""
-                cpx #dsp0-7
-                bcs underflow_error
-                rts
-
-underflow_error:
-                ; Entry for COLD/ABORT/QUIT
-                lda #err_underflow      ; fall through to error
-
-error:
-        ; """Given the error number in a, display the error and call abort. Uses tmp3.
-        ; """
-                pha                     ; save error
-                jsr print_error_n
-                jsr w_cr
-                pla
-                cmp #err_underflow      ; should we display return stack?
-                bne _no_underflow
-
-                lda #err_returnstack
-                jsr print_error_n
-
-                ; dump return stack from SP...$1FF to help debug source of underflow
-                ; the data stack pointer in X is already corrupted so safe to reuse here
-                tsx
--
-                inx
-                beq +
-                jsr w_space
-                lda $100,x
-                jsr byte_to_ascii
-                bra -
-+
-                jsr w_cr
-
-_no_underflow:
-                jmp w_abort            ; no jsr, as we clobber return stack
-
 ; =====================================================================
 ; PRINTING ROUTINES
 

--- a/taliforth.asm
+++ b/taliforth.asm
@@ -789,22 +789,22 @@ _done:
 underflow_1:
         ; """Make sure we have at least one cell on the Data Stack"""
                 cpx #dsp0-1
-                bpl underflow_error
+                bcs underflow_error
                 rts
 underflow_2:
         ; """Make sure we have at least two cells on the Data Stack"""
                 cpx #dsp0-3
-                bpl underflow_error
+                bcs underflow_error
                 rts
 underflow_3:
         ; """Make sure we have at least three cells on the Data Stack"""
                 cpx #dsp0-5
-                bpl underflow_error
+                bcs underflow_error
                 rts
 underflow_4:
         ; """Make sure we have at least four cells on the Data Stack"""
                 cpx #dsp0-7
-                bpl underflow_error
+                bcs underflow_error
                 rts
 
 underflow_error:

--- a/tests/tester.fs
+++ b/tests/tester.fs
@@ -86,7 +86,7 @@ create actual-results  20 cells allot
 \ helper words to capture output to a buffer
 
 output @ constant 'emit-a
-$fe constant 'bufp
+$7e constant 'bufp      \ zp pointer in the stack floodplain
 
 \ assembly routine to capture output to pointer at 'bufp
 \ sta (bufp) / inc bufp / bne +2 / inc bufp+1 / rts

--- a/words/all.asm
+++ b/words/all.asm
@@ -195,8 +195,9 @@ _success:
                 ; Main compile/execute routine
                 jsr interpret
 
-                ; Test for Data Stack underflow. Tali Forth does not check for
-                ; overflow because it is so rare
+                ; Test for Data Stack underflow. Tali Forth doesn't explicitly check for
+                ; overflow because it is so rare but the `bpl` test will trigger a
+                ; wraparound "underflow" error if the stack exceeds 64 words.
                 cpx #dsp0+1
                 bpl underflow_error      ; DSP must always be smaller than DSP0
 

--- a/words/all.asm
+++ b/words/all.asm
@@ -197,13 +197,9 @@ _success:
 
                 ; Test for Data Stack underflow. Tali Forth does not check for
                 ; overflow because it is so rare
-                cpx #dsp0
-                beq _stack_ok
-                bcc _stack_ok           ; DSP must always be smaller than DSP0
+                cpx #dsp0+1
+                bpl underflow_error      ; DSP must always be smaller than DSP0
 
-                jmp underflow_error
-
-_stack_ok:
                 ; Display system prompt if all went well. If we're interpreting,
                 ; this is " ok", if we're compiling, it's " compiled". Note
                 ; space at beginning of the string.
@@ -221,6 +217,64 @@ _print:
 z_cold:
 z_abort:
 z_quit:         ; no RTS required
+
+
+underflow_error:
+                ; Entry for COLD/ABORT/QUIT
+                lda #err_underflow      ; fall through to error
+
+error:
+        ; """Given the error number in a, display the error and call abort. Uses tmp3.
+        ; """
+                pha                     ; save error
+                jsr print_error_n
+                jsr w_cr
+                pla
+                cmp #err_underflow      ; should we display return stack?
+                bne w_abort
+
+                lda #err_returnstack
+                jsr print_error_n
+
+                ; dump return stack from SP...$1FF to help debug source of underflow
+                ; the data stack pointer in X is already corrupted so safe to reuse here
+                tsx
+-
+                inx
+                beq +
+                jsr w_space
+                lda $100,x
+                jsr byte_to_ascii
+                bra -
++
+                jsr w_cr
+
+                bra w_abort            ; no jsr, as we clobber return stack
+
+
+; Underflow tests. We jump to the label with the number of cells (not: bytes)
+; required for the word. This routine flows into the generic error handling
+; code
+underflow_1:
+        ; """Make sure we have at least one cell on the Data Stack"""
+                cpx #+dsp0-1
+                bpl underflow_error
+                rts
+underflow_2:
+        ; """Make sure we have at least two cells on the Data Stack"""
+                cpx #+dsp0-3
+                bpl underflow_error
+                rts
+underflow_3:
+        ; """Make sure we have at least three cells on the Data Stack"""
+                cpx #+dsp0-5
+                bpl underflow_error
+                rts
+underflow_4:
+        ; """Make sure we have at least four cells on the Data Stack"""
+                cpx #+dsp0-7
+                bpl underflow_error
+                rts
 
 
 .include "core.asm"

--- a/words/all.asm
+++ b/words/all.asm
@@ -255,6 +255,11 @@ error:
 ; Underflow tests. We jump to the label with the number of cells (not: bytes)
 ; required for the word. This routine flows into the generic error handling
 ; code
+; Note that using bpl will also generate an error if the stack is more than 64 items (128 bytes)
+; beyond the comparison point (effectively an overflow).
+; An alternative is to switch bpl to bcs everywhere which allows a slightly larger stack.
+; However in that case dsp0 must be at most $f0 or these tests will fail in unexpected ways.
+; See discussion in https://github.com/SamCoVT/TaliForth2/issues/148
 underflow_1:
         ; """Make sure we have at least one cell on the Data Stack"""
                 cpx #+dsp0-1

--- a/words/tools.asm
+++ b/words/tools.asm
@@ -59,7 +59,7 @@ w_dot_s:
                 ; from bottom to top
                 ply
 
-                lda #dsp0-1     ; go up one to avoid garbage
+                lda #+dsp0-1     ; go up one to avoid garbage
                 sta tmp3
                 stz tmp3+1      ; must be zero page on the 65c02
 _loop:


### PR DESCRIPTION
this addresses #148 - see discussion there for alternative option.