### PR TITLE
Support usage of upper-half of zeropage

### DIFF
--- a/words/all.asm
+++ b/words/all.asm
@@ -245,23 +245,23 @@ error:
 ; See discussion in https://github.com/SamCoVT/TaliForth2/issues/148
 underflow_1:
         ; """Make sure we have at least one cell on the Data Stack"""
-                cpx #+dsp0-1
-                bpl underflow_error
+                cpx #dsp0-1
+                bcs underflow_error
                 rts
 underflow_2:
         ; """Make sure we have at least two cells on the Data Stack"""
-                cpx #+dsp0-3
-                bpl underflow_error
+                cpx #dsp0-3
+                bcs underflow_error
                 rts
 underflow_3:
         ; """Make sure we have at least three cells on the Data Stack"""
-                cpx #+dsp0-5
-                bpl underflow_error
+                cpx #dsp0-5
+                bcs underflow_error
                 rts
 underflow_4:
         ; """Make sure we have at least four cells on the Data Stack"""
-                cpx #+dsp0-7
-                bpl underflow_error
+                cpx #dsp0-7
+                bcs underflow_error
                 rts
 
 

--- a/words/tools.asm
+++ b/words/tools.asm
@@ -59,7 +59,7 @@ w_dot_s:
                 ; from bottom to top
                 ply
 
-                lda #+dsp0-1     ; go up one to avoid garbage
+                lda #dsp0-1     ; go up one to avoid garbage
                 sta tmp3
                 stz tmp3+1      ; must be zero page on the 65c02
 _loop:


### PR DESCRIPTION
Handle the cases where one uses the upper half of the zeropage (eg: user0 = $80, zp_end = $ff). By using signed values, we overflow and so force use of unsigned and use a more accurate branching strategy to check for greater/lesser/equal, which is what we are really worried about.

fixes https://github.com/SamCoVT/TaliForth2/issues/203