### PR TITLE
bug: I broke TYPE for long strings, added more tests

### DIFF
--- a/tests/tools.fs
+++ b/tests/tools.fs
@@ -6,12 +6,25 @@ testing tools words: .s ? dump name>string see state words
 \ TYPE tests
 T{ s" five by five" 2dup capture-output type restore-output compare -> 0 }T
 
+T{
+  \ longer than 256 chars
+  s" Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+  2dup capture-output type restore-output compare -> 0
+}T
+
+T{
+  \ exactly 256 chars
+  s" Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in"
+  dup 256 <> -rot 2dup capture-output type restore-output compare or -> 0
+}T
+
 \ .S tests
 T{ capture-output .s restore-output s" <0> " compare -> 0 }T
 T{ 1 2 3 capture-output .s restore-output s" <3> 1 2 3 " compare -> 1 2 3 0 }T
 T{ hex $12345678. capture-output .s restore-output s" <2> 5678 1234 " compare decimal -> $12345678. 0 }T
 
 \ ? tests
+: clinging-to-life ;    \ ensure following variable has a near pointer
 variable life  42 life !
 T{ capture-output life ? restore-output s" 42 " compare -> 0 }T
 

--- a/words/core.asm
+++ b/words/core.asm
@@ -3418,7 +3418,7 @@ z_max:          rts
 ; ## "min"  auto  ANS core
         ; """https://forth-standard.org/standard/core/MIN
         ; Adapted from Lance A. Leventhal "6502 Assembly Language
-        ; Subroutines." Negative Flag indicateds which number is larger. See
+        ; Subroutines." Negative Flag indicates which number is larger. See
         ; http://www.righto.com/2012/12/the-6502-overflow-flag-explained.html
         ; """
 
@@ -6484,21 +6484,24 @@ w_type:
                 lda 3,x
                 sta tmp1+1
 
-                lda 0,x         ; partial page to do?
-                beq +
-_page:
-                ldy #0
--
+                ldy #0          ; initialize offset
+
+                lda 0,x
+                beq _check      ; check empty string
+_loop:
                 lda (tmp1),y
                 jsr emit_a      ; avoids stack foolery
                 iny
-                dec 0,x
-                bne -
+                bne +
+                inc tmp1+1
 +
+                dec 0,x
+                bne _loop
+_check:
                 lda 1,x         ; See if we are done
                 beq _cleanup
                 dec 1,x         ; Not done - do another page
-                bra _page
+                bra _loop
 
 _cleanup:
                 ; clean up the stack


### PR DESCRIPTION
Seems like I broke TYPE for long strings with this previous commit: 69ba8d216c161884af4f825b43c72a36b24142b6

This also adds some additional tests to verify the fix.  