### PR TITLE
fix: flag NN when word includes absolute zero branch

### DIFF
--- a/tests/tali.fs
+++ b/tests/tali.fs
@@ -168,6 +168,14 @@ T{ latestxt int>name wordsize ->  3 }T
 T{ ' five int>name wordsize -> 16 }t
 T{ five -> 42 }T
 
+\ Test inlined zero_branch call (issue #158)
+
+0 nc-limit !      \ force zero_branch call with absolute address
+: test1 0 if then ;
+16 nc-limit !
+: test2 test1 5 ; \ test1 should be NN and leave 5 on stack
+T{ test2 -> 5 }T
+
 \ Test large words, relocatable and not
 here
 : lorem ." Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." ;

--- a/words/assembler.asm
+++ b/words/assembler.asm
@@ -187,9 +187,9 @@ _x9:
                 ; for $x9, bit 4 set means 3 bytes, clear means 2
                 and #$10
                 beq _two
-_three:         iny
-_two:           iny
-_one:           rts
+                iny             ; leave Y=3
+_two:           iny             ; leave Y=2
+_one:           rts             ; leave Y=1
 
 
 ; ==========================================================
@@ -207,7 +207,6 @@ _loop:
                 iny
                 cpy #z_push_a_tos - push_a_tos
                 bne _loop
-_done:
 z_asm_push_a:
                 rts
 

--- a/words/compile.asm
+++ b/words/compile.asm
@@ -390,6 +390,10 @@ cmpl_0branch_tos:
                 lda #<zero_branch_runtime
                 jsr cmpl_subroutine             ; call the 0branch runtime
 
+                ; we're adding an absolute address, so flag this word as never-native (NN)
+                lda #%00010000                  ; unset bit 4 to for NN
+                trb status
+
                 jmp w_comma                    ; add the payload and return
 
 _inline:

--- a/words/tali.asm
+++ b/words/tali.asm
@@ -213,7 +213,6 @@ w_find_name:
                 ora 1,x
                 beq _fail_done
 
-_nonempty:
                 ; Truncate names longer than the max allowed (31).
                 dex
                 dex

--- a/words/tools.asm
+++ b/words/tools.asm
@@ -286,7 +286,7 @@ _show_header:
 
                 ; Show flag values from the status byte along with
                 ; any calculated (synthetic) flag values
-                lda (2, x)              ; grab status flags @ NT
+                lda (2,x)               ; grab status flags @ NT
                 dex                     ; make some space
                 dex                     ; ( nt xt flags )
                 sta 0,x                 ; stash status flag byte


### PR DESCRIPTION
fixes #158 
fixes #126 (latest incarnation)  
removes a couple of unused symbols