### PR TITLE
fix: regression with SEE invalid opcodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,9 @@ sim: taliforth-py65mon.bin
 csim: $(C65) taliforth-c65.bin
 	$(C65) -qq -r taliforth-c65.bin
 
+cdbg: $(C65) taliforth-c65.bin
+	$(C65) -r taliforth-c65.bin -l platform/c65/c65-labelmap.txt
+
 # Some convenience targets for the documentation.
 docs/manual.html: docs/*.adoc
 	cd docs && asciidoctor -a toc=left manual.adoc

--- a/words/assembler.asm
+++ b/words/assembler.asm
@@ -131,15 +131,16 @@ op_find_nt:
                 sta tmp1
                 lda #>nt_asm_end
                 sta tmp1+1
+                bra +                   ; skip first pointer update
 
 _loop:
+                jsr nt_to_nt            ; update tmp1 to previous NT in the list
++
                 jsr nt_to_xt            ; return XT in Y,A
                 cmp tmptos              ; check LSB of this word's XT
                 beq _found
 
-                jsr nt_to_nt            ; update tmp1 to previous NT in the list
-
-                lda tmp1
+                lda tmp1                ; have we checked the last candidate?
                 cmp #<nt_asm_begin
                 bne _loop
 

--- a/words/disasm.asm
+++ b/words/disasm.asm
@@ -63,10 +63,12 @@ _byte_loop:
                 ; use nt_question which will show "?" as the name
                 ; and assume it has length 1
 
+                tay                 ; Y=0
                 lda #>nt_question
                 pha
                 lda #<nt_question
                 pha
+                phy                 ; flag length as 1
                 bra _no_operand
 
 _found:


### PR DESCRIPTION
fix #196 

i must have introduced this during a refactor.  It was expecting an operand length byte on the stack which wasn't present for invalid opcode.

also fixed a small bug where the first opcode in the asm headers ($6d) wasn't recognized.  

new behavior demonstrated below

```
: testword [ 3 c, 4 c, ] ;  ok
see testword 
nt: 80D  xt: 819  header: 00 08 00 02 
flags: HC 0 NN 0 AN 0 IM 0 CO 0 DC 0 LC 0 FP 0 | UF 0 ST 0 
size (decimal): 2 

0819  03 04                                             ..

819        ?
81A     60 tsb.z
 ok


: test2 [ $6d c, $69 c, ] ;   ok
see test2 
nt: 800  xt: 80A  header: 01 05 0E BF 02 
flags: HC 0 NN 0 AN 0 IM 0 CO 0 DC 0 LC 0 FP 1 | UF 0 ST 0 
size (decimal): 2 

080A  6D 69                                             mi

80A   6069 adc
 ok


❯ make ctests
...
================================================================================
Summary for: core_a core_b core_c string double facility ed asm tali tools block search user cycles
Tali Forth 2 ran all tests requested
All available tests passed

```
