### PR TITLE
assembler produces off-by-two branch displacement

### DIFF
--- a/tests/asm.fs
+++ b/tests/asm.fs
@@ -68,7 +68,7 @@ T{ capture-output see cword restore-output s"  NN 1 " search -rot 2drop -> true 
 \ Testing pseudo-instructions
 T{ here  0a lda.# push-a rts  execute -> 0a }T
 
-\ Testing --> <B for correct displacment
+\ Testing <B for correct displacement
 T{ here 2 lda.# --> dec.a <B bne push-a rts execute -> 0 }T
 
 \ Testing a two-byte instruction for correct operand handling

--- a/tests/asm.fs
+++ b/tests/asm.fs
@@ -68,6 +68,9 @@ T{ capture-output see cword restore-output s"  NN 1 " search -rot 2drop -> true 
 \ Testing pseudo-instructions
 T{ here  0a lda.# push-a rts  execute -> 0a }T
 
+\ Testing --> <B for correct displacment
+T{ here 2 lda.# --> dec.a <B bne push-a rts execute -> 0 }T
+
 \ Testing a two-byte instruction for correct operand handling
 T{ 12 s" 12 lda.#" correct-operand? -> true }T
 

--- a/words/assembler.asm
+++ b/words/assembler.asm
@@ -235,6 +235,7 @@ xt_asm_back_branch:
                 ; We subtract two more because of the branch instruction itself
                 dea
                 dea
+                sta 0,x
 
 z_asm_back_branch:
                 rts

--- a/words/assembler.asm
+++ b/words/assembler.asm
@@ -233,9 +233,8 @@ xt_asm_back_branch:
                 jsr w_minus            ; ( offset )
 
                 ; We subtract two more because of the branch instruction itself
-                dea
-                dea
-                sta 0,x
+                dec 0,x
+                dec 0,x
 
 z_asm_back_branch:
                 rts


### PR DESCRIPTION
Below is a very simple assembly routine that counts down using the Y register.
```
: branch-bug  ( n -- )
    [
        0 ldy.zx
    -->
        dey
        <b bne
        inx
        inx
    ]
    ;
```

Using latest `master-64tass`, the routine assembles as follows.

```
nt: 800  xt: 80F  header: 01 0A 65 C0 07
flags: HC 0 NN 0 AN 0 IM 0 CO 0 DC 0 LC 0 FP 1 | UF 0 ST 0
size (decimal): 7

080F  B4 00 88 D0 FF E8 E8                              .......

80F      0 ldy.zx
811        dey
812     FF bne      813 ^
814        inx
815        inx
```

Note that the displacement here is $ff (-1). Given that PC will be $814 when this displacement is added, the effective address for the branch is the second byte of the `bne` instruction itself at $813. Whoops. The correct displacement is $fd (-3) = $814 - 3 = $811. I'm guessing that maybe the `<b` pseudo-instruction isn't accounting for the size of the `BNE` instruction itself.

Looking at the source for `assembler.asm`, it seems the code is attempting to account for the size of the branch instruction, but it neglects put the result of the two decrement instructions onto the data stack with `sta 0,x` before returning.

```
xt_asm_back_branch:
                ; We arrive here with ( addr-l ) of the label on the stack and
                ; then subtract the current address
                jsr w_here             ; ( addr-l addr-h )
                jsr w_minus            ; ( offset )

                ; We subtract two more because of the branch instruction itself
                dea
                dea
                
z_asm_back_branch:
                rts
```

This PR adds an instruction to save the resulting displacement at TOS.