### PR TITLE
Assembler produces off-by-two branch displacement

### DIFF
--- a/platform/README.md
+++ b/platform/README.md
@@ -209,6 +209,29 @@ so that any subequent call to KEY would block until a key is actually ready.
 Your platform configuration should define the 6502 NMI, Reset and IRQ vectors
 at $fffa-$ffff.  Typically at least Reset ($fffc) should point to `kernel_init`.
 
+### Supporting User Interrupt (e.g. Ctrl-C to break)
+
+If your platform has support for hardware interrupts, you can easily
+support the ability for a user to stop running (runaway?) code and return to
+the input prompt.
+
+For platforms that have an interrupt-driven serial console, this can be
+implemented by checking to see if an input character read in the interrupt
+service routine is the "break" key (e.g. Ctrl-C). If so, instead of
+buffering the input character and returning from the interrupt, remove
+the return address and the program status word from the stack, set A to the
+error code `err_usersigint` (see `stringtable.asm`) and jump to Taliforth's
+`error` re-entry point. The "user interrupt" error message will be displayed
+and Taliforth will await the next input from the user. You may also wish to
+flush the input buffer before jumping to `error`.
+
+Any other mechanism that can respond to a hardware input via an interrupt
+service routine could be used in a similar manner to allow a user to
+interrupt running code and return to the prompt. For example, the 6502's
+NMI input could be used with a simple push-button that vectors to code that
+cleans up the stack and jumps to `error` as described above.
+
+
 ## Contributing
 
 To submit your configuration file, pick a name with the form `platform-*.asm`

--- a/stringtable.asm
+++ b/stringtable.asm
@@ -125,12 +125,13 @@ err_wordlist     = 11
 err_blockwords   = 12
 err_returnstack  = 13
 err_toolong      = 14
+err_usersigint   = 15
 
 error_table:
-        .word es_allot, es_badsource, es_compileonly, es_defer  ;  0-3
-        .word es_divzero, es_noname, es_refill, es_state        ;  4-7
-        .word es_syntax, es_underflow, es_negallot, es_wordlist ;  8-11
-        .word es_blockwords, es_returnstack, es_toolong         ; 12-14
+        .word es_allot, es_badsource, es_compileonly, es_defer          ;  0-3
+        .word es_divzero, es_noname, es_refill, es_state                ;  4-7
+        .word es_syntax, es_underflow, es_negallot, es_wordlist         ;  8-11
+        .word es_blockwords, es_returnstack, es_toolong, es_usersigint  ; 12-15
 
 .if ! TALI_OPTION_TERSE
 es_allot:       .shift "ALLOT using all available memory"
@@ -148,6 +149,7 @@ es_wordlist:    .shift "No wordlists available"
 es_blockwords:  .shift "Please assign vectors BLOCK-READ-VECTOR and BLOCK-WRITE-VECTOR"
 es_returnstack: .shift "Return stack:"
 es_toolong:     .shift "Name too long (max 31)"
+es_usersigint:  .shift "User interrupt"
 .else
 es_allot:       .shift "EALLT"
 es_badsource:   .shift "EBSRC"
@@ -164,6 +166,7 @@ es_wordlist:    .shift "EWLST"
 es_blockwords:  .shift "EBLKW"
 es_returnstack: .shift "RS"
 es_toolong:     .shift "E2LNG"
+es_usersigint:  .shift "EINTR"
 .endif
 
 

--- a/words/assembler.asm
+++ b/words/assembler.asm
@@ -235,6 +235,7 @@ xt_asm_back_branch:
                 ; We subtract two more because of the branch instruction itself
                 dea
                 dea
+                sta 0,x
 
 z_asm_back_branch:
                 rts


### PR DESCRIPTION
Below is a very simple assembly routine that counts down using the Y register.
```
: branch-bug  ( n -- )
    [
        0 ldy.zx
    -->
        dey
        <b bne
        inx
        inx
    ]
    ;
previous
```

Using latest `master-64tass`, the routine assembles as follows.

```
nt: 800  xt: 80F  header: 01 0A 65 C0 07
flags: HC 0 NN 0 AN 0 IM 0 CO 0 DC 0 LC 0 FP 1 | UF 0 ST 0
size (decimal): 7

080F  B4 00 88 D0 FF E8 E8                              .......

80F      0 ldy.zx
811        dey
812     FF bne      813 ^
814        inx
815        inx
```

Note that the displacement here is $ff (-1). Given that PC will be $814 when this displacement is added, the effective address for the branch is the second byte of the `bne` instruction itself at $813. Whoops. The correct displacement is $fd (-3) = $814 - 3 = $811. I'm guessing that maybe the `<b` pseudo-instruction isn't accounting for the size of the `BNE` instruction itself.

Looking at the listing output for `assembler.asm`, it seems the code is attempting to account for the size of the branch instruction, but it neglects put the result of the two decrement instructions onto the data stack with `sta 0,x` before returning.

```
xt_asm_back_branch:
                ; We arrive here with ( addr-l ) of the label on the stack and
                ; then subtract the current address
                jsr w_here             ; ( addr-l addr-h )
                jsr w_minus            ; ( offset )

                ; We subtract two more because of the branch instruction itself
                dea
                dea
                
z_asm_back_branch:
                rts
```

The attached PR adds an instruction to save the resulting displacement at TOS.