### PR TITLE
Restore variable and evaluate* to glossary

### DIFF
--- a/words/core.asm
+++ b/words/core.asm
@@ -1028,7 +1028,13 @@ z_constant:
 ; Shared helpers for CONSTANT, VARIABLE, VALUE, 2CONSTANT, 2VARIABLE
 ; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-
+; ## VARIABLE ( "name" -- ) "Define a variable"
+; ## "variable"  auto  ANS core
+        ; """https://forth-standard.org/standard/core/VARIABLE
+        ; There are various Forth definitions for this word, such as
+        ; `CREATE 1 CELLS ALLOT`  or  `CREATE 0 ,`  We use a variant of the
+        ; second one so the variable is initialized to zero
+        ; """
 xt_variable:
 w_variable:
                 ; push the address of the variable storage (HERE)

--- a/words/tali.asm
+++ b/words/tali.asm
@@ -355,8 +355,8 @@ _done:
 z_hexstore:     rts
 
 
-; ## EVALUATE* ( addr u -- ) "Separately EVALUATE each line of a multi-line string"
-; ## "evaluate*" auto  ANS file
+; ## EVALUATE_LINES ( addr u -- ) "Separately EVALUATE each line of a multi-line string"
+; ## "evaluate*" auto  ANS  file
         ; EVALUATE* is handy for running multi-line code containing comments.
         ; The normal EVALUATE treats line breaks as whitespace which can cause problems
         ; with backslash comments, see https://github.com/SamCoVT/TaliForth2/issues/35


### PR DESCRIPTION
Hello,

I noticed that **variable** had disappeared from the Glossary and there was also a message at the top of the Glossary that indicated a problem with **evaluate***. It looks like the description of variable disappeared at some point, so I edited core.asm to add back in a description of variable from an old version. I also changed "evaluate*" in tali.asm to "evaluate_lines" and now both entries appear to be correct in the Glossary.

I hope this is helpful. Thanks! Ben