### PR TITLE
add user interrupt support

### DIFF
--- a/platform/README.md
+++ b/platform/README.md
@@ -234,7 +234,6 @@ interrupt running code and return to the prompt. For example, the 6502's
 NMI input could be used with a simple push-button that vectors to code that
 jumps to `error` as described above.
 
-
 ## Contributing
 
 To submit your configuration file, pick a name with the form `platform-*.asm`

--- a/platform/README.md
+++ b/platform/README.md
@@ -209,6 +209,29 @@ so that any subequent call to KEY would block until a key is actually ready.
 Your platform configuration should define the 6502 NMI, Reset and IRQ vectors
 at $fffa-$ffff.  Typically at least Reset ($fffc) should point to `kernel_init`.
 
+### Supporting User Interrupt (e.g. Ctrl-C to break)
+
+If your platform has support for hardware interrupts, you can easily
+support the ability for a user to stop running (runaway?) code and return to
+the input prompt.
+
+For platforms that have an interrupt-driven serial console, this can be
+implemented by checking to see if an input character read in the interrupt
+service routine is the "break" key (e.g. Ctrl-C). If so, instead of
+buffering the input character and returning from the interrupt, remove
+the return address and the program status word from the stack, set A to the
+error code `err_usersigint` (see `stringtable.asm`) and jump to Taliforth's
+`error` re-entry point. The "user interrupt" error message will be displayed
+and Taliforth will await the next input from the user. You may also wish to
+flush the input buffer before jumping to `error`.
+
+Any other mechanism that can respond to a hardware input via an interrupt
+service routine could be used in a similar manner to allow a user to
+interrupt running code and return to the prompt. For example, the 6502's
+NMI input could be used with a simple push-button that vectors to code that
+cleans up the stack and jumps to `error` as described above.
+
+
 ## Contributing
 
 To submit your configuration file, pick a name with the form `platform-*.asm`

--- a/platform/README.md
+++ b/platform/README.md
@@ -218,18 +218,21 @@ the input prompt.
 For platforms that have an interrupt-driven serial console, this can be
 implemented by checking to see if an input character read in the interrupt
 service routine is the "break" key (e.g. Ctrl-C). If so, instead of
-buffering the input character and returning from the interrupt, remove
-the return address and the program status word from the stack, set A to the
+buffering the input character and returning from the interrupt, set A to
 error code `err_usersigint` (see `stringtable.asm`) and jump to Taliforth's
-`error` re-entry point. The "user interrupt" error message will be displayed
-and Taliforth will await the next input from the user. You may also wish to
-flush the input buffer before jumping to `error`.
+`error` entry point. After printing the "User interrupt" message, Taliforth
+will jump to `ABORT` which resets the Forth data stack and the return stack.
+
+Before jumping to `error` you should re-enable interrupts (since no RTI
+instruction will be executed), and flush your input buffer so that characters
+buffered before the break key was detected will not be processed as new
+input when Taliforth next awaits user input.
 
 Any other mechanism that can respond to a hardware input via an interrupt
 service routine could be used in a similar manner to allow a user to
 interrupt running code and return to the prompt. For example, the 6502's
 NMI input could be used with a simple push-button that vectors to code that
-cleans up the stack and jumps to `error` as described above.
+jumps to `error` as described above.
 
 
 ## Contributing

--- a/stringtable.asm
+++ b/stringtable.asm
@@ -125,12 +125,13 @@ err_wordlist     = 11
 err_blockwords   = 12
 err_returnstack  = 13
 err_toolong      = 14
+err_usersigint   = 15
 
 error_table:
-        .word es_allot, es_badsource, es_compileonly, es_defer  ;  0-3
-        .word es_divzero, es_noname, es_refill, es_state        ;  4-7
-        .word es_syntax, es_underflow, es_negallot, es_wordlist ;  8-11
-        .word es_blockwords, es_returnstack, es_toolong         ; 12-14
+        .word es_allot, es_badsource, es_compileonly, es_defer          ;  0-3
+        .word es_divzero, es_noname, es_refill, es_state                ;  4-7
+        .word es_syntax, es_underflow, es_negallot, es_wordlist         ;  8-11
+        .word es_blockwords, es_returnstack, es_toolong, es_usersigint  ; 12-15
 
 .if ! TALI_OPTION_TERSE
 es_allot:       .shift "ALLOT using all available memory"
@@ -148,6 +149,7 @@ es_wordlist:    .shift "No wordlists available"
 es_blockwords:  .shift "Please assign vectors BLOCK-READ-VECTOR and BLOCK-WRITE-VECTOR"
 es_returnstack: .shift "Return stack:"
 es_toolong:     .shift "Name too long (max 31)"
+es_usersigint:  .shift "User interrupt"
 .else
 es_allot:       .shift "EALLT"
 es_badsource:   .shift "EBSRC"
@@ -164,6 +166,7 @@ es_wordlist:    .shift "EWLST"
 es_blockwords:  .shift "EBLKW"
 es_returnstack: .shift "RS"
 es_toolong:     .shift "E2LNG"
+es_usersigint:  .shift "EINTR"
 .endif
 
 


### PR DESCRIPTION
This PR simply adds an error code and corresponding strings to allow the `error` entry point to be used by an interrupt service routine to implement break key functionality. Additionally, some details of the approach are documented in `platform/README.md` for others who want similar functionality on their preferred platform.
 