### PR TITLE
fix: revamp compile flow to NN/UF issue

### DIFF
--- a/tests/results.txt
+++ b/tests/results.txt
@@ -2667,7 +2667,6 @@ decimal  ok
 \ Test for DISASM not implemented  ok
 \ Test for INPUT not implemented  ok
 \ Test for OUTPUT not implemented  ok
-\ Test for UF-STRIP not implemented  ok
   ok
 T{ capture-output BELL restore-output s\" \a" compare -> 0 }T  ok
 ( TODO COMPILE-ONLY test missing)  ok
@@ -2728,13 +2727,29 @@ T{ ' four-b int>name wordsize ->  3 }T  ok
 T{ latestnt wordsize          ->  3 }T  ok
 T{ latestxt int>name wordsize ->  3 }T  ok
   ok
+\ Test strip-underflow  ok
+strip-underflow @ constant default-uf  ok
+false strip-underflow !  ok
+: test-native-with-uf drop ;   \ small word inlines UF check  ok
+: test-call-with-uf allot ;   \ large word gets called with UF test  ok
+T{ ' test-native-with-uf int>name wordsize -> 5 }T  ok
+T{ ' test-call-with-uf 1+ @ -> ' allot }T  ok
+  ok
+true strip-underflow !  ok
+: test-native-strip-uf drop ;  \ small word gets inlined as two bytes  ok
+: test-call-strip-uf allot ;  \ large word gets called past UF test  ok
+: test-nn-strip-uf execute ;  \ NN word gets called past UF test (issue 201)  ok
+T{ ' test-native-strip-uf @ -> $e8e8 }T   \ just inx inx  ok
+T{ ' test-call-strip-uf 1+ @ 3 - -> ' allot }T  ok
+T{ ' test-nn-strip-uf 1+ @ 3 - -> ' execute }T  ok
+default-uf strip-underflow !  ok
+  ok
 \ Test inline vs jsr+payload literals  ok
 : five 6 [ 0 nc-limit ! ] 7 * ; 16 nc-limit !  ok
 T{ ' five int>name wordsize -> 15 }t  ok
 T{ five -> 42 }T  ok
   ok
 \ Test inlined zero_branch call (issue #158)  ok
-  ok
 0 nc-limit !      \ force zero_branch call with absolute address  ok
 : test1 0 if then ;  ok
 16 nc-limit !  ok
@@ -3583,12 +3598,12 @@ here 5       ' blank         cycle_test            CYCLES:    339 ok
 5            ' chars         cycle_test drop       CYCLES:     28 ok
 pad here 5   ' cmove         cycle_test            CYCLES:    188 ok
 pad here 5   ' cmove>        cycle_test            CYCLES:    183 ok
-             ' :             cycle_test wrd ;      CYCLES:  20804 ok
+             ' :             cycle_test wrd ;      CYCLES:  20807 ok
              ' :noname       cycle_test ; drop     CYCLES:     50 ok
 5            ' ,             cycle_test            CYCLES:     92 ok
-' aword      ' compile,      cycle_test            CYCLES:   1082 ok
+' aword      ' compile,      cycle_test            CYCLES:   1090 ok
 : bword ;    ' compile-only  cycle_test            CYCLES:     69 ok
-5            ' constant      cycle_test mycnst     CYCLES:  21482 ok
+5            ' constant      cycle_test mycnst     CYCLES:  21485 ok
 here         ' count         cycle_test 2drop      CYCLES:     57 ok
 \ skipping     cr  ok
 \ skipping     create  ok
@@ -3637,7 +3652,7 @@ nc-limit !  ok
 5 5          ' =             cycle_test drop       CYCLES:     64 ok
 here 5       ' erase         cycle_test            CYCLES:    337 ok
 here 5 5     ' fill          cycle_test            CYCLES:    309 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  21728 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  21730 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     58 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -3672,7 +3687,7 @@ s" aword"    ' find-name     cycle_test drop       CYCLES:   1466 ok
 \ skipping     +loop  ok
 5 5          ' lshift        cycle_test drop       CYCLES:    126 ok
 5 5          ' m*            cycle_test 2drop      CYCLES:    409 ok
-             ' marker        cycle_test marka      CYCLES:  24005 ok
+             ' marker        cycle_test marka      CYCLES:  24009 ok
              ' marka         cycle_test            CYCLES:    781 ok
 5 5          ' max           cycle_test drop       CYCLES:     69 ok
 5 5          ' min           cycle_test drop       CYCLES:     54 ok
@@ -3694,7 +3709,7 @@ decimal  ok
              ' nops          cycle_test            CYCLES:     29 ok
 5 5          ' <>            cycle_test drop       CYCLES:     64 ok
 5 5 5        ' -rot          cycle_test 2drop drop CYCLES:     76 ok
-s" 5"        ' number        cycle_test drop       CYCLES:    630 ok
+s" 5"        ' number        cycle_test drop       CYCLES:    629 ok
 \ skipping     #  ok
 \ skipping     #>  ok
 \ skipping     #s  ok
@@ -3756,7 +3771,7 @@ here         ' 2@            cycle_test 2drop      CYCLES:     88 ok
 5. here      ' 2!            cycle_test            CYCLES:     99 ok
 5 5 5 5      ' 2swap         cycle_test 4drop      CYCLES:     92 ok
 \ skipping     2>r  ok
-             ' 2variable     cycle_test eword      CYCLES:  22849 ok
+             ' 2variable     cycle_test eword      CYCLES:  22853 ok
              ' eword         cycle_test drop       CYCLES:     43 ok
 s" *"        ' type          cycle_test           *CYCLES:    106 ok
 5            ' u.            cycle_test          5 CYCLES:   1163 ok
@@ -3767,10 +3782,10 @@ s" *"        ' type          cycle_test           *CYCLES:    106 ok
 5 5          ' um*           cycle_test 2drop      CYCLES:    333 ok
 \ skipping     unloop  ok
              ' unused        cycle_test drop       CYCLES:     36 ok
-5            ' value         cycle_test fword      CYCLES:  22920 ok
+5            ' value         cycle_test fword      CYCLES:  22924 ok
              ' fword         cycle_test drop       CYCLES:     58 ok
 5            ' to            cycle_test fword      CYCLES:   1373 ok
-             ' variable      cycle_test gword      CYCLES:  22812 ok
+             ' variable      cycle_test gword      CYCLES:  22816 ok
              ' gword         cycle_test drop       CYCLES:     43 ok
 char "       ' word          cycle_test "txt" drop CYCLES:    632 ok
 \ skipping     words  ok
@@ -3783,4 +3798,4 @@ char "       ' word          cycle_test "txt" drop CYCLES:    632 ok
 5            ' 0<            cycle_test drop       CYCLES:     47 ok
 5            ' 0<>           cycle_test drop       CYCLES:     48 ok
   ok
-bye c65: PC=f016 A=29 X=78 Y=98 S=f8 FLAGS=<N0 V0 B1 D0 I1 Z0 C1> ticks=181582479
+bye c65: PC=f016 A=25 X=78 Y=98 S=f8 FLAGS=<N0 V0 B1 D0 I1 Z0 C1> ticks=182727780

--- a/tests/tali.fs
+++ b/tests/tali.fs
@@ -107,7 +107,6 @@ decimal
 \ Test for DISASM not implemented
 \ Test for INPUT not implemented
 \ Test for OUTPUT not implemented
-\ Test for UF-STRIP not implemented
 
 T{ capture-output BELL restore-output s\" \a" compare -> 0 }T
 ( TODO COMPILE-ONLY test missing)
@@ -168,13 +167,29 @@ T{ ' four-b int>name wordsize ->  3 }T
 T{ latestnt wordsize          ->  3 }T
 T{ latestxt int>name wordsize ->  3 }T
 
+\ Test strip-underflow
+strip-underflow @ constant default-uf
+false strip-underflow !
+: test-native-with-uf drop ;   \ small word inlines UF check
+: test-call-with-uf allot ;   \ large word gets called with UF test
+T{ ' test-native-with-uf int>name wordsize -> 5 }T
+T{ ' test-call-with-uf 1+ @ -> ' allot }T
+
+true strip-underflow !
+: test-native-strip-uf drop ;  \ small word gets inlined as two bytes
+: test-call-strip-uf allot ;  \ large word gets called past UF test
+: test-nn-strip-uf execute ;  \ NN word gets called past UF test (issue 201)
+T{ ' test-native-strip-uf @ -> $e8e8 }T   \ just inx inx
+T{ ' test-call-strip-uf 1+ @ 3 - -> ' allot }T
+T{ ' test-nn-strip-uf 1+ @ 3 - -> ' execute }T
+default-uf strip-underflow !
+
 \ Test inline vs jsr+payload literals
 : five 6 [ 0 nc-limit ! ] 7 * ; 16 nc-limit !
 T{ ' five int>name wordsize -> 15 }t
 T{ five -> 42 }T
 
 \ Test inlined zero_branch call (issue #158)
-
 0 nc-limit !      \ force zero_branch call with absolute address
 : test1 0 if then ;
 16 nc-limit !

--- a/words/compile.asm
+++ b/words/compile.asm
@@ -13,11 +13,9 @@
 ;
 ; We can compile words inline or as JSR calls based on the nc-limit
 ; variable:  COMPILE, has internal entry points cmpl_by_limit,
-; cmpl_inline[_drop] and cmpl_call_[nos|tos].  Inline compilation copies the
-; source code for a word between xt_<word> and <z_word>,
-; optionally removing the initial stack depth check.
-; For some words we also discard leading and trailing stack
-; juggling based on the ST flag.
+; cmpl_inline[_drop] and cmpl_call_[nos|tos].
+; Inline compilation copies the source code for a word between
+; xt_<word> and <z_word> with nuances based on UF and ST flags.
 ;
 ; A great way to understand what's going on is to write simple
 ; Forth words and use SEE to disassemble them.  Try different
@@ -79,148 +77,163 @@ w_compile_comma:
                 ; better to use the compile_comma_common entrypoint below
                 ; if the nt is already available, e.g. while interpreting
                 jsr w_int_to_name
-                ; ( xt nt )
+                ; ( xt nt|0 )
 
                 ; Does this xt even have a valid (non-zero) nt?
                 lda 0,x
                 ora 1,x
-                beq cmpl_call_nos       ; No nt so unknown size; must compile as a JSR
 
-compile_comma_common:
-                ; ( xt nt )
-
-                ; Otherwise investigate the nt
-                lda (0,x)               ; get status flags byte @ NT
-                sta tmp3                ; and keep a copy
-                and #AN+NN              ; check if never native (NN)
-                cmp #NN                 ; NN=1, AN=0?  i.e. not ST=AN+AN
+                ; Without an NT we don't know flags or size so must compile as a JSR
                 beq cmpl_call_nos
 
-                ; ( xt nt )             ; could possibly inline, keep checking
-                jsr w_wordsize
-                ; ( xt u )
+compile_comma_common:
+                ; Otherwise investigate the NT to decide how to proceed
+                lda (0,x)               ; stash status flags byte
+                sta tmp3
 
-                ; --- SPECIAL CASE 1: PREVENT RETURN STACK THRASHING ---
+                ; The target word we're compiling looks like this:
+                ;
+                ; xt_word:
+                ;       ST? - optional 5 byte stack prequel
+                ; inline_st_word:
+                ;       UF? - optional 3 byte jsr underflow_<N>
+                ; w_word:
+                ;       ... source code ...
+                ; z_word:
+                ;       rts
+                ;
+                ; We need to decide both whether to call or inline
+                ; the word, and which entrypoint to use.
+                ;
+                ; The entrypoint is typically xt_word or w_word
+                ; depending on whether we're stripping the UF check.
+                ; But for ST words, the call entrypoint xt_word
+                ; differs from the inline entrypoint st_word or w_word.
+                ;
+                ; Now we decide whether to inline or call.
+                ; If the word is always or never native (AN/NN) we're
+                ; done, otherwise we compare nc-limit to the word length
+                ; based on the inline entrypoint.
+
+                jsr w_wordsize
+                jsr w_over
+                jsr w_swap
+
+                ; We'll start from ( xt xt u ) and adjust
+                ; until we have ( call-addr inline-addr inline-len )
+
+                ; --- SPECIAL CASE 1: STACK THRASHING WORDS (ST) ---
 
                 lda tmp3
                 and #ST                 ; Check the Stack Thrash flag (ST=NN+AN)
                 cmp #ST                 ; C=1 if equal, C=0 otherwise
+                php                     ; We'll reuse this check shortly
                 bcc _no_st
-                jsr w_over              ; if ST, preserve original xt for call
-                bra +
-_no_st:
-                jsr w_zero              ; else safe to call whatever we strip down to
-+
-                jsr w_not_rot
 
-                ; ( xt xt u ) if ST else ( 0 xt u )
-                bcc _check_uf           ; no stack juggling to skip?
-
-                ; skip the standard 5 byte stack juggling byte header
                 jsr push_inline_bliteral
                 .byte 5
-                jsr w_slash_string
+                jsr w_slash_string      ; skip 5 byte ST prequel
 
-                ; ( xt|0 xt+sz u-sz )
-
+                ; ( xt xt+5 u-5 )
+_no_st:
                 ; --- SPECIAL CASE 2: REMOVE UNDERFLOW CHECKING ---
-_check_uf:
-                ; The user can choose to remove the unterflow testing in those
-                ; words that have the UF flag. This shortens the word by
-                ; 3 bytes if there is no underflow.
 
                 ; Does the user want to strip underflow checks?
                 ldy #uf_strip_offset
                 lda (up),y
                 iny
                 ora (up),y
-                beq _check_limit
+                beq _no_uf
 
                 jsr w_over
-                jsr has_uf_check
-                bcc _check_limit        ; not an underflow check
-
-                ; Ready to remove the 3 byte underflow check.
+                jsr has_uf_check        ; is there an UF check?
+                bcc _no_uf
 
                 jsr push_inline_bliteral
                 .byte 3
                 jsr w_slash_string
+_no_uf:
+                plp
+                bcs _has_st
+
+                ; words with ST use original XT as call-addr
+                ; but others can call the inline entrypoint
+                lda 2,x         ; ( xt addr u -- addr addr u )
+                sta 4,x
+                lda 3,x
+                sta 5,x
+
+_has_st:
+                ; --- END OF SPECIAL CASES ---
+                ; ( call-addr inline-addr inline-len )
 
 _check_limit:
-                ; --- END OF SPECIAL CASES ---
-                ; ( 0|xt xt' u )
-
                 lda tmp3
-                and #AN+NN              ; check Always Native (AN) bit
+                and #AN+NN              ; check for AN and NN
                 cmp #AN                 ; AN=1, NN=0?  (i.e. not ST=AN+NN)
                 beq cmpl_inline_drop    ; always natively compile
-                bne cmpl_by_limit2
+                cmp #NN
+                beq cmpl_call_3os       ; always compile as call
+                bra cmpl_by_limit2      ; else check word length
 
 cmpl_by_limit:
-        ; simple entrypoint for cmpl_by_limit2 when xt == xt'
+                ; external entrypoint for ( xt u -- xt xt u )
                 jsr w_over
                 jsr w_swap
 
 cmpl_by_limit2:
-                ; ( 0|xt xt' u )
-                ; Compile either inline or as subroutine depending on
-                ; whether native code size <= user limit
-                ; xt' is always used for inlining; with xt preferred for call if non-zero
-                ; Returns C=0 if native, C=1 if subroutine
+                ; ( call-addr inline-addr u )
+                ; Compline call or inline based on size vs nc-limit
+                ; Eventually returns C=0 if inline, C=1 if call
+
                 ldy #nc_limit_offset+1
                 lda 1,x                 ; MSB of word size
                 cmp (up),y              ; user-defined limit MSB
                 bcc cmpl_inline_drop    ; borrow (C=0) means size < limit
-                bne +                   ; else non-zero means size > limit
+                bne cmpl_call_3os       ; else non-zero means size > limit
 
-                ; Check the wordsize LSB against the user-defined limit.
-                dey
+                dey                     ; MSB equal so check LSB
                 lda (up),y              ; user-defined limit LSB
                 cmp 0,x
-                bcs cmpl_inline_drop    ; not bigger, so good to go
-+
-                ; Prepare for cmpl_call_nos.  We have:
-                ;  ( 0|xt xt' u )
-                ; and want to call xt' unless the original xt was preserved with stack juggling
-                jsr w_drop              ; discard size
-                ; ( 0|xt xt' )
-                lda 3,x                 ; if MSB of NOS is non-zero we had stack juggling
-                bne cmpl_call_nos       ; use original xt from ( xt xt' )
-                jsr w_swap              ; use stripped xt via ( xt' 0 )
+                bcs cmpl_inline_drop    ; not bigger, we can inline!
 
+                ; else fall through and compile as call
+cmpl_call_3os:
+                ; compile call from ( xt ? ? -- ), return C=1
+                jsr w_two_drop
+                bra cmpl_call_tos
 cmpl_call_nos:
-        ; Compile xt as a subroutine call, return with C=1
-                ; ( xt ? )
+                ; compile call from ( xt ? -- ), return C=1
                 jsr w_drop
 cmpl_call_tos:
                 ; ( target -- )
                 lda #OpJSR
                 jsr cmpl_a
                 jsr w_comma
-                sec
+                sec                     ; return C=1 for call
                 rts
 
 cmpl_inline_drop:
         ; compile inline, with extraneous arg to drop, returning C=0
-                ; ( 0|xt xt' u -- )
+                ; ( call-addr inline-addr u -- )
                 jsr w_rot
-                jsr w_drop              ; discard the 0|xt
+                jsr w_drop              ; drop call-addr
 cmpl_inline:
-                ; ( xt' u -- )
+                ; ( inline-addr u -- )
                 jsr w_here
                 jsr w_swap
                 ; ( xt' cp u -- )
                 jsr w_dup
                 jsr w_allot             ; allocate space for the word
                 jsr w_move              ; let's move those bytes already!
-                clc
+                clc                     ; return C=0 for inline
 z_compile_comma:
                 rts
 
 
 has_uf_check:
-                ; Check if the addr TOS points an underflow check,
-                ; consuming TOS and returning C=1 (true) or C=0 (false)
+                ; Check if TOS points to an underflow check,
+                ; returning C=1 (true) or C=0 (false)
                 ; ( addr -- )
 
                 ; Does addr point at a JSR?

--- a/words/compile.asm
+++ b/words/compile.asm
@@ -110,10 +110,10 @@ compile_comma_common:
                 ; But for ST words, the call entrypoint xt_word
                 ; differs from the inline entrypoint st_word or w_word.
                 ;
-                ; Now we decide whether to inline or call.
-                ; If the word is always or never native (AN/NN) we're
-                ; done, otherwise we compare nc-limit to the word length
-                ; based on the inline entrypoint.
+                ; Once we have the inline entrypoint and length
+                ; we can decide whether to inline or call.
+                ; If the word is always- or never-native (AN/NN) we're
+                ; done, otherwise we compare the word length to nc-limit.
 
                 jsr w_wordsize
                 jsr w_over
@@ -156,8 +156,8 @@ _no_uf:
                 plp
                 bcs _has_st
 
-                ; words with ST use original XT as call-addr
-                ; but others can call the inline entrypoint
+                ; for ST words we keep the original XT as call-addr
+                ; but for others we can call the inline entrypoint
                 lda 2,x         ; ( xt addr u -- addr addr u )
                 sta 4,x
                 lda 3,x
@@ -183,7 +183,7 @@ cmpl_by_limit:
 
 cmpl_by_limit2:
                 ; ( call-addr inline-addr u )
-                ; Compline call or inline based on size vs nc-limit
+                ; Compile call or inline based on size vs nc-limit
                 ; Eventually returns C=0 if inline, C=1 if call
 
                 ldy #nc_limit_offset+1

--- a/words/compile.asm
+++ b/words/compile.asm
@@ -200,8 +200,7 @@ cmpl_by_limit2:
                 ; else fall through and compile as call
 cmpl_call_3os:
                 ; compile call from ( xt ? ? -- ), return C=1
-                jsr w_two_drop
-                bra cmpl_call_tos
+                jsr w_drop
 cmpl_call_nos:
                 ; compile call from ( xt ? -- ), return C=1
                 jsr w_drop


### PR DESCRIPTION
fix #201

adds strip-underflow tests, the last of which fails without this fix