### PR TITLE
fix c65 location for talitest_c65.py

### DIFF
--- a/tests/talitest_c65.py
+++ b/tests/talitest_c65.py
@@ -22,7 +22,7 @@ import subprocess
 TESTER = 'tester.fs'
 RESULTS = 'results.txt'
 BLOCK_FILE = 'blocks.bin'
-C65_LOCATION = '../c65/c65'
+C65_LOCATION = '../tools/c65/c65'
 TALIFORTH_LOCATION = '../taliforth-c65.bin'
 TALI_ERRORS = ['Undefined word',
                'Stack underflow',


### PR DESCRIPTION
I pulled master so happily deleted my c65 folder in the top level and of course found a bug immediately...
