### PR TITLE
support configurable platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@
 #
 #   $ make steckschwein
 #
-# Build a specific configuration of a platform.  Here CONFIG
+# Build a specific variant of a platform.  Here VARIANT
 # is passed as an assembler symbol to drive conditional compilation
 # generating taliforth-uc-c65.bin
 #
-#	$ make uc CONFIG=c65
+#	$ make uc VARIANT=c65
 #
 # Show known platforms:
 #
@@ -62,8 +62,8 @@ endif
 # enumerate the known platforms
 PLATFORMS := $(patsubst platform/%/,%,$(dir $(wildcard platform/*/platform.asm)))
 
-# prepend hyphen to CONFIG if defined
-_CONFIG := $(if $(CONFIG),-${CONFIG},)
+# prepend hyphen to VARIANT if defined
+_VARIANT := $(if $(VARIANT),-${VARIANT},)
 
 COMMON_SOURCES=taliforth.asm definitions.asm $(wildcard words/*.asm) stringtable.asm
 TEST_SUITE=tests/core_a.fs tests/core_b.fs tests/core_c.fs tests/string.fs tests/double.fs \
@@ -85,29 +85,29 @@ platforms:
 # create a phony target for each platform, so we can do make <platformname> `
 .PHONY: $(PLATFORMS)
 
-# for known platforms, the dummy target should build the configured binary
-# e.g. make sbc CONFIG=dbg should build taliforth-sbc-dbg.bin
-$(PLATFORMS): %: taliforth-%${_CONFIG}.bin
+# For known platforms, the dummy target should build the binary for the selected variant
+# e.g. make sbc VARIANT=dbg should build taliforth-sbc-dbg.bin
+$(PLATFORMS): %: taliforth-%${_VARIANT}.bin
 
 # add dependencies on .asm files within platform or platform/*/
-taliforth-%${_CONFIG}.bin: platform/%/*.asm platform/%/*/*.asm platform/%/platform_forth.asc $(COMMON_SOURCES)
+taliforth-%${_VARIANT}.bin: platform/%/*.asm platform/%/*/*.asm platform/%/platform_forth.asc $(COMMON_SOURCES)
 	64tass --nostart \
-	--list=platform/$*/$*${_CONFIG}-listing.txt \
+	--list=platform/$*/$*${_VARIANT}-listing.txt \
 	--vice-labels \
-	--labels=platform/$*/$*${_CONFIG}-labelmap.txt \
-	-D CONFIG:=\"${CONFIG}\" \
+	--labels=platform/$*/$*${_VARIANT}-labelmap.txt \
+	-D VARIANT:=\"${VARIANT}\" \
 	--output $@ \
 	$<
-	python3 tools/sort_vice_labels.py platform/$*/$*${_CONFIG}-labelmap.txt
+	python3 tools/sort_vice_labels.py platform/$*/$*${_VARIANT}-labelmap.txt
 
-taliforth-%${_CONFIG}.prg: platform/%/*.asm platform/%/*/*.asm platform/%/platform_forth.asc $(COMMON_SOURCES)
+taliforth-%${_VARIANT}.prg: platform/%/*.asm platform/%/*/*.asm platform/%/platform_forth.asc $(COMMON_SOURCES)
 	64tass --cbm-prg \
-	--list=platform/$*/$*${_CONFIG}-listing.txt \
-	--labels=platform/$*/$*${_CONFIG}-labelmap.txt \
-	-D CONFIG:=\"${CONFIG}\" \
+	--list=platform/$*/$*${_VARIANT}-listing.txt \
+	--labels=platform/$*/$*${_VARIANT}-labelmap.txt \
+	-D VARIANT:=\"${VARIANT}\" \
 	--output $@ \
 	$<
-	python3 tools/sort_vice_labels.py platform/$*/$*${_CONFIG}-labelmap.txt
+	python3 tools/sort_vice_labels.py platform/$*/$*${_VARIANT}-labelmap.txt
 
 # Compact the Forth word definitons for inclusion in the binary.
 # This will only process the file if it exists.

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,19 @@
 #
 # Build Taliforth 2 for a different platform (steckschwein shown here).
 # There must be a matching platform file in the platform folder.
+# This will generate taliforth-steckschwein.bin
 #
-#   $ make taliforth-steckschwein.bin
+#   $ make steckschwein
+#
+# Build a specific configuration of a platform.  Here CONFIG
+# is passed as an assembler symbol to drive conditional compilation
+# generating taliforth-uc-c65.bin
+#
+#	$ make uc CONFIG=c65
+#
+# Show known platforms:
+#
+#   $ make platforms
 #
 # Run tests
 #
@@ -48,6 +59,12 @@ else
 	PYTHON = python3
 endif
 
+# enumerate the known platforms
+PLATFORMS := $(patsubst platform/%/,%,$(dir $(wildcard platform/*/platform.asm)))
+
+# prepend hyphen to CONFIG if defined
+_CONFIG := $(if $(CONFIG),-${CONFIG},)
+
 COMMON_SOURCES=taliforth.asm definitions.asm $(wildcard words/*.asm) stringtable.asm
 TEST_SUITE=tests/core_a.fs tests/core_b.fs tests/core_c.fs tests/string.fs tests/double.fs \
     tests/facility.fs tests/ed.fs tests/asm.fs tests/tali.fs \
@@ -62,22 +79,35 @@ clean:
 	$(RM) *.bin *.prg
 	make -C c65 clean
 
-taliforth-%.bin: platform/%/platform.asm platform/%/platform_words.asm platform/%/platform_forth.asc $(COMMON_SOURCES)
-	64tass --nostart \
-	--list=platform/$*/$*-listing.txt \
-	--vice-labels \
-	--labels=platform/$*/$*-labelmap.txt \
-	--output $@ \
-	$<
-	python3 tools/sort_vice_labels.py platform/$*/$*-labelmap.txt
+platforms:
+	@echo Available platforms: $(PLATFORMS)
 
-taliforth-%.prg: platform/%/platform.asm platform/%/platform_words.asm platform/%/platform_forth.asc $(COMMON_SOURCES)
-	64tass --cbm-prg \
-	--list=platform/$*/$*-listing.txt \
-	--labels=platform/$*/$*-labelmap.txt \
+# create a phony target for each platform, so we can do make <platformname> `
+.PHONY: $(PLATFORMS)
+
+# for known platforms, the dummy target should build the configured binary
+# e.g. make sbc CONFIG=dbg should build taliforth-sbc-dbg.bin
+$(PLATFORMS): %: taliforth-%${_CONFIG}.bin
+
+# add dependencies on .asm files within platform or platform/*/
+taliforth-%${_CONFIG}.bin: platform/%/*.asm platform/%/*/*.asm platform/%/platform_forth.asc $(COMMON_SOURCES)
+	64tass --nostart \
+	--list=platform/$*/$*${_CONFIG}-listing.txt \
+	--vice-labels \
+	--labels=platform/$*/$*${_CONFIG}-labelmap.txt \
+	-D CONFIG:=\"${CONFIG}\" \
 	--output $@ \
 	$<
-	python3 tools/sort_vice_labels.py platform/$*/$*-labelmap.txt
+	python3 tools/sort_vice_labels.py platform/$*/$*${_CONFIG}-labelmap.txt
+
+taliforth-%${_CONFIG}.prg: platform/%/*.asm platform/%/*/*.asm platform/%/platform_forth.asc $(COMMON_SOURCES)
+	64tass --cbm-prg \
+	--list=platform/$*/$*${_CONFIG}-listing.txt \
+	--labels=platform/$*/$*${_CONFIG}-labelmap.txt \
+	-D CONFIG:=\"${CONFIG}\" \
+	--output $@ \
+	$<
+	python3 tools/sort_vice_labels.py platform/$*/$*${_CONFIG}-labelmap.txt
 
 # Compact the Forth word definitons for inclusion in the binary.
 # This will only process the file if it exists.
@@ -88,9 +118,6 @@ platform/%/platform_forth.asc: platform/%/platform_forth.fs
 # Allow platform_forth.fs and platform_words.asm to be missing.
 platform/%/platform_forth.fs:
 	@echo No platform_forth.fs for this platform.
-platform/%/platform_words.asm:
-	@echo No platform_words.asm for this platform.
-
 
 # Automatically update the wordlist which also gives us the status of the words
 # We need for the binary to be generated first or else we won't be able to find

--- a/platform/README.md
+++ b/platform/README.md
@@ -32,12 +32,13 @@ This will use the configuration defined in `platforms/minimal/platform.asm`
 and produce a binary called `taliforth-minimal.bin` at the top level
 along with listing and label (symbol) files in the platform folder.
 
-If the platform supports multiple sub-configurations---for example
-a version that runs on the c65 simulator as opposed to physical 
-hardware---add a CONFIG value to the make command.  This will
-produce a binary called `taliforth-uc-c65.bin`.
+If the platform supports multiple variants---for example
+one version that runs on the c65 simulator and one for physical 
+hardware---specify the VARIANT name in the make command:  
 
-    make uc CONFIG=c65
+    make uc VARIANT=c65
+
+This will produce a binary called `taliforth-uc-c65.bin`.
 
 ## Creating or modifying a configuration
 
@@ -59,8 +60,8 @@ The configuration has these responsibilities:
 
 4. Define the 65c02 reset and interrupt vectors at $fffa-$ffff, if needed.
 
-5. (optional) If your platform is configurable, use conditional assembly
-   based on the `CONFIG` symbol, e.g. `.if CONFIG="c65" ... .endif`.
+5. (optional) If your platform supports multiple variants, use conditional assembly
+   based on the `VARIANT` symbol, e.g. `.if VARIANT="c65" ... .endif`.
 
 ### Tali Forth 2 memory layout
 

--- a/platform/README.md
+++ b/platform/README.md
@@ -11,11 +11,11 @@ IO with the c65 emulator is `c65/platform.asm`.   These both assume a memory lay
 with at least 32Kb of ROM.  The `minimal/platform.asm` configuration strips out
 a number of optional features to run in 12-16Kb of ROM.
 
-Other configurations are included to make life easier for individual developers,
+Other platforms are included to make life easier for individual developers,
 along with `skeleton/platform.asm` as a template for people who want to port Tali to their own hardware.
 Those not mentioned above may not be up to date with the latest changes: *caveat emptor*.
 
-A configuration file is simply a [64tass](https://tass64.sourceforge.net/)
+A platform file is simply a [64tass](https://tass64.sourceforge.net/)
 `.asm` file that customizes Tali's memory layout and feature set by
 overriding default parameters.  The configuration then includes the global
 `taliforth.asm` and finally defines the basic I/O routines that Tali uses
@@ -23,12 +23,21 @@ to get and put characters.  The configuration can optionally include platform-sp
 words written in either assembly or Forth.
 
 By default the top-level `make` will build `taliforth-py65mon.bin`.
-To build for a different platform simply specify the binary corresponding
-to the platform's folder name on the end. For example build a 16K image with:
+To build for a different platform simply specify the name of the platform
+folder.  For example build a 16K image with:
 
-    make taliforth-minimal.bin
+    make minimal
 
-This will use the platform.asm file from the minimal folder.
+This will use the configuration defined in `platforms/minimal/platform.asm`
+and produce a binary called `taliforth-minimal.bin` at the top level
+along with listing and label (symbol) files in the platform folder.
+
+If the platform supports multiple sub-configurations---for example
+a version that runs on the c65 simulator as opposed to physical 
+hardware---add a CONFIG value to the make command.  This will
+produce a binary called `taliforth-uc-c65.bin`.
+
+    make uc CONFIG=c65
 
 ## Creating or modifying a configuration
 
@@ -49,6 +58,9 @@ The configuration has these responsibilities:
    and `kernel_kbhit` (optional), along with the `s_kernel_id` string to show on startup.
 
 4. Define the 65c02 reset and interrupt vectors at $fffa-$ffff, if needed.
+
+5. (optional) If your platform is configurable, use conditional assembly
+   based on the `CONFIG` symbol, e.g. `.if CONFIG="c65" ... .endif`.
 
 ### Tali Forth 2 memory layout
 


### PR DESCRIPTION
Potential solution for #182 supporting multiple variants for each platform.  

It lets you build a platform using the platform name instead of the binary name, and passes an optional VARIANT parameter to the assembler to create different variants for the same platform via conditional assembly:

    make py65mon  # build taliforth-py65mon.bin

    make uc VARIANT=hw   # build taliforth-uc-hw.bin, passing VARIANT:="hw" to the assembler

    make platforms   # show known platforms (subfolders in platform/ containing a platform.asm)