### PR TITLE
remove ip variable

### DIFF
--- a/definitions.asm
+++ b/definitions.asm
@@ -15,8 +15,8 @@
 ; The top half of zero page is free for kernel/external use (zpage_end+1 to $FF).
 
 ; The default TaliForth zero page usage is as follows:
-;   zero page variables: 28 words = 56 bytes ($0000-$0037) - see cold_zp_table
-;   Forth Data Stack: 128 - 56 - 8 = 64 bytes or 32 words ($0038-$0077)
+;   zero page variables: 27 words = 54 bytes ($0000-$0035) - see cold_zp_table
+;   Forth Data Stack: 128 - 54 - 8 = 66 bytes or 33 words ($0036-$0077)
 ;   Data Stack floodplain: 8 bytes after stack to protect against underflow ($0078-$007F)
 
 ; The maximum size of Tali's data stack is 128 bytes (64 words), after which wraparound
@@ -97,7 +97,6 @@ cold_zp_table:
 cp:         .word cp0+256+1024      ; Compiler Pointer
                                     ; moved to make room for user vars and block buffer
 dp:         .word dictionary_start  ; Dictionary Pointer
-ip:         .word 0                 ; Instruction Pointer (current xt)
 workword:   .word 0                 ; nt (not xt!) of word being compiled, except in
                                     ; a :NONAME declared word (see status)
 up:         .word cp0               ; Forth user vars at start of available RAM
@@ -149,7 +148,7 @@ tmpdsp:     .byte ?         ; temporary DSP (X) storage (single byte)
 ; Loop control data
 
 loopctrl:   .byte ?         ; Offset from lcbstack0 to current loop control block for DO/LOOP/+LOOP
-loopidx0    .byte ?         ; cached LSB of current loop index for LOOP (not +LOOP)
+loopidx0:   .byte ?         ; cached LSB of current loop index for LOOP (not +LOOP)
 
 lcbstack0 = stack0
 loopindex = lcbstack0+0     ; loop control block index for adjusted loopindex

--- a/words/all.asm
+++ b/words/all.asm
@@ -123,10 +123,6 @@ w_quit:
                 txs
                 tax             ; Restore the DSP. Dude, seriously.
 
-                ; make sure instruction pointer is empty
-                stz ip
-                stz ip+1
-
                 ; SOURCE-ID is zero (keyboard input)
                 stz insrc
                 stz insrc+1

--- a/words/core.asm
+++ b/words/core.asm
@@ -2227,17 +2227,12 @@ z_fill:         rts
 xt_execute:
                 jsr underflow_1
 w_execute:
-                lda 0,x
-                sta ip
-                lda 1,x
-                sta ip+1
-
-                inx
+                inx             ; pre-drop the target address
                 inx
 
-                ; we don't need a RTS here because we highjack the RTS of
-                ; the word we're calling to get back to xt_execute
-                jmp (ip)
+                ; we don't need RTS here because the RTS of
+                ; the word we're calling will return to our caller
+                jmp ($fffe,x)   ; jump to the dropped address at x-2
 
 z_execute:      ; never reached
 


### PR DESCRIPTION
I noticed that the IP variable was only used in one spot, and we can use an indexed JMP instead saving a few bytes