### PR TITLE
Simplify DEFER/IS

### DIFF
--- a/docs/ch_internals.adoc
+++ b/docs/ch_internals.adoc
@@ -76,7 +76,7 @@ However, it increases the stability of the program. There is an option for
 stripping it out when compiling user-defined words (see below).
 
 Tali Forth does not explicitly check for overflow, which in normal operation is too rare
-to justify the computing expense.  However, the underlow checks use a signed test which
+to justify the computing expense.  However, the underflow checks use a signed test which
 triggers both when the stack depth is negative and when the stack exceeds 128 bytes:
 also negative as far as the 65c02 is concerned!
 This means the maximum stack size is 64 words with an implicit overflow test at that depth.
@@ -142,9 +142,9 @@ while the last two -- *CO* and *IM* -- are useful for words with special compila
 [horizontal]
 HC::
   *Has CFA.* The word's first three bytes are considered the Code Field Area (CFA).
-  The CFA is a `jsr` to either a known handler like `dovar` or indirectly to `dodefer`
+  The CFA is normally a `jsr` to a data handler like `dovar`
   and is followed by the Parameter Field Area (PFA) with any data used by the CFA.
-  This is used by words defined with `create` so that `>body` returns the correct value.
+  The word `>body` uses this flag to skip past the CFA of words defined with `create`.
 NN::
   *Never Native.* This Word is never inlined. This is usually because the word needs
   the caller's return address for processing, or because the word
@@ -395,16 +395,26 @@ version is easier to explain.
 to `(does>)` and one to `dodoes`, which is a pre-defined system routine like
 `dovar`. We'll discuss those later.
 
-In Tali Forth, a number of words such as `defer` are "hand-compiled", that is,
-instead of using forth such as
+In Tali Forth, many words are "hand-compiled" to produce more efficient assembly.
+For example, the word `bounds` could be defined in forth as
 
 ----
-: defer create ['] abort , does> @ execute ;
+: bounds over + swap ;
 ----
 
-we write an optimized assembler version ourselves (see the actual `defer` code).
-In these cases, we need to use `(does>)` and `dodoes` instead of `does>` as
-well.
+but rather than simply calling the relevant forth words like
+
+----
+        jsr w_over
+        jsr w_plus
+        jsr w_swap
+----
+
+we write an optimized assembler version ourselves.
+(Compare the actual `bounds` implementation in `words/tali.asm`.)
+There is often a tradeoff between speed and size:
+in this case the simple approach is 9 bytes but
+takes many more cycles to execute than the 21 byte hand-crafted version.
 
 
 ==== Sequence 2: Executing the Word `constant`

--- a/taliforth.asm
+++ b/taliforth.asm
@@ -99,29 +99,6 @@ doconst:
                 rts
 
 
-dodefer:
-        ; """Execute a DEFER statement at runtime: Execute the address we
-        ; find after the caller in the Data Field
-        ; """
-                ; The xt we need is stored in the two bytes after the JSR
-                ; return address, which is what is on top of the Return
-                ; Stack. So all we have to do is replace our return jump
-                ; with what we find there
-                pla             ; LSB
-                sta tmp1
-                pla             ; MSB
-                sta tmp1+1
-
-                ldy #1
-                lda (tmp1),y
-                sta tmp2
-                iny
-                lda (tmp1),y
-                sta tmp2+1
-
-                jmp (tmp2)      ; This is actually a jump to the new target
-
-
 dodoes:
         ; """Execute the runtime portion of DOES>. See DOES> and
         ; docs/create-does.txt for details and

--- a/words/core.asm
+++ b/words/core.asm
@@ -390,7 +390,7 @@ accept_total_recall:
         ; """http://forth-standard.org/standard/core/ACTION-OF"""
 xt_action_of:
 w_action_of:
-                ; This is a state aware word with differet behavior
+                ; This is a state aware word with different behavior
                 ; when used while compiling vs interpreting.
                 ; Check STATE
                 lda state
@@ -1220,7 +1220,8 @@ _process_name:
                 ; like looping constructs with non-relocatable JMPs.
 
                 ; Long story short, we flag everything as NN here, but then revert when
-                ; possible in ";".
+                ; possible in ";".  Note this only applies to : ... ; words, other words
+                ; created via DEFER, CONSTANT, VARIABLE etc will remain as NN.
                 ora #NN
 
                 ; Words defined by CREATE are marked in the header as
@@ -1234,7 +1235,7 @@ _process_name:
                 ldy 7,x                 ; check MSB of CFA
                 beq +                   ; 0 means no CFA, don't set HC
 
-                ora #HC                 ; otherwise set the HC bit
+                ora #HC                 ; all words with CFA get the HC bit set
 +
                 ; Now start writing the header byte-by-byte
 
@@ -1347,21 +1348,18 @@ z_decimal:      rts
         ;
         ; The ANS reference implementation is
         ;       CREATE ['] ABORT , DOES> @ EXECUTE ;
-        ; But we use this routine as a low-level word so things go faster
-
+        ; but does not require that DEFER / IS can interoperate with CREATE DOES>.
+        ; For speed we instead create a simple NN word that JMP's to its target:
+        ;       : "name" [ <target> JMP ] ;
+        ; Since it's never-native (NN) the target eventually returns to its caller.
+        ; This makes DEFER!, DEFER@, IS, and ACTION-OF trivial.
 xt_defer:
 w_defer:
-                ; we want CREATE but with DODEFER as the CFA
-                jsr create_inline
-                .byte 2+3               ; TOS; 2 byte PFA +3 for JSR
-                .word dodefer
-                ; DODEFER executes the next address it finds after
-                ; its call. As default, we include the error
-                ; "Defer not defined"
-                lda #<defer_error
+                jsr w_colon
+                lda #<defer_error               ; Initially show "DEFERed word not defined"
                 ldy #>defer_error
-                jsr cmpl_word_ya
-
+                jsr cmpl_jump_ya                ; The JMP makes the DEFER'd word remain NN
+                jsr w_semicolon
 z_defer:        rts
 
 
@@ -1378,7 +1376,7 @@ defer_error:
 xt_defer_fetch:
                 jsr underflow_1
 w_defer_fetch:
-                jsr w_to_body
+                jsr w_one_plus
                 jsr w_fetch
 z_defer_fetch:  rts
 
@@ -1391,7 +1389,7 @@ z_defer_fetch:  rts
 xt_defer_store:
                 jsr underflow_2
 w_defer_store:
-                jsr w_to_body
+                jsr w_one_plus          ; update the JMP target
                 jsr w_store
 z_defer_store:  rts
 
@@ -5835,7 +5833,7 @@ w_to_body:
                 ; Ideally, xt already points to the CFA. We just need to check
                 ; the HC flag for special cases
                 jsr w_dup              ; ( xt xt )
-                jsr w_int_to_name      ; ( xt nt )
+                jsr w_int_to_name      ; ( xt nt )      - Nb. expensive wordlist search
 
                 ; The status flags byte is @ NT
                 lda (0,x)               ; get status byte

--- a/words/core.asm
+++ b/words/core.asm
@@ -5584,9 +5584,8 @@ z_star:         rts
         ; Multiply n1 by n2 and divide by n3, returning the result
         ; without a remainder. This is */MOD without the mod.
         ;
-        ; This word
-        ; can be defined in Forth as : */  */MOD SWAP DROP ; which is
-        ; pretty much what we do here
+        ; This word can be defined in Forth as : */  */MOD SWAP DROP ;
+        ; which is pretty much what we do here
         ; """
 xt_star_slash:
                 jsr underflow_3
@@ -5840,7 +5839,7 @@ w_to_body:
                 and #HC
                 beq _no_cfa
 
-                ; We've got a DOVAR, DOCONST, DODEFER, DODOES or whatever,
+                ; We've got a DOVAR, DOCONST, DODOES or whatever,
                 ; so we add three to xt, which is NOS
                 clc
                 lda 2,x         ; LSB

--- a/words/core.asm
+++ b/words/core.asm
@@ -1219,9 +1219,9 @@ _process_name:
                 ; we don't know for sure until we've seen whether they contain things
                 ; like looping constructs with non-relocatable JMPs.
 
-                ; Long story short, we flag everything as NN here, but then revert when
-                ; possible in ";".  Note this only applies to : ... ; words, other words
-                ; created via DEFER, CONSTANT, VARIABLE etc will remain as NN.
+                ; Long story short, we flag everything as NN here, but then ";" reverts if
+                ; possible.  This only applies to COLON words that end with SEMICOLON.
+                ; Words built with CREATE like CONSTANT and VARIABLE will stay as NN.
                 ora #NN
 
                 ; Words defined by CREATE are marked in the header as
@@ -1235,7 +1235,7 @@ _process_name:
                 ldy 7,x                 ; check MSB of CFA
                 beq +                   ; 0 means no CFA, don't set HC
 
-                ora #HC                 ; all words with CFA get the HC bit set
+                ora #HC                 ; all words with CFA have HC set
 +
                 ; Now start writing the header byte-by-byte
 
@@ -1349,10 +1349,10 @@ z_decimal:      rts
         ; The ANS reference implementation is
         ;       CREATE ['] ABORT , DOES> @ EXECUTE ;
         ; but does not require that DEFER / IS can interoperate with CREATE DOES>.
-        ; For speed we instead create a simple NN word that JMP's to its target:
+        ; For speed we instead create a never-native word that JMPs to the target:
         ;       : "name" [ <target> JMP ] ;
-        ; Since it's never-native (NN) the target eventually returns to its caller.
-        ; This makes DEFER!, DEFER@, IS, and ACTION-OF trivial.
+        ; The target word ultimately returns to the deferred word's caller.
+        ; This makes it easy to implement DEFER!, DEFER@, IS, and ACTION-OF
 xt_defer:
 w_defer:
                 jsr w_colon


### PR DESCRIPTION
Fix #200 

Now DEFER builds a normal colon word `: name [ <target> JMP ] ; `.   So DEFER@/DEFER! and thus IS are super simple/fast.  It does look like the standard says that DEFER'd words don't need to interoperate with CREATE so this seems safe.  All tests still pass.