### PR TITLE
feat: Inline compare_16bit

### DIFF
--- a/examples/words/dasm.asm
+++ b/examples/words/dasm.asm
@@ -38,23 +38,18 @@ w_dasm:
         sta pc
         lda 3,x
         sta pc+1
-        jsr w_plus
-        dex
-        dex                     ; ( addr' ?? )
+        jsr w_plus              ; ( addr_end )
         jsr w_cr
 -
-        phx
+        phx                     ; preserve data stack ptr
         jsr d65c
         plx
         lda pc
-        sta 0,x
+        cmp 0,x
         lda pc+1
-        sta 1,x
-        jsr compare_16bit
+        sbc 1,x                 ; C=1 if PC >= addr_end
         bcc -
 
-        inx
-        inx
         inx
         inx
 z_dasm:

--- a/taliforth.asm
+++ b/taliforth.asm
@@ -156,7 +156,7 @@ push_pfa:
         ; the Data Field (PFA) onto the stack. This is called with JSR so we
         ; can pick up the address of the calling variable off the 65c02's
         ; stack. The final RTS takes us to the original caller of the
-        ; routine that itself called push_pfa. 
+        ; routine that itself called push_pfa.
         ; """
                 ; Pull the return address off the machine's stack, adding
                 ; one because of the way the 65c02 handles subroutines
@@ -525,44 +525,6 @@ _next_nt:
 _done:
                 rts
 
-
-compare_16bit:
-        ; """Compare TOS/NOS and return results in form of the 65c02 flags
-        ; Adapted from Leventhal "6502 Assembly Language Subroutines", see
-        ; also http://www.6502.org/tutorials/compare_beyond.html
-        ; For signed numbers, Z signals equality and N which number is larger:
-        ;       if TOS = NOS: Z=1 and N=0
-        ;       if TOS > NOS: Z=0 and N=0
-        ;       if TOS < NOS: Z=0 and N=1
-        ; For unsigned numbers, Z signals equality and C which number is larger:
-        ;       if TOS = NOS: Z=1 and N=0
-        ;       if TOS > NOS: Z=0 and C=1
-        ;       if TOS < NOS: Z=0 and C=0
-        ; Compared to the book routine, WORD1 (MINUEND) is TOS
-        ;                               WORD2 (SUBTRAHEND) is NOS
-        ; """
-                ; Compare LSB first to set the carry flag
-                lda 0,x                 ; LSB of TOS
-                cmp 2,x                 ; LSB of NOS
-                beq _equal
-
-                ; LSBs are not equal, compare MSB
-                lda 1,x                 ; MSB of TOS
-                sbc 3,x                 ; MSB of NOS
-                bvs _overflow
-                bra _not_equal
-_equal:
-                ; Low bytes are equal, so we compare high bytes
-                lda 1,x                 ; MSB of TOS
-                sbc 3,x                 ; MSB of NOS
-                bvc _done
-_overflow:
-                ; Handle overflow because we use signed numbers
-                eor #$80                ; complement negative flag
-_not_equal:
-                ora #1                  ; set Z=0 since we're not equal
-_done:
-                rts
 
 current_to_dp:
         ; """Look up the current (compilation) dictionary pointer

--- a/words/core.asm
+++ b/words/core.asm
@@ -494,39 +494,44 @@ w_allot:
 _release:
    		; The ANS standard doesn't really say what to do if too much
                 ; memory is freed ("negatively alloted"). In fact, there isn't
-                ; even an official test. Gforth is little help either. The good
+                ; even an official test. GForth is little help either. The good
                 ; news is, this is going to be a rare case. We want to use as
                 ; few bytes as possible.
 
                 ; What we do is let the user free anything up to the beginning
-                ; of the RAM area assigned to the Dicionary (CP0), but at
+                ; of the RAM area assigned to the Dictionary (CP0), but at
                 ; their own risk. This means that the Dictionary pointer DP
                 ; might end up pointing to garbage. However, an attempt to
                 ; free more than RAM than CP0 will lead to CP being set to CP0,
                 ; the DP pointing to the last word in RAM (should be DROP) and
                 ; an error message.
 
-                ; We arrive here with ( n ) which is negative. First step,
-                ; subtract the number TOS from the CP for a new CP
+                ; Note: using CP0 clobbers the user vars and block buffer,
+                ; it might be safer to simply cold start here,
+                ; or use the starting CP value from cold_zp_table as the lower bound?
+
+                ; We arrive here with ( n ) which is negative, but we need to be
+                ; careful as CP and CP0 are unsigned addresses (CP > $8000 could happen).
+                ; We can't just update CP to CP+N and compare to CP0: for example,
+                ; CP0 = $400, N = -$800 is bad when CP = $600 but ok when CP = $9600
+                ; but in both cases CP+N > $8000 > CP0.  One approach is to
+                ; calculate CP+N and ensure it's within [CP0, CP)
+
                 lda cp
                 ldy cp+1
-                jsr push_ya_tos
-
-                jsr w_plus                     ; new CP is now TOS
-
-                ; Second step, see if we've gone too far. We compare the new
-                ; CP on TOS (which, if we've really screwed up, might be
-                ; negative) with CP0. This is a signed comparison
-                jsr push_inline_literal         ; ( CP CP0 )
+                jsr push_ya_tos                 ; ( N CP )
+                jsr w_plus                      ; add the negative offset to update CP
+                dex
+                dex                             ; undrop CP leaving ( N+CP CP )
+                jsr w_over                      ; ( N+CP CP N+CP )
+                jsr push_inline_literal
                 .word cp0
-                jsr compare_16bit               ; still ( CP CP0 )
+                jsr w_rot                       ; ( N+CP N+CP CP0 CP )
+                jsr w_within                    ; ( N+CP f )  test CP+N within [CP0, CP)
+                lda 0,x
+                bne _nega_done                   ; if flag is true, we're ok with new CP NOS
 
-                ; If CP (NOS) is smaller than CP0 (TOS), we're in trouble.
-                ; This means we want Z=1 or N=1
-                beq _nega_done
-                bmi _nega_done
-
-                ; Yep, we're in trouble. Set CP to CP0, set DP to the first
+                ; Otherwise we're in trouble. Set CP to CP0, set DP to the first
                 ; word in ROM (should be DROP), and abort with an error
                 lda #<cp0
                 sta cp
@@ -548,8 +553,8 @@ _nega_done:
                 lda 3,x
                 sta cp+1
 
+                inx                     ; drop flag and fall thru to _done
                 inx
-                inx                     ; drop through to _done
 _done:
                 inx
                 inx
@@ -2546,22 +2551,21 @@ z_evaluate:     rts
 xt_greater_than:
                 jsr underflow_2
 w_greater_than:
-                ldy #0          ; default false
-                jsr compare_16bit
-
-                ; for signed numbers, NOS>TOS gives us Z=0 and N=1
-                beq _false
-                bpl _false
-
-                ; true
+                ldy #0
+                lda 0,x
+                cmp 2,x
+                lda 1,x
+                sbc 3,x
+                bvc +           ; if V = 0 then N eor V is just N
+                eor #$80        ; otherwise N eor V is N eor 1
++
+                bpl +           ; NUM1 >= NUM2
                 dey
-_false:
-                tya
-
++
                 inx
                 inx
-                sta 0,x
-                sta 1,x
+                sty 0,x
+                sty 1,x
 
 z_greater_than: rts
 
@@ -2909,22 +2913,21 @@ z_less_number_sign:
 xt_less_than:
                 jsr underflow_2
 w_less_than:
-                ldy #0          ; default false
-                jsr compare_16bit
-
-                ; for signed numbers, NOS < TOS if Z=0 and N=0
-                beq _false
-                bmi _false
-
-                ; true
+                ldy #0
+                lda 2,x
+                cmp 0,x
+                lda 3,x
+                sbc 1,x
+                bvc +           ; if V = 0 then N eor V is just N
+                eor #$80        ; otherwise N eor V is N eor 1
++
+                bpl +           ; NUM1 >= NUM2
                 dey
-_false:
-                tya
-
++
                 inx
                 inx
-                sta 0,x
-                sta 1,x
+                sty 0,x
+                sty 1,x
 
 z_less_than:    rts
 
@@ -5836,7 +5839,7 @@ to_runtime:     ; ( n xt )
 
                 ; Poke MSB at XT+1 (native) or XT+4 (non-native)
                 bcc +                   ; C=0 -> non-native
-                ldy #0                  
+                ldy #0
 +               iny                     ; Y = 3+1 (NN) or 0+1 (native)
                 lda 3,x                 ; MSB of n
                 sta (tmp1),y

--- a/words/disasm.asm
+++ b/words/disasm.asm
@@ -351,23 +351,27 @@ _no_prefix:
                 plp                         ; was it a string?
                 bne _skip_payload
 
-                ; for a string we'll show up to 15 characters
-                ; with ... if it's too long
+                ; for a string we'll show up to 15 characters, with ellipses if it's too long
+
                 ; ( addr u saddr n )
 
-                ; print up to 15 chars of the string
-                jsr push_inline_bliteral
-                .byte 15
-                jsr compare_16bit   ; check if string length > 15 (sets C=0)
-                php
-                jsr w_min
+                lda 0,x
+                and #$f0            ; check high 12 bits
+                ora 1,x
+                php                 ; non-zero if >15 char
+                beq +
+
+                stz 1,x
+                lda #12             ; long label shows first 12 chars plus ...
+                sta 0,x
++
                 jsr w_type          ; print up to 15 characters
                 plp
-                bcs _skip_payload   ; did we truncate?
+                beq _skip_payload   ; did we truncate?
 
                 ldy #3
 -
-                lda #'.'            ; show ...
+                lda #'.'            ; add "..."
                 jsr emit_a
                 dey
                 bne -


### PR DESCRIPTION
I noticed that `u<` and `u>` already inlined the comparison, but `<` and `>` were using the generic `compare_16bit` routine which does a bunch of extra work (via a `jsr`) so are a lot slower.   

I refactored the other couple of places where it appears (fixing a bug with negative allot I believe), and overall removing it saves one byte but mainly makes comparisons faster and more inlineable.

In passing it looks to me like `allot` has a couple of potential problems if you unallocate too much memory.  First is when the dictionary extends beyond $8000 (e.g. with a small Tali kernel starting at $C000 instead of $8000), then the current signed comparisons will fail in unexpected ways (see notes in PR).   So I switched to a `within` version.  

The other thing I notice is that we're currently using CP0 as the floor, but `COLD` normally sets the starting value of CP past the user vars and block buffer.   Perhaps un-allotting the block buffer is fine, but removing the user vars seems dangerous?   We could use the cold_zero_page value of CP as the lower bound (which preserves block buffer), or add some CP_min setting that preserves user vars.    wdyt?

```
...
Type 'bye' to exit
here . 2048  ok
-1024 allot  ok   <- removing the block buffer, maybe ok?
here . 1024  ok
-2048 allot Max memory freed with ALLOT
here . 768  ok     <- reset to CP0, so user vars are getting stomped
cold 
...
here . 2048  ok
```